### PR TITLE
additional grains osqueryversion and osquerybinpath

### DIFF
--- a/hubblestack/extmods/grains/osqueryinfo.py
+++ b/hubblestack/extmods/grains/osqueryinfo.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+import salt.utils
+
+__salt__ = { 'cmd.run': salt.modules.cmdmod._run_quiet }
+
+def osquerygrain():
+    '''
+    Return osquery version in grain
+    '''
+    # Provides:
+    #   osqueryversion
+    #   osquerybinpath
+    grains = {}
+    option = '--version'
+
+    osqueryipaths = ('osqueryi', '/usr/bin/osqueryi', '/opt/osquery/osqueryi')
+    for path in osqueryipaths:
+        if salt.utils.which(path):
+            for item in __salt__['cmd.run']('{0} {1}'.format(path, option)).split():
+                if item[:1].isdigit():
+                    grains['osqueryversion'] = item
+                    grains['osquerybinpath'] = path
+                    break
+            break
+    return grains


### PR DESCRIPTION
The aim of this commit is to make dealing with missing binaries easier and to avoid unexpected failures.

TODO: log in case the binary wasn't found.