### PR TITLE
initial working Logstash HTTP input returners

### DIFF
--- a/hubblestack/extmods/returners/logstash_nebula_return.py
+++ b/hubblestack/extmods/returners/logstash_nebula_return.py
@@ -1,5 +1,23 @@
 # -*- encoding: utf-8 -*-
 '''
+HubbleStack Nebula-to-Logstash (http input) returner
+
+:maintainer: HubbleStack
+:platform: All
+:requires: HubbleStack
+
+Deliver HubbleStack Nebula query data into Logstash using the HTTP input
+plugin. Required config/pillar settings:
+
+.. code-block:: yaml
+
+    hubblestack:
+      returner:
+        logstash:
+          - user: edwin
+            port: 8080
+            password: xoxepap0ooxoha4Xeen2ub6ohTh3huXo
+            indexer: http://logstash.http.input.tld
 '''
 
 import socket

--- a/hubblestack/extmods/returners/logstash_nebula_return.py
+++ b/hubblestack/extmods/returners/logstash_nebula_return.py
@@ -1,0 +1,72 @@
+# -*- encoding: utf-8 -*-
+'''
+'''
+
+import socket
+import requests
+import json
+import time
+from datetime import datetime
+from requests.auth import HTTPBasicAuth
+
+
+def returner(ret):
+    '''
+    '''
+    ## collect config options
+    try:
+        port = __salt__['config.get']('hubblestack:returner:logstash:port')
+        user = __salt__['config.get']('hubblestack:returner:logstash:user')
+        indexer = __salt__['config.get']('hubblestack:returner:logstash:indexer')
+        password = __salt__['config.get']('hubblestack:returner:logstash:password')
+    except:
+        return None
+
+    ## assign all the things
+    data = ret['return']
+    minion_id = ret['id']
+    jid = ret['jid']
+    master = __grains__['master']
+    fqdn = __grains__['fqdn']
+    fqdn = fqdn if fqdn else minion_id
+    try:
+        fqdn_ip4 = __grains__['fqdn_ip4'][0]
+    except IndexError:
+        fqdn_ip4 = __grains__['ipv4'][0]
+    if fqdn_ip4.startswith('127.'):
+        for ip4_addr in __grains__['ipv4']:
+            if ip4_addr and not ip4_addr.startswith('127.'):
+                fqdn_ip4 = ip4_addr
+                break
+
+    if not data:
+        return
+    else:
+        for query in data:
+            for query_name, query_results in query.iteritems():
+                for query_result in query_results['data']:
+                    event = {}
+                    payload = {}
+                    event.update(query_result)
+                    event.update({'query': query_name})
+                    event.update({'job_id': jid})
+                    event.update({'master': master})
+                    event.update({'minion_id': minion_id})
+                    event.update({'dest_host': fqdn})
+                    event.update({'dest_ip': fqdn_ip4})
+
+                    payload.update({'host': fqdn})
+                    payload.update({'event': event})
+
+                    # If the osquery query includes a field called 'time' it will be checked.
+                    # If it's within the last year, it will be used as the eventtime.
+                    event_time = query_result.get('time', '')
+                    try:
+                        if (datetime.fromtimestamp(time.time()) - datetime.fromtimestamp(float(event_time))).days > 365:
+                            event_time = ''
+                    except:
+                        event_time = ''
+                    finally:
+                        rdy = json.dumps(payload)
+                        requests.put('{}:{}/hubble/nebula'.format(indexer, port), rdy, auth=HTTPBasicAuth(user, password))
+    return

--- a/hubblestack/extmods/returners/logstash_nebula_return.py
+++ b/hubblestack/extmods/returners/logstash_nebula_return.py
@@ -14,77 +14,153 @@ plugin. Required config/pillar settings:
     hubblestack:
       returner:
         logstash:
-          - user: edwin
-            port: 8080
-            password: xoxepap0ooxoha4Xeen2ub6ohTh3huXo
+          - port: 8080
+            proxy: {}
+            timeout: 10
+            user: username
+            indexer_ssl: True
+            sourcetype_nebula: hubble_osquery
             indexer: http://logstash.http.input.tld
+            password: password
+            custom_fields:
+              - site
+              - product_group
 '''
 
-import socket
-import requests
 import json
 import time
+import socket
+import requests
 from datetime import datetime
+from aws_details import get_aws_details
 from requests.auth import HTTPBasicAuth
 
 
 def returner(ret):
     '''
     '''
-    ## collect config options
-    try:
-        port = __salt__['config.get']('hubblestack:returner:logstash:port')
-        user = __salt__['config.get']('hubblestack:returner:logstash:user')
-        indexer = __salt__['config.get']('hubblestack:returner:logstash:indexer')
-        password = __salt__['config.get']('hubblestack:returner:logstash:password')
-    except:
-        return None
+    opts = _get_options():
 
-    ## assign all the things
-    data = ret['return']
-    minion_id = ret['id']
-    jid = ret['jid']
-    master = __grains__['master']
-    fqdn = __grains__['fqdn']
-    fqdn = fqdn if fqdn else minion_id
-    try:
-        fqdn_ip4 = __grains__['fqdn_ip4'][0]
-    except IndexError:
-        fqdn_ip4 = __grains__['ipv4'][0]
-    if fqdn_ip4.startswith('127.'):
-        for ip4_addr in __grains__['ipv4']:
-            if ip4_addr and not ip4_addr.startswith('127.'):
-                fqdn_ip4 = ip4_addr
-                break
+    aws = get_aws_details()
 
-    if not data:
-        return
-    else:
-        for query in data:
-            for query_name, query_results in query.iteritems():
-                for query_result in query_results['data']:
-                    event = {}
-                    payload = {}
-                    event.update(query_result)
-                    event.update({'query': query_name})
-                    event.update({'job_id': jid})
-                    event.update({'master': master})
-                    event.update({'minion_id': minion_id})
-                    event.update({'dest_host': fqdn})
-                    event.update({'dest_ip': fqdn_ip4})
+    for opts in opts_list:
+        logging.info('Options: %s' % json.dumps(opts))
+        http_event_collector_key = opts['token']
+        http_event_collector_host = opts['indexer']
+        http_event_collector_port = opts['port']
+        hec_ssl = opts['http_event_server_ssl']
+        proxy = opts['proxy']
+        timeout = opts['timeout']
+        custom_fields = opts['custom_fields']
 
-                    payload.update({'host': fqdn})
-                    payload.update({'event': event})
+        ## assign all the things
+        data = ret['return']
+        minion_id = ret['id']
+        jid = ret['jid']
+        master = __grains__['master']
+        fqdn = __grains__['fqdn']
+        fqdn = fqdn if fqdn else minion_id
+        try:
+            fqdn_ip4 = __grains__['fqdn_ip4'][0]
+        except IndexError:
+            fqdn_ip4 = __grains__['ipv4'][0]
+        if fqdn_ip4.startswith('127.'):
+            for ip4_addr in __grains__['ipv4']:
+                if ip4_addr and not ip4_addr.startswith('127.'):
+                    fqdn_ip4 = ip4_addr
+                    break
 
-                    # If the osquery query includes a field called 'time' it will be checked.
-                    # If it's within the last year, it will be used as the eventtime.
-                    event_time = query_result.get('time', '')
-                    try:
-                        if (datetime.fromtimestamp(time.time()) - datetime.fromtimestamp(float(event_time))).days > 365:
+        if not data:
+            return
+        else:
+            for query in data:
+                for query_name, query_results in query.iteritems():
+                    for query_result in query_results['data']:
+                        event = {}
+                        payload = {}
+                        event.update(query_result)
+                        event.update({'query': query_name})
+                        event.update({'job_id': jid})
+                        event.update({'master': master})
+                        event.update({'minion_id': minion_id})
+                        event.update({'dest_host': fqdn})
+                        event.update({'dest_ip': fqdn_ip4})
+
+                        if aws['aws_account_id'] is not None:
+                            event.update({'aws_ami_id': aws['aws_ami_id']})
+                            event.update({'aws_instance_id': aws['aws_instance_id']})
+                            event.update({'aws_account_id': aws['aws_account_id']})
+
+                        for custom_field in custom_fields:
+                            custom_field_name = 'custom_' + custom_field
+                            custom_field_value = __salt__['config.get'](custom_field, '')
+                            if isinstance(custom_field_value, str):
+                                event.update({custom_field_name: custom_field_value})
+                            elif isinstance(custom_field_value, list):
+                                custom_field_value = ','.join(custom_field_value)
+                                event.update({custom_field_name: custom_field_value})
+
+                        payload.update({'host': fqdn})
+                        payload.update({'index': opts['index']})
+                        if opts['add_query_to_sourcetype']:
+                            payload.update({'sourcetype': "%s_%s" % (opts['sourcetype'], query_name)})
+                        else:
+                            payload.update({'sourcetype': opts['sourcetype']})
+                        payload.update({'event': event})
+
+                        # If the osquery query includes a field called 'time' it will be checked.
+                        # If it's within the last year, it will be used as the eventtime.
+                        event_time = query_result.get('time', '')
+                        try:
+                            if (datetime.fromtimestamp(time.time()) - datetime.fromtimestamp(float(event_time))).days > 365:
+                                event_time = ''
+                        except:
                             event_time = ''
-                    except:
-                        event_time = ''
-                    finally:
-                        rdy = json.dumps(payload)
-                        requests.put('{}:{}/hubble/nebula'.format(indexer, port), rdy, auth=HTTPBasicAuth(user, password))
+                        finally:
+                            rdy = json.dumps(payload)
+                            requests.put('{}:{}/hubble/nebula'.format(indexer, port), rdy, auth=HTTPBasicAuth(user, password))
     return
+
+
+def _get_options():
+    opts = _get_options():
+
+    aws = get_aws_details()
+
+    if __salt__['config.get']('hubblestack:returner:logstash'):
+        splunk_opts = []
+        returner_opts = __salt__['config.get']('hubblestack:returner:logstash')
+        if not isinstance(returner_opts, list):
+            returner_opts = [returner_opts]
+        for opt in returner_opts:
+            processed = {}
+            processed['password'] = opt.get('password')
+            processed['indexer'] = opt.get('indexer')
+            processed['port'] = str(opt.get('port', '8080'))
+            processed['index'] = opt.get('index')
+            processed['custom_fields'] = opt.get('custom_fields', [])
+            processed['sourcetype'] = opt.get('sourcetype_nebula', 'hubble_osquery')
+            processed['indexer_ssl'] = opt.get('indexer_ssl', True)
+            processed['proxy'] = opt.get('proxy', {})
+            processed['timeout'] = opt.get('timeout', 9.05)
+            logstash_opts.append(processed)
+        return logstash_opts
+    else:
+        try:
+            port = __salt__['config.get']('hubblestack:returner:logstash:port')
+            user = __salt__['config.get']('hubblestack:returner:logstash:user')
+            indexer = __salt__['config.get']('hubblestack:returner:logstash:indexer')
+            password = __salt__['config.get']('hubblestack:returner:logstash:password')
+            sourcetype = __salt__['config.get']('hubblestack:nebula:returner:logstash:sourcetype')
+            custom_fields = __salt__['config.get']('hubblestack:nebula:returner:logstash:custom_fields', [])
+        except:
+            return None
+
+        logstash_opts = {'token': token, 'indexer': indexer, 'sourcetype': sourcetype, 'index': index, 'custom_fields': custom_fields}
+
+        indexer_ssl = __salt__['config.get']('hubblestack:nebula:returner:logstash:indexer_ssl', True)
+        logstash_opts['http_input_server_ssl'] = indexer_ssl
+        logstash_opts['proxy'] = __salt__['config.get']('hubblestack:nebula:returner:logstash:proxy', {})
+        logstash_opts['timeout'] = __salt__['config.get']('hubblestack:nebula:returner:logstash:timeout', 9.05)
+
+        return [logstash_opts]

--- a/hubblestack/extmods/returners/logstash_nova_return.py
+++ b/hubblestack/extmods/returners/logstash_nova_return.py
@@ -35,157 +35,176 @@ from aws_details import get_aws_details
 from requests.auth import HTTPBasicAuth
 
 def returner(ret):
-    opts = _get_options():
+    '''
+    '''
+    opts_list = _get_options()
 
     aws = get_aws_details()
 
-    data = ret['return']
-    minion_id = ret['id']
-    jid = ret['jid']
-    fqdn = __grains__['fqdn']
-    # Sometimes fqdn is blank. If it is, replace it with minion_id
-    fqdn = fqdn if fqdn else minion_id
-    master = __grains__['master']
-    try:
-        fqdn_ip4 = __grains__['fqdn_ip4'][0]
-    except IndexError:
-        fqdn_ip4 = __grains__['ipv4'][0]
-    if fqdn_ip4.startswith('127.'):
-        for ip4_addr in __grains__['ipv4']:
-            if ip4_addr and not ip4_addr.startswith('127.'):
-                fqdn_ip4 = ip4_addr
-                break
+    for opts in opts_list:
+        proxy = opts['proxy']
+        timeout = opts['timeout']
+        custom_fields = opts['custom_fields']
 
-    if __grains__['master']:
+        indexer = opts['indexer']
+        port = opts['port']
+        password = opts['password']
+        user = opts['user']
+
+        data = ret['return']
+        minion_id = ret['id']
+        jid = ret['jid']
+        fqdn = __grains__['fqdn']
+        # Sometimes fqdn is blank. If it is, replace it with minion_id
+        fqdn = fqdn if fqdn else minion_id
         master = __grains__['master']
-    else:
-        master = socket.gethostname()  # We *are* the master, so use our hostname
+        try:
+            fqdn_ip4 = __grains__['fqdn_ip4'][0]
+        except IndexError:
+            fqdn_ip4 = __grains__['ipv4'][0]
+        if fqdn_ip4.startswith('127.'):
+            for ip4_addr in __grains__['ipv4']:
+                if ip4_addr and not ip4_addr.startswith('127.'):
+                    fqdn_ip4 = ip4_addr
+                    break
 
-    if not isinstance(data, dict):
-        log.error('Data sent to splunk_nova_return was not formed as a '
-                  'dict:\n{0}'.format(data))
-        return
+        if __grains__['master']:
+            master = __grains__['master']
+        else:
+            master = socket.gethostname()  # We *are* the master, so use our hostname
 
-    for fai in data.get('Failure', []):
-        check_id = fai.keys()[0]
-        payload = {}
-        event = {}
-        event.update({'check_result': 'Failure'})
-        event.update({'check_id': check_id})
-        event.update({'job_id': jid})
-        if not isinstance(fai[check_id], dict):
-            event.update({'description': fai[check_id]})
-        elif 'description' in fai[check_id]:
-            for key, value in fai[check_id].iteritems():
-                if key not in ['tag']:
-                    event[key] = value
-        event.update({'master': master})
-        event.update({'minion_id': minion_id})
-        event.update({'dest_host': fqdn})
-        event.update({'dest_ip': fqdn_ip4})
+        if not isinstance(data, dict):
+            log.error('Data sent to splunk_nova_return was not formed as a '
+                      'dict:\n{0}'.format(data))
+            return
 
-        if aws['aws_account_id'] is not None:
-            event.update({'aws_ami_id': aws['aws_ami_id']})
-            event.update({'aws_instance_id': aws['aws_instance_id']})
-            event.update({'aws_account_id': aws['aws_account_id']})
+        for fai in data.get('Failure', []):
+            check_id = fai.keys()[0]
+            payload = {}
+            event = {}
+            event.update({'check_result': 'Failure'})
+            event.update({'check_id': check_id})
+            event.update({'job_id': jid})
+            if not isinstance(fai[check_id], dict):
+                event.update({'description': fai[check_id]})
+            elif 'description' in fai[check_id]:
+                for key, value in fai[check_id].iteritems():
+                    if key not in ['tag']:
+                        event[key] = value
+            event.update({'master': master})
+            event.update({'minion_id': minion_id})
+            event.update({'dest_host': fqdn})
+            event.update({'dest_ip': fqdn_ip4})
 
-        for custom_field in custom_fields:
-            custom_field_name = 'custom_' + custom_field
-            custom_field_value = __salt__['config.get'](custom_field, '')
-            if isinstance(custom_field_value, str):
-                event.update({custom_field_name: custom_field_value})
-            elif isinstance(custom_field_value, list):
-                custom_field_value = ','.join(custom_field_value)
-                event.update({custom_field_name: custom_field_value})
+            if aws['aws_account_id'] is not None:
+                event.update({'aws_ami_id': aws['aws_ami_id']})
+                event.update({'aws_instance_id': aws['aws_instance_id']})
+                event.update({'aws_account_id': aws['aws_account_id']})
 
-        payload.update({'host': fqdn})
-        payload.update({'event': event})
+            for custom_field in custom_fields:
+                custom_field_name = 'custom_' + custom_field
+                custom_field_value = __salt__['config.get'](custom_field, '')
+                if isinstance(custom_field_value, str):
+                    event.update({custom_field_name: custom_field_value})
+                elif isinstance(custom_field_value, list):
+                    custom_field_value = ','.join(custom_field_value)
+                    event.update({custom_field_name: custom_field_value})
 
-        rdy = json.dumps(payload)
-        requests.put('{}:{}/hubble/nova'.format(indexer, port), rdy, auth=HTTPBasicAuth(user, password))
+            payload.update({'host': fqdn})
+            payload.update({'index': opts['index']})
+            payload.update({'sourcetype': opts['sourcetype']})
+            payload.update({'event': event})
 
-
-    for suc in data.get('Success', []):
-        check_id = suc.keys()[0]
-        payload = {}
-        event = {}
-        event.update({'check_result': 'Success'})
-        event.update({'check_id': check_id})
-        event.update({'job_id': jid})
-        if not isinstance(suc[check_id], dict):
-            event.update({'description': suc[check_id]})
-        elif 'description' in suc[check_id]:
-            for key, value in suc[check_id].iteritems():
-                if key not in ['tag']:
-                    event[key] = value
-        event.update({'master': master})
-        event.update({'minion_id': minion_id})
-        event.update({'dest_host': fqdn})
-        event.update({'dest_ip': fqdn_ip4})
-
-        if aws['aws_account_id'] is not None:
-            event.update({'aws_ami_id': aws['aws_ami_id']})
-            event.update({'aws_instance_id': aws['aws_instance_id']})
-            event.update({'aws_account_id': aws['aws_account_id']})
-
-        for custom_field in custom_fields:
-            custom_field_name = 'custom_' + custom_field
-            custom_field_value = __salt__['config.get'](custom_field, '')
-            if isinstance(custom_field_value, str):
-                event.update({custom_field_name: custom_field_value})
-            elif isinstance(custom_field_value, list):
-                custom_field_value = ','.join(custom_field_value)
-                event.update({custom_field_name: custom_field_value})
-
-        payload.update({'host': fqdn})
-        payload.update({'event': event})
-
-        rdy = json.dumps(payload)
-        requests.put('{}:{}/hubble/nova'.format(indexer, port), rdy, auth=HTTPBasicAuth(user, password))
+            rdy = json.dumps(payload)
+            requests.put('{}:{}/hubble/nova'.format(indexer, port), rdy, auth=HTTPBasicAuth(user, password))
 
 
-    if data.get('Compliance', None):
-        payload = {}
-        event = {}
-        event.update({'job_id': jid})
-        event.update({'compliance_percentage': data['Compliance']})
-        event.update({'master': master})
-        event.update({'minion_id': minion_id})
-        event.update({'dest_host': fqdn})
-        event.update({'dest_ip': fqdn_ip4})
+        for suc in data.get('Success', []):
+            check_id = suc.keys()[0]
+            payload = {}
+            event = {}
+            event.update({'check_result': 'Success'})
+            event.update({'check_id': check_id})
+            event.update({'job_id': jid})
+            if not isinstance(suc[check_id], dict):
+                event.update({'description': suc[check_id]})
+            elif 'description' in suc[check_id]:
+                for key, value in suc[check_id].iteritems():
+                    if key not in ['tag']:
+                        event[key] = value
+            event.update({'master': master})
+            event.update({'minion_id': minion_id})
+            event.update({'dest_host': fqdn})
+            event.update({'dest_ip': fqdn_ip4})
 
-        if aws['aws_account_id'] is not None:
-            event.update({'aws_ami_id': aws['aws_ami_id']})
-            event.update({'aws_instance_id': aws['aws_instance_id']})
-            event.update({'aws_account_id': aws['aws_account_id']})
+            if aws['aws_account_id'] is not None:
+                event.update({'aws_ami_id': aws['aws_ami_id']})
+                event.update({'aws_instance_id': aws['aws_instance_id']})
+                event.update({'aws_account_id': aws['aws_account_id']})
 
-        for custom_field in custom_fields:
-            custom_field_name = 'custom_' + custom_field
-            custom_field_value = __salt__['config.get'](custom_field, '')
-            if isinstance(custom_field_value, str):
-                event.update({custom_field_name: custom_field_value})
-            elif isinstance(custom_field_value, list):
-                custom_field_value = ','.join(custom_field_value)
-                event.update({custom_field_name: custom_field_value})
+            for custom_field in custom_fields:
+                custom_field_name = 'custom_' + custom_field
+                custom_field_value = __salt__['config.get'](custom_field, '')
+                if isinstance(custom_field_value, str):
+                    event.update({custom_field_name: custom_field_value})
+                elif isinstance(custom_field_value, list):
+                    custom_field_value = ','.join(custom_field_value)
+                    event.update({custom_field_name: custom_field_value})
 
-        payload.update({'host': fqdn})
-        payload.update({'event': event})
+            payload.update({'host': fqdn})
+            payload.update({'index': opts['index']})
+            payload.update({'sourcetype': opts['sourcetype']})
+            payload.update({'event': event})
 
-        rdy = json.dumps(payload)
-        requests.put('{}:{}/hubble/nova'.format(indexer, port), rdy, auth=HTTPBasicAuth(user, password))
+            rdy = json.dumps(payload)
+            requests.put('{}:{}/hubble/nova'.format(indexer, port), rdy, auth=HTTPBasicAuth(user, password))
+
+
+        if data.get('Compliance', None):
+            payload = {}
+            event = {}
+            event.update({'job_id': jid})
+            event.update({'compliance_percentage': data['Compliance']})
+            event.update({'master': master})
+            event.update({'minion_id': minion_id})
+            event.update({'dest_host': fqdn})
+            event.update({'dest_ip': fqdn_ip4})
+
+            if aws['aws_account_id'] is not None:
+                event.update({'aws_ami_id': aws['aws_ami_id']})
+                event.update({'aws_instance_id': aws['aws_instance_id']})
+                event.update({'aws_account_id': aws['aws_account_id']})
+
+            for custom_field in custom_fields:
+                custom_field_name = 'custom_' + custom_field
+                custom_field_value = __salt__['config.get'](custom_field, '')
+                if isinstance(custom_field_value, str):
+                    event.update({custom_field_name: custom_field_value})
+                elif isinstance(custom_field_value, list):
+                    custom_field_value = ','.join(custom_field_value)
+                    event.update({custom_field_name: custom_field_value})
+
+            payload.update({'host': fqdn})
+            payload.update({'index': opts['index']})
+            payload.update({'sourcetype': opts['sourcetype']})
+            payload.update({'event': event})
+
+            rdy = json.dumps(payload)
+            requests.put('{}:{}/hubble/nova'.format(indexer, port), rdy, auth=HTTPBasicAuth(user, password))
 
     return
 
 
 def _get_options():
     if __salt__['config.get']('hubblestack:returner:logstash'):
-        splunk_opts = []
+        logstash_opts = []
         returner_opts = __salt__['config.get']('hubblestack:returner:logstash')
         if not isinstance(returner_opts, list):
             returner_opts = [returner_opts]
         for opt in returner_opts:
             processed = {}
-            processed['token'] = opt.get('token')
+            processed['password'] = opt.get('password')
+            processed['user'] = opt.get('user')
             processed['indexer'] = opt.get('indexer')
             processed['port'] = str(opt.get('port', '8080'))
             processed['index'] = opt.get('index')
@@ -202,12 +221,12 @@ def _get_options():
             user = __salt__['config.get']('hubblestack:returner:logstash:user')
             indexer = __salt__['config.get']('hubblestack:returner:logstash:indexer')
             password = __salt__['config.get']('hubblestack:returner:logstash:password')
-            sourcetype = __salt__['config.get']('hubblestack:nova:returner:logstash:sourcetype')
-            custom_fields = __salt__['config.get']('hubblestack:nova:returner:logstash:custom_fields', [])
+            sourcetype = __salt__['config.get']('hubblestack:returner:logstash:sourcetype')
+            custom_fields = __salt__['config.get']('hubblestack:returner:logstash:custom_fields', [])
         except:
             return None
 
-        logstash_opts = {'token': token, 'indexer': indexer, 'sourcetype': sourcetype, 'index': index, 'custom_fields': custom_fields}
+        logstash_opts = {'password': password, 'indexer': indexer, 'sourcetype': sourcetype, 'index': index, 'custom_fields': custom_fields}
 
         indexer_ssl = __salt__['config.get']('hubblestack:nova:returner:logstash:indexer_ssl', True)
         logstash_opts['http_input_server_ssl'] = indexer_ssl

--- a/hubblestack/extmods/returners/logstash_nova_return.py
+++ b/hubblestack/extmods/returners/logstash_nova_return.py
@@ -1,5 +1,23 @@
 # -*- encoding: utf-8 -*-
 '''
+HubbleStack Nova-to-Logstash (http input) returner
+
+:maintainer: HubbleStack
+:platform: All
+:requires: HubbleStack
+
+Deliver HubbleStack Nova data into Logstash using the HTTP input
+plugin. Required config/pillar settings:
+
+.. code-block:: yaml
+
+    hubblestack:
+      returner:
+        logstash:
+          - user: edwin
+            port: 8080
+            password: xoxepap0ooxoha4Xeen2ub6ohTh3huXo
+            indexer: http://logstash.http.input.tld
 '''
 
 import socket

--- a/hubblestack/extmods/returners/logstash_nova_return.py
+++ b/hubblestack/extmods/returners/logstash_nova_return.py
@@ -1,0 +1,113 @@
+# -*- encoding: utf-8 -*-
+'''
+'''
+
+import socket
+import requests
+from requests.auth import HTTPBasicAuth
+import json
+import time
+
+def returner(ret):
+    try:
+        port = __salt__['config.get']('hubblestack:returner:logstash:port')
+        user = __salt__['config.get']('hubblestack:returner:logstash:user')
+        indexer = __salt__['config.get']('hubblestack:returner:logstash:indexer')
+        password = __salt__['config.get']('hubblestack:returner:logstash:password')
+    except:
+        return None
+
+    data = ret['return']
+    minion_id = ret['id']
+    jid = ret['jid']
+    fqdn = __grains__['fqdn']
+    # Sometimes fqdn is blank. If it is, replace it with minion_id
+    fqdn = fqdn if fqdn else minion_id
+    master = __grains__['master']
+    try:
+        fqdn_ip4 = __grains__['fqdn_ip4'][0]
+    except IndexError:
+        fqdn_ip4 = __grains__['ipv4'][0]
+    if fqdn_ip4.startswith('127.'):
+        for ip4_addr in __grains__['ipv4']:
+            if ip4_addr and not ip4_addr.startswith('127.'):
+                fqdn_ip4 = ip4_addr
+                break
+
+    if __grains__['master']:
+        master = __grains__['master']
+    else:
+        master = socket.gethostname()  # We *are* the master, so use our hostname
+
+    if not isinstance(data, dict):
+        log.error('Data sent to splunk_nova_return was not formed as a '
+                  'dict:\n{0}'.format(data))
+        return
+
+    for fai in data.get('Failure', []):
+        check_id = fai.keys()[0]
+        payload = {}
+        event = {}
+        event.update({'check_result': 'Failure'})
+        event.update({'check_id': check_id})
+        event.update({'job_id': jid})
+        if not isinstance(fai[check_id], dict):
+            event.update({'description': fai[check_id]})
+        elif 'description' in fai[check_id]:
+            for key, value in fai[check_id].iteritems():
+                if key not in ['tag']:
+                    event[key] = value
+        event.update({'master': master})
+        event.update({'minion_id': minion_id})
+        event.update({'dest_host': fqdn})
+        event.update({'dest_ip': fqdn_ip4})
+
+        payload.update({'host': fqdn})
+        payload.update({'event': event})
+
+        rdy = json.dumps(payload)
+        requests.put('{}:{}/hubble/nova'.format(indexer, port), rdy, auth=HTTPBasicAuth(user, password))
+
+
+    for suc in data.get('Success', []):
+        check_id = suc.keys()[0]
+        payload = {}
+        event = {}
+        event.update({'check_result': 'Success'})
+        event.update({'check_id': check_id})
+        event.update({'job_id': jid})
+        if not isinstance(suc[check_id], dict):
+            event.update({'description': suc[check_id]})
+        elif 'description' in suc[check_id]:
+            for key, value in suc[check_id].iteritems():
+                if key not in ['tag']:
+                    event[key] = value
+        event.update({'master': master})
+        event.update({'minion_id': minion_id})
+        event.update({'dest_host': fqdn})
+        event.update({'dest_ip': fqdn_ip4})
+
+        payload.update({'host': fqdn})
+        payload.update({'event': event})
+
+        rdy = json.dumps(payload)
+        requests.put('{}:{}/hubble/nova'.format(indexer, port), rdy, auth=HTTPBasicAuth(user, password))
+
+
+    if data.get('Compliance', None):
+        payload = {}
+        event = {}
+        event.update({'job_id': jid})
+        event.update({'compliance_percentage': data['Compliance']})
+        event.update({'master': master})
+        event.update({'minion_id': minion_id})
+        event.update({'dest_host': fqdn})
+        event.update({'dest_ip': fqdn_ip4})
+
+        payload.update({'host': fqdn})
+        payload.update({'event': event})
+
+        rdy = json.dumps(payload)
+        requests.put('{}:{}/hubble/nova'.format(indexer, port), rdy, auth=HTTPBasicAuth(user, password))
+
+    return

--- a/hubblestack/extmods/returners/logstash_pulsar_return.py
+++ b/hubblestack/extmods/returners/logstash_pulsar_return.py
@@ -1,5 +1,23 @@
 # -*- encoding: utf-8 -*-
 '''
+HubbleStack Pulsar-to-Logstash (http input) returner
+
+:maintainer: HubbleStack
+:platform: All
+:requires: HubbleStack
+
+Deliver HubbleStack Pulsar event data into Logstash using the HTTP input
+plugin. Required config/pillar settings:
+
+.. code-block:: yaml
+
+    hubblestack:
+      returner:
+        logstash:
+          - user: edwin
+            port: 8080
+            password: xoxepap0ooxoha4Xeen2ub6ohTh3huXo
+            indexer: http://logstash.http.input.tld
 '''
 
 import requests

--- a/hubblestack/extmods/returners/logstash_pulsar_return.py
+++ b/hubblestack/extmods/returners/logstash_pulsar_return.py
@@ -204,7 +204,7 @@ def _get_options():
             processed['port'] = str(opt.get('port', '8080'))
             processed['index'] = opt.get('index')
             processed['custom_fields'] = opt.get('custom_fields', [])
-            processed['sourcetype'] = opt.get('sourcetype_pulsar', 'hubble_osquery')
+            processed['sourcetype'] = opt.get('sourcetype_pulsar', 'hubble_fim')
             processed['indexer_ssl'] = opt.get('indexer_ssl', True)
             processed['proxy'] = opt.get('proxy', {})
             processed['timeout'] = opt.get('timeout', 9.05)

--- a/hubblestack/extmods/returners/logstash_pulsar_return.py
+++ b/hubblestack/extmods/returners/logstash_pulsar_return.py
@@ -1,0 +1,159 @@
+# -*- encoding: utf-8 -*-
+'''
+'''
+
+import requests
+import json
+import logging
+import os
+import time
+from collections import defaultdict
+from requests.auth import HTTPBasicAuth
+
+log = logging.getLogger(__name__)
+
+def returner(ret):
+    '''
+    '''
+    ## collect config options
+    try:
+        port = __salt__['config.get']('hubblestack:returner:logstash:port')
+        user = __salt__['config.get']('hubblestack:returner:logstash:user')
+        indexer = __salt__['config.get']('hubblestack:returner:logstash:indexer')
+        password = __salt__['config.get']('hubblestack:returner:logstash:password')
+    except:
+        return None
+
+    if isinstance(ret, dict) and not ret.get('return'):
+        return
+
+    data = _dedupList(ret['return'])
+    minion_id = __opts__['id']
+    fqdn = __grains__['fqdn']
+    fqdn = fqdn if fqdn else minion_id
+    master = __grains__['master']
+    try:
+        fqdn_ip4 = __grains__['fqdn_ip4'][0]
+    except IndexError:
+        fqdn_ip4 = __grains__['ipv4'][0]
+    if fqdn_ip4.startswith('127.'):
+        for ip4_addr in __grains__['ipv4']:
+            if ip4_addr and not ip4_addr.startswith('127.'):
+                fqdn_ip4 = ip4_addr
+                break
+
+    alerts = []
+    for item in data:
+        events = item
+        if not isinstance(events, list):
+            events = [events]
+        alerts.extend(events)
+
+    for alert in alerts:
+        event = {}
+        payload = {}
+        if('change' in alert):  # Linux, normal pulsar
+            # The second half of the change will be '|IN_ISDIR' for directories
+            change = alert['change'].split('|')[0]
+            # Skip the IN_IGNORED events
+            if change == 'IN_IGNORED':
+                continue
+            if len(alert['change'].split('|')) == 2:
+                object_type = 'directory'
+            else:
+                object_type = 'file'
+
+            actions = defaultdict(lambda: 'unknown')
+            actions['IN_ACCESS'] = 'read'
+            actions['IN_ATTRIB'] = 'acl_modified'
+            actions['IN_CLOSE_NOWRITE'] = 'read'
+            actions['IN_CLOSE_WRITE'] = 'read'
+            actions['IN_CREATE'] = 'created'
+            actions['IN_DELETE'] = 'deleted'
+            actions['IN_DELETE_SELF'] = 'deleted'
+            actions['IN_MODIFY'] = 'modified'
+            actions['IN_MOVE_SELF'] = 'modified'
+            actions['IN_MOVED_FROM'] = 'modified'
+            actions['IN_MOVED_TO'] = 'modified'
+            actions['IN_OPEN'] = 'read'
+            actions['IN_MOVE'] = 'modified'
+            actions['IN_CLOSE'] = 'read'
+
+            event['action'] = actions[change]
+            event['change_type'] = 'filesystem'
+            event['object_category'] = object_type
+            event['object_path'] = alert['path']
+            event['file_name'] = alert['name']
+            event['file_path'] = alert['tag']
+
+            if alert['stats']:  # Gather more data if the change wasn't a delete
+                stats = alert['stats']
+                event['object_id'] = stats['inode']
+                event['file_acl'] = stats['mode']
+                event['file_create_time'] = stats['ctime']
+                event['file_modify_time'] = stats['mtime']
+                event['file_size'] = stats['size'] / 1024.0  # Convert bytes to kilobytes
+                event['user'] = stats['user']
+                event['group'] = stats['group']
+                if object_type == 'file':
+                    event['file_hash'] = alert['checksum']
+                    event['file_hash_type'] = alert['checksum_type']
+
+        else:  # Windows, win_pulsar
+            change = alert['Accesses']
+            if alert['Hash'] == 'Item is a directory':
+                object_type = 'directory'
+            else:
+                object_type = 'file'
+
+            actions = defaultdict(lambda: 'unknown')
+            actions['Delete'] = 'deleted'
+            actions['Read Control'] = 'read'
+            actions['Write DAC'] = 'acl_modified'
+            actions['Write Owner'] = 'modified'
+            actions['Synchronize'] = 'modified'
+            actions['Access Sys Sec'] = 'read'
+            actions['Read Data'] = 'read'
+            actions['Write Data'] = 'modified'
+            actions['Append Data'] = 'modified'
+            actions['Read EA'] = 'read'
+            actions['Write EA'] = 'modified'
+            actions['Execute/Traverse'] = 'read'
+            actions['Read Attributes'] = 'read'
+            actions['Write Attributes'] = 'acl_modified'
+            actions['Query Key Value'] = 'read'
+            actions['Set Key Value'] = 'modified'
+            actions['Create Sub Key'] = 'created'
+            actions['Enumerate Sub-Keys'] = 'read'
+            actions['Notify About Changes to Keys'] = 'read'
+            actions['Create Link'] = 'created'
+            actions['Print'] = 'read'
+
+            event['action'] = actions[change]
+            event['change_type'] = 'filesystem'
+            event['object_category'] = object_type
+            event['object_path'] = alert['Object Name']
+            event['file_name'] = os.path.basename(alert['Object Name'])
+            event['file_path'] = os.path.dirname(alert['Object Name'])
+            # TODO: Should we be reporting 'EntryType' or 'TimeGenerated?
+            #   EntryType reports whether attempt to change was successful.
+
+        event.update({'master': master})
+        event.update({'minion_id': minion_id})
+        event.update({'dest_host': fqdn})
+        event.update({'dest_ip': fqdn_ip4})
+
+        payload.update({'host': fqdn})
+        payload.update({'event': event})
+
+        rdy = json.dumps(payload)
+        requests.put('{}:{}/hubble/pulsar'.format(indexer, port), rdy, auth=HTTPBasicAuth(user, password))
+    return
+
+
+def _dedupList(l):
+    deduped = []
+    for i, x in enumerate(l):
+        if x not in l[i + 1:]:
+            deduped.append(x)
+    return deduped

--- a/hubblestack/extmods/returners/logstash_pulsar_return.py
+++ b/hubblestack/extmods/returners/logstash_pulsar_return.py
@@ -14,159 +14,26 @@ plugin. Required config/pillar settings:
     hubblestack:
       returner:
         logstash:
-          - user: edwin
-            port: 8080
-            password: xoxepap0ooxoha4Xeen2ub6ohTh3huXo
+          - port: 8080
+            proxy: {}
+            timeout: 10
+            user: username
+            indexer_ssl: True
+            sourcetype_pulsar: hubble_fim
             indexer: http://logstash.http.input.tld
+            password: password
+            custom_fields:
+              - site
+              - product_group
 '''
 
-import requests
-import json
-import logging
 import os
 import time
+import json
+import requests
 from collections import defaultdict
+from aws_details import get_aws_details
 from requests.auth import HTTPBasicAuth
-
-log = logging.getLogger(__name__)
-
-def returner(ret):
-    '''
-    '''
-    ## collect config options
-    try:
-        port = __salt__['config.get']('hubblestack:returner:logstash:port')
-        user = __salt__['config.get']('hubblestack:returner:logstash:user')
-        indexer = __salt__['config.get']('hubblestack:returner:logstash:indexer')
-        password = __salt__['config.get']('hubblestack:returner:logstash:password')
-    except:
-        return None
-
-    if isinstance(ret, dict) and not ret.get('return'):
-        return
-
-    data = _dedupList(ret['return'])
-    minion_id = __opts__['id']
-    fqdn = __grains__['fqdn']
-    fqdn = fqdn if fqdn else minion_id
-    master = __grains__['master']
-    try:
-        fqdn_ip4 = __grains__['fqdn_ip4'][0]
-    except IndexError:
-        fqdn_ip4 = __grains__['ipv4'][0]
-    if fqdn_ip4.startswith('127.'):
-        for ip4_addr in __grains__['ipv4']:
-            if ip4_addr and not ip4_addr.startswith('127.'):
-                fqdn_ip4 = ip4_addr
-                break
-
-    alerts = []
-    for item in data:
-        events = item
-        if not isinstance(events, list):
-            events = [events]
-        alerts.extend(events)
-
-    for alert in alerts:
-        event = {}
-        payload = {}
-        if('change' in alert):  # Linux, normal pulsar
-            # The second half of the change will be '|IN_ISDIR' for directories
-            change = alert['change'].split('|')[0]
-            # Skip the IN_IGNORED events
-            if change == 'IN_IGNORED':
-                continue
-            if len(alert['change'].split('|')) == 2:
-                object_type = 'directory'
-            else:
-                object_type = 'file'
-
-            actions = defaultdict(lambda: 'unknown')
-            actions['IN_ACCESS'] = 'read'
-            actions['IN_ATTRIB'] = 'acl_modified'
-            actions['IN_CLOSE_NOWRITE'] = 'read'
-            actions['IN_CLOSE_WRITE'] = 'read'
-            actions['IN_CREATE'] = 'created'
-            actions['IN_DELETE'] = 'deleted'
-            actions['IN_DELETE_SELF'] = 'deleted'
-            actions['IN_MODIFY'] = 'modified'
-            actions['IN_MOVE_SELF'] = 'modified'
-            actions['IN_MOVED_FROM'] = 'modified'
-            actions['IN_MOVED_TO'] = 'modified'
-            actions['IN_OPEN'] = 'read'
-            actions['IN_MOVE'] = 'modified'
-            actions['IN_CLOSE'] = 'read'
-
-            event['action'] = actions[change]
-            event['change_type'] = 'filesystem'
-            event['object_category'] = object_type
-            event['object_path'] = alert['path']
-            event['file_name'] = alert['name']
-            event['file_path'] = alert['tag']
-
-            if alert['stats']:  # Gather more data if the change wasn't a delete
-                stats = alert['stats']
-                event['object_id'] = stats['inode']
-                event['file_acl'] = stats['mode']
-                event['file_create_time'] = stats['ctime']
-                event['file_modify_time'] = stats['mtime']
-                event['file_size'] = stats['size'] / 1024.0  # Convert bytes to kilobytes
-                event['user'] = stats['user']
-                event['group'] = stats['group']
-                if object_type == 'file':
-                    event['file_hash'] = alert['checksum']
-                    event['file_hash_type'] = alert['checksum_type']
-
-        else:  # Windows, win_pulsar
-            change = alert['Accesses']
-            if alert['Hash'] == 'Item is a directory':
-                object_type = 'directory'
-            else:
-                object_type = 'file'
-
-            actions = defaultdict(lambda: 'unknown')
-            actions['Delete'] = 'deleted'
-            actions['Read Control'] = 'read'
-            actions['Write DAC'] = 'acl_modified'
-            actions['Write Owner'] = 'modified'
-            actions['Synchronize'] = 'modified'
-            actions['Access Sys Sec'] = 'read'
-            actions['Read Data'] = 'read'
-            actions['Write Data'] = 'modified'
-            actions['Append Data'] = 'modified'
-            actions['Read EA'] = 'read'
-            actions['Write EA'] = 'modified'
-            actions['Execute/Traverse'] = 'read'
-            actions['Read Attributes'] = 'read'
-            actions['Write Attributes'] = 'acl_modified'
-            actions['Query Key Value'] = 'read'
-            actions['Set Key Value'] = 'modified'
-            actions['Create Sub Key'] = 'created'
-            actions['Enumerate Sub-Keys'] = 'read'
-            actions['Notify About Changes to Keys'] = 'read'
-            actions['Create Link'] = 'created'
-            actions['Print'] = 'read'
-
-            event['action'] = actions[change]
-            event['change_type'] = 'filesystem'
-            event['object_category'] = object_type
-            event['object_path'] = alert['Object Name']
-            event['file_name'] = os.path.basename(alert['Object Name'])
-            event['file_path'] = os.path.dirname(alert['Object Name'])
-            # TODO: Should we be reporting 'EntryType' or 'TimeGenerated?
-            #   EntryType reports whether attempt to change was successful.
-
-        event.update({'master': master})
-        event.update({'minion_id': minion_id})
-        event.update({'dest_host': fqdn})
-        event.update({'dest_ip': fqdn_ip4})
-
-        payload.update({'host': fqdn})
-        payload.update({'event': event})
-
-        rdy = json.dumps(payload)
-        requests.put('{}:{}/hubble/pulsar'.format(indexer, port), rdy, auth=HTTPBasicAuth(user, password))
-    return
 
 
 def _dedupList(l):
@@ -175,3 +42,190 @@ def _dedupList(l):
         if x not in l[i + 1:]:
             deduped.append(x)
     return deduped
+
+
+def returner(ret):
+    '''
+    '''
+    if isinstance(ret, dict) and not ret.get('return'):
+        return
+
+    opts_list = _get_options()
+
+    aws = get_aws_details()
+
+    for opts in opts_list:
+        proxy = opts['proxy']
+        timeout = opts['timeout']
+        custom_fields = opts['custom_fields']
+
+        indexer = opts['indexer']
+        port = opts['port']
+        password = opts['password']
+        user = opts['user']
+
+        data = _dedupList(ret['return'])
+        minion_id = __opts__['id']
+        fqdn = __grains__['fqdn']
+        fqdn = fqdn if fqdn else minion_id
+        master = __grains__['master']
+        try:
+            fqdn_ip4 = __grains__['fqdn_ip4'][0]
+        except IndexError:
+            fqdn_ip4 = __grains__['ipv4'][0]
+        if fqdn_ip4.startswith('127.'):
+            for ip4_addr in __grains__['ipv4']:
+                if ip4_addr and not ip4_addr.startswith('127.'):
+                    fqdn_ip4 = ip4_addr
+                    break
+
+        alerts = []
+        for item in data:
+            events = item
+            if not isinstance(events, list):
+                events = [events]
+            alerts.extend(events)
+
+        for alert in alerts:
+            event = {}
+            payload = {}
+            if('change' in alert):  # Linux, normal pulsar
+                # The second half of the change will be '|IN_ISDIR' for directories
+                change = alert['change'].split('|')[0]
+                # Skip the IN_IGNORED events
+                if change == 'IN_IGNORED':
+                    continue
+                if len(alert['change'].split('|')) == 2:
+                    object_type = 'directory'
+                else:
+                    object_type = 'file'
+
+                actions = defaultdict(lambda: 'unknown')
+                actions['IN_ACCESS'] = 'read'
+                actions['IN_ATTRIB'] = 'acl_modified'
+                actions['IN_CLOSE_NOWRITE'] = 'read'
+                actions['IN_CLOSE_WRITE'] = 'read'
+                actions['IN_CREATE'] = 'created'
+                actions['IN_DELETE'] = 'deleted'
+                actions['IN_DELETE_SELF'] = 'deleted'
+                actions['IN_MODIFY'] = 'modified'
+                actions['IN_MOVE_SELF'] = 'modified'
+                actions['IN_MOVED_FROM'] = 'modified'
+                actions['IN_MOVED_TO'] = 'modified'
+                actions['IN_OPEN'] = 'read'
+                actions['IN_MOVE'] = 'modified'
+                actions['IN_CLOSE'] = 'read'
+
+                event['action'] = actions[change]
+                event['change_type'] = 'filesystem'
+                event['object_category'] = object_type
+                event['object_path'] = alert['path']
+                event['file_name'] = alert['name']
+                event['file_path'] = alert['tag']
+
+                if alert['stats']:  # Gather more data if the change wasn't a delete
+                    stats = alert['stats']
+                    event['object_id'] = stats['inode']
+                    event['file_acl'] = stats['mode']
+                    event['file_create_time'] = stats['ctime']
+                    event['file_modify_time'] = stats['mtime']
+                    event['file_size'] = stats['size'] / 1024.0  # Convert bytes to kilobytes
+                    event['user'] = stats['user']
+                    event['group'] = stats['group']
+                    if object_type == 'file':
+                        event['file_hash'] = alert['checksum']
+                        event['file_hash_type'] = alert['checksum_type']
+
+            else:  # Windows, win_pulsar
+                change = alert['Accesses']
+                if alert['Hash'] == 'Item is a directory':
+                    object_type = 'directory'
+                else:
+                    object_type = 'file'
+
+                actions = defaultdict(lambda: 'unknown')
+                actions['Delete'] = 'deleted'
+                actions['Read Control'] = 'read'
+                actions['Write DAC'] = 'acl_modified'
+                actions['Write Owner'] = 'modified'
+                actions['Synchronize'] = 'modified'
+                actions['Access Sys Sec'] = 'read'
+                actions['Read Data'] = 'read'
+                actions['Write Data'] = 'modified'
+                actions['Append Data'] = 'modified'
+                actions['Read EA'] = 'read'
+                actions['Write EA'] = 'modified'
+                actions['Execute/Traverse'] = 'read'
+                actions['Read Attributes'] = 'read'
+                actions['Write Attributes'] = 'acl_modified'
+                actions['Query Key Value'] = 'read'
+                actions['Set Key Value'] = 'modified'
+                actions['Create Sub Key'] = 'created'
+                actions['Enumerate Sub-Keys'] = 'read'
+                actions['Notify About Changes to Keys'] = 'read'
+                actions['Create Link'] = 'created'
+                actions['Print'] = 'read'
+
+                event['action'] = actions[change]
+                event['change_type'] = 'filesystem'
+                event['object_category'] = object_type
+                event['object_path'] = alert['Object Name']
+                event['file_name'] = os.path.basename(alert['Object Name'])
+                event['file_path'] = os.path.dirname(alert['Object Name'])
+                # TODO: Should we be reporting 'EntryType' or 'TimeGenerated?
+                #   EntryType reports whether attempt to change was successful.
+
+            event.update({'master': master})
+            event.update({'minion_id': minion_id})
+            event.update({'dest_host': fqdn})
+            event.update({'dest_ip': fqdn_ip4})
+
+            payload.update({'host': fqdn})
+            payload.update({'index': opts['index']})
+            payload.update({'sourcetype': opts['sourcetype']})
+            payload.update({'event': event})
+
+            rdy = json.dumps(payload)
+            requests.put('{}:{}/hubble/pulsar'.format(indexer, port), rdy, auth=HTTPBasicAuth(user, password))
+    return
+
+
+def _get_options():
+    if __salt__['config.get']('hubblestack:returner:logstash'):
+        logstash_opts = []
+        returner_opts = __salt__['config.get']('hubblestack:returner:logstash')
+        if not isinstance(returner_opts, list):
+            returner_opts = [returner_opts]
+        for opt in returner_opts:
+            processed = {}
+            processed['password'] = opt.get('password')
+            processed['user'] = opt.get('user')
+            processed['indexer'] = opt.get('indexer')
+            processed['port'] = str(opt.get('port', '8080'))
+            processed['index'] = opt.get('index')
+            processed['custom_fields'] = opt.get('custom_fields', [])
+            processed['sourcetype'] = opt.get('sourcetype_pulsar', 'hubble_osquery')
+            processed['indexer_ssl'] = opt.get('indexer_ssl', True)
+            processed['proxy'] = opt.get('proxy', {})
+            processed['timeout'] = opt.get('timeout', 9.05)
+            logstash_opts.append(processed)
+        return logstash_opts
+    else:
+        try:
+            port = __salt__['config.get']('hubblestack:returner:logstash:port')
+            user = __salt__['config.get']('hubblestack:returner:logstash:user')
+            indexer = __salt__['config.get']('hubblestack:returner:logstash:indexer')
+            password = __salt__['config.get']('hubblestack:returner:logstash:password')
+            sourcetype = __salt__['config.get']('hubblestack:pulsar:returner:logstash:sourcetype')
+            custom_fields = __salt__['config.get']('hubblestack:pulsar:returner:logstash:custom_fields', [])
+        except:
+            return None
+
+        logstash_opts = {'password': password, 'indexer': indexer, 'sourcetype': sourcetype, 'index': index, 'custom_fields': custom_fields}
+
+        indexer_ssl = __salt__['config.get']('hubblestack:pulsar:returner:logstash:indexer_ssl', True)
+        logstash_opts['http_input_server_ssl'] = indexer_ssl
+        logstash_opts['proxy'] = __salt__['config.get']('hubblestack:pulsar:returner:logstash:proxy', {})
+        logstash_opts['timeout'] = __salt__['config.get']('hubblestack:pulsar:returner:logstash:timeout', 9.05)
+
+        return [logstash_opts]


### PR DESCRIPTION
These three returners are initial working concepts for ingesting Hubble data into Logstash for use in ELK stacks. The http input module for Logstash is required, as well as enabling the json filter source:

Example logstash config:
```
input {
  http {
    port => '8080'
    host => '0.0.0.0'
    type => 'hubble'
    user => 'hubble'
    password => 'password'
  }
}

filter {
  json {
    source => 'message'
  }
}

output {
  elasticsearch { hosts => ["localhost:9200"] }
  stdout { codec => rubydebug }
}
```