### PR TITLE
Never settle for 127.x.x.x ip address if you can help it (splunk returners)

### DIFF
--- a/hubblestack/extmods/returners/splunk_nebula_return.py
+++ b/hubblestack/extmods/returners/splunk_nebula_return.py
@@ -89,6 +89,11 @@ def returner(ret):
             fqdn_ip4 = __grains__['fqdn_ip4'][0]
         except IndexError:
             fqdn_ip4 = __grains__['ipv4'][0]
+        if fqdn_ip4.startswith('127.'):
+            for ip4_addr in __grains__['ipv4']:
+                if ip4_addr and not ip4_addr.startswith('127.'):
+                    fqdn_ip4 = ip4_addr
+                    break
 
         if not data:
             return

--- a/hubblestack/extmods/returners/splunk_nova_return.py
+++ b/hubblestack/extmods/returners/splunk_nova_return.py
@@ -88,6 +88,11 @@ def returner(ret):
             fqdn_ip4 = __grains__['fqdn_ip4'][0]
         except IndexError:
             fqdn_ip4 = __grains__['ipv4'][0]
+        if fqdn_ip4.startswith('127.'):
+            for ip4_addr in __grains__['ipv4']:
+                if ip4_addr and not ip4_addr.startswith('127.'):
+                    fqdn_ip4 = ip4_addr
+                    break
 
         if __grains__['master']:
             master = __grains__['master']

--- a/hubblestack/extmods/returners/splunk_pulsar_return.py
+++ b/hubblestack/extmods/returners/splunk_pulsar_return.py
@@ -97,6 +97,11 @@ def returner(ret):
             fqdn_ip4 = __grains__['fqdn_ip4'][0]
         except IndexError:
             fqdn_ip4 = __grains__['ipv4'][0]
+        if fqdn_ip4.startswith('127.'):
+            for ip4_addr in __grains__['ipv4']:
+                if ip4_addr and not ip4_addr.startswith('127.'):
+                    fqdn_ip4 = ip4_addr
+                    break
 
         alerts = []
         for item in data:


### PR DESCRIPTION
On hosts with a misconfigured (or not configured) fqdn, the fqdn_ip4 grain can end up with a useless value in it. Let's not settle for that value.