### PR TITLE
'windows fixes'

### DIFF
--- a/hubblestack/extmods/modules/nebula_osquery.py
+++ b/hubblestack/extmods/modules/nebula_osquery.py
@@ -119,8 +119,8 @@ def queries(query_group,
 
     if salt.utils.is_windows():
         win_version = __grains__['osfullname']
-        if '2012' not in win_version and '2016' not in win_version:
-            log.error('osquery does not run on windows versions earlier than Server 2012 and Windows 8')
+        if '2008' not in win_version and '2012' not in win_version and '2016' not in win_version:
+            log.error('osquery does not run on windows versions earlier than Server 2008')
             if query_group == 'day':
                 ret = []
                 ret.append(

--- a/pkg/windows/build_pkg.ps1
+++ b/pkg/windows/build_pkg.ps1
@@ -46,6 +46,9 @@ if (!(Test-Path '.\dist\hubble\etc\hubble')) {
 }
 Copy-Item '.\pkg\windows\hubble.conf' -Destination '.\dist\hubble\etc\hubble\'
 
+# Copy PortableGit to correct location
+Copy-Item '.\PortableGit' -Destination '.\dist\hubble\' -Recurse -Force
+
 # Copy nssm.exe to correct location
 if (Test-Path '..\Salt-Dev\salt\pkg\windows\buildenv\nssm.exe') {
     Copy-Item '..\Salt-Dev\salt\pkg\windows\buildenv\nssm.exe' -Destination '.\dist\hubble\'

--- a/pkg/windows/create_build_env.ps1
+++ b/pkg/windows/create_build_env.ps1
@@ -42,6 +42,12 @@ if (!($git)) {
     }
 }
 
+$7zip = choco list --localonly | Where-Object {$_ -like "git *"} 
+if (!($7zip)) {
+    choco install 7zip -y
+    reloadEnv
+}
+
 # Install salt and dependencies - including python
 if (Test-Path .\Salt-Dev) {
     Remove-Item -Recurse -Force Salt-Dev
@@ -73,6 +79,16 @@ foreach ($line in $lines) {
     }
 }
 popd
+
+# Download PortableGit.  Requirement for Hubble
+$path = (Get-Location).Path
+If (Test-Path "C:\Program Files (x86)") {
+    Invoke-WebRequest -Uri https://github.com/git-for-windows/git/releases/download/v2.12.2.windows.2/PortableGit-2.12.2.2-64-bit.7z.exe -OutFile .\PortableGit.7z.exe
+} else {
+    Invoke-WebRequest -Uri https://github.com/git-for-windows/git/releases/download/v2.12.2.windows.2/PortableGit-2.12.2.2-32-bit.7z.exe -OutFile .\PortableGit.7z.exe
+}
+7za x PortableGit.7z.exe -o"$path\hubble\PortableGit" -y
+& "$path\hubble\PortableGit\post-install.bat"
 
 # Install osquery for executible
 if (!(Test-path C:\ProgramData\osquery)) {

--- a/pkg/windows/create_build_env.ps1
+++ b/pkg/windows/create_build_env.ps1
@@ -26,7 +26,7 @@ if (!(Test-Path C:\ProgramData\chocolatey)) {
     iwr https://chocolatey.org/install.ps1 -UseBasicParsing | iex
     reloadEnv
 } else {
-    $chocoCur = (choco) -replace "Chocolatey v",""
+    $chocoCur = (choco)[0] -replace "Chocolatey v",""
     if ($chocoCur -lt $chocoVer) {
         choco upgrade chocolatey -y
     }
@@ -68,7 +68,7 @@ pushd hubble\pkg\scripts
 $lines = Get-Content pyinstaller-requirements.txt | Where {$_ -notmatch '^\s+$'} 
 foreach ($line in $lines) {
     $line = $line -replace "#.+$",""
-    if ($line -notlike '*pyinotify*' -or $line -notlike '*salt-ssh*') { #pyinotify and salt-ssh are for linux only
+    if ($line -notlike '*pyinotify*' -and $line -notlike '*salt-ssh*') { #pyinotify and salt-ssh are for linux only
         pip install $line
     }
 }

--- a/pkg/windows/create_build_env.ps1
+++ b/pkg/windows/create_build_env.ps1
@@ -42,7 +42,7 @@ if (!($git)) {
     }
 }
 
-$7zip = choco list --localonly | Where-Object {$_ -like "git *"} 
+$7zip = choco list --localonly | Where-Object {$_ -like "7zip*"} 
 if (!($7zip)) {
     choco install 7zip -y
     reloadEnv

--- a/pkg/windows/hubble-Setup.nsi
+++ b/pkg/windows/hubble-Setup.nsi
@@ -289,9 +289,9 @@ ${StrStrAdv}
     ; Register the Hubble Service
     nsExec::Exec "nssm.exe install Hubble $INSTDIR\hubble.exe"
     nsExec::Exec "nssm.exe set Hubble Description Open Source software for security compliance"
-    nsExec::Exec "nssm.exe set Hubble Application $INSTDIR\hubble.exe"
+    nsExec::Exec "nssm.exe set Hubble Application $INSTDIR\PortableGit\git-cmd.exe"
     nsExec::Exec "nssm.exe set Hubble AppDirectory $INSTDIR"
-    nsExec::Exec "nssm.exe set Hubble AppParameters -c .\etc\hubble\hubble.conf"
+    nsExec::Exec "nssm.exe set Hubble AppParameters hubble.exe -c .\etc\hubble\hubble.conf"
     nsExec::Exec "nssm.exe set Hubble Start SERVICE_AUTO_START"
 
     RMDir /R "$INSTDIR\var" ; removing cache from old version


### PR DESCRIPTION
This change satisfies the git requirement on computers that don't have git already installed.  It uses PortableGit and runs from the git-cmd.exe instead of the regular command prompt.

I also changed the logic to allow windows server 2008 to use osquery.  Osquery updated their software  to work with 2008 a few months ago, so now we can allow osquery to work in hubble for those machines.