### PR TITLE
Win upgrade uninstall fix

### DIFF
--- a/pkg/windows/create_build_env.ps1
+++ b/pkg/windows/create_build_env.ps1
@@ -1,7 +1,6 @@
 ﻿# Script to install hubble dependencies and create executible
 $chocoVer = "0.10.5"
 $gitVer = "2.12.0"
-$hooks = "./pkg/"
 
 # Verify you are running with elevated permission mode (administrator token)
 if (!([bool](([System.Security.Principal.WindowsIdentity]::GetCurrent()).groups -match "S-1-5-32-544"))) {
@@ -87,7 +86,7 @@ If (Test-Path "C:\Program Files (x86)") {
 } else {
     Invoke-WebRequest -Uri https://github.com/git-for-windows/git/releases/download/v2.12.2.windows.2/PortableGit-2.12.2.2-32-bit.7z.exe -OutFile .\PortableGit.7z.exe
 }
-7za x PortableGit.7z.exe -o"$path\hubble\PortableGit" -y
+7z x PortableGit.7z.exe -o"$path\hubble\PortableGit" -y
 & "$path\hubble\PortableGit\post-install.bat"
 
 # Install osquery for executible

--- a/pkg/windows/hubble-Setup.nsi
+++ b/pkg/windows/hubble-Setup.nsi
@@ -250,7 +250,7 @@ ${StrStrAdv}
   Section "MainSection" SEC01
 
     SetOutPath "$INSTDIR\"
-    SetOverwrite off
+    SetOverwrite ifdiff 
 	CreateDirectory $INSTDIR\var
     File /r "..\..\dist\hubble\"
 	File "..\osqueryi.exe"
@@ -294,7 +294,7 @@ ${StrStrAdv}
     nsExec::Exec "nssm.exe set Hubble AppParameters hubble.exe -c .\etc\hubble\hubble.conf"
     nsExec::Exec "nssm.exe set Hubble Start SERVICE_AUTO_START"
 
-    RMDir /R "$INSTDIR\var" ; removing cache from old version
+    RMDir /R "$INSTDIR\var\cache" ; removing cache from old version
 
     Call updateHubbleConfig
 


### PR DESCRIPTION
These few simple changes make it possible to get a working environment with the powershell script, and allow for correct upgrading.