### PR TITLE
Fix up systemctl.py

### DIFF
--- a/hubblestack/files/hubblestack_nova/mount.py
+++ b/hubblestack/files/hubblestack_nova/mount.py
@@ -76,17 +76,17 @@ def audit(data_list, tags, debug=False, **kwargs):
                 if 'control' in tag_data:
                     ret['Controlled'].append(tag_data)
                     continue
-                
+
 
                 name  = tag_data.get('name')
                 audittype = tag_data.get('type')
-  
+
 
                 if 'attribute' not in tag_data:
                     log.error('No attribute found for mount audit {0}, file {1}'
                               .format(tag,name))
                     tag_data = copy.deepcopy(tag_data)
-                    tag_data['error'] = 'No pattern found'.format(mod) 
+                    tag_data['error'] = 'No pattern found'.format(mod)
                     ret['Failure'].append(tag_data)
                     continue
 
@@ -195,16 +195,16 @@ def _get_tags(data):
 
 def _check_mount_attribute(path,attribute, check_type):
     '''
-    This function checks if the partition at a given path is mounted with a particular attribute or not. 
-    If 'check_type' is 'hard', the function returns False if he specified path does not exist, or if it 
-    is not a mounted partition. If 'check_type' is 'soft', the functions returns True in such cases. 
+    This function checks if the partition at a given path is mounted with a particular attribute or not.
+    If 'check_type' is 'hard', the function returns False if he specified path does not exist, or if it
+    is not a mounted partition. If 'check_type' is 'soft', the functions returns True in such cases.
     '''
 
     if not os.path.exists(path):
         if check_type == 'hard':
             return False
         else:
-            return True   
+            return True
 
 
     mount_object  = __salt__['mount.active']()
@@ -221,5 +221,5 @@ def _check_mount_attribute(path,attribute, check_type):
         if check_type == 'hard':
             return False
         else:
-            return True 
+            return True
 

--- a/hubblestack/files/hubblestack_nova/systemctl.py
+++ b/hubblestack/files/hubblestack_nova/systemctl.py
@@ -61,11 +61,11 @@ def audit(data_list, tags, debug=False, **kwargs):
     __tags__ = _get_tags(__data__)
 
     if debug:
-	log.debug('systemctl audit __data__:')
+        log.debug('systemctl audit __data__:')
         log.debug(__data__)
         log.debug('systemctl audit __tags__:')
         log.debug(__tags__)
-   
+
     ret = {'Success': [], 'Failure': [], 'Controlled': []}
     for tag in __tags__:
         if fnmatch.fnmatch(tag, tags):
@@ -75,23 +75,23 @@ def audit(data_list, tags, debug=False, **kwargs):
                     continue
                 name = tag_data['name']
                 audittype = tag_data['type']
-		disabled_states = ["disabled", "not_found", "indirect"]
+                disabled_states = ["disabled", "not_found", "indirect"]
 
                 status_code, status = _systemctl(name)
                 # Blacklisted service (must not be running or not found)
                 if audittype == 'blacklist':
-		    if status_code == "1" or status in disabled_states:
-                    	ret['Success'].append(tag_data)
-		    else:
-			tag_data["failure_reason"] = "Service Status: " + status + ", return code: " + status_code
-			ret['Failure'].append(tag_data)
+                    if status_code == "1" or status in disabled_states:
+                        ret['Success'].append(tag_data)
+                    else:
+                        tag_data["failure_reason"] = "Service Status: " + status + ", return code: " + status_code
+                        ret['Failure'].append(tag_data)
                 # Whitelisted pattern (must be found and running)
                 elif audittype == 'whitelist':
-		    if status_code == "0":
-                    	ret['Success'].append(tag_data)
-		    else:
-			tag_data["failure_reason"] = "Service Status: " + status + ", return code: " + status_code
-			ret['Failure'].append(tag_data)
+                    if status_code == "0":
+                        ret['Success'].append(tag_data)
+                    else:
+                        tag_data["failure_reason"] = "Service Status: " + status + ", return code: " + status_code
+                        ret['Failure'].append(tag_data)
 
     return ret
 
@@ -162,7 +162,7 @@ def _get_tags(data):
                         formatted_data.update(audit_data)
                         formatted_data.pop('data')
                         ret[tag].append(formatted_data)
-	
+
     return ret
 
 def _execute_shell_command(cmd):
@@ -180,6 +180,5 @@ def _systemctl(service_name):
     output = _execute_shell_command('systemctl is-enabled ' + service_name + ' 2>/dev/null; echo $?').strip()
     output = output.split('\n') if output != "" else []
     if output == []:
-	return False
+        return False
     return (output[1], output[0]) if len(output) == 2 else (output[0], "not_found")
-

--- a/hubblestack/files/hubblestack_nova/systemctl.py
+++ b/hubblestack/files/hubblestack_nova/systemctl.py
@@ -3,7 +3,7 @@
 HubbleStack Nova plugin for using systemctl to verify status of a given service.
 
 Supports both blacklisting and whitelisting patterns. Blacklisted services must
-not be running. Whitelisted services must be running.
+not be enabled. Whitelisted services must be enabled.
 
 :maintainer: HubbleStack / basepi
 :maturity: 2017.8.29


### PR DESCRIPTION
Ref https://github.com/hubblestack/hubble/pull/192

@anuragpaliwal80 I fixed up the trailing whitespace and tabs mixed with spaces. We also noticed that your old version had a command injection vulnerability -- if you passed in a semicolon as part of the service name you could inject a command into your `cmd.run`. That's pretty easily fixable -- I could have just used `cmd.retcode` instead to get the results you wanted. However, I also happened to know that salt has a module which can tell us whether a service is enabled. So I simplified your module to use that function. Keep me posted if you have any questions/concerns.

Edit: also removed trailing whitespace from mount.py