### PR TITLE
Fix pulsar.top

### DIFF
--- a/hubblestack/extmods/modules/pulsar.py
+++ b/hubblestack/extmods/modules/pulsar.py
@@ -393,7 +393,7 @@ def _dict_update(dest, upd, recursive_update=True, merge_lists=False):
                 dest_subkey = None
             if isinstance(dest_subkey, collections.Mapping) \
                     and isinstance(val, collections.Mapping):
-                ret = update(dest_subkey, val, merge_lists=merge_lists)
+                ret = _dict_update(dest_subkey, val, merge_lists=merge_lists)
                 dest[key] = ret
             elif isinstance(dest_subkey, list) \
                      and isinstance(val, list):

--- a/hubblestack/extmods/modules/win_pulsar.py
+++ b/hubblestack/extmods/modules/win_pulsar.py
@@ -545,7 +545,7 @@ def _dict_update(dest, upd, recursive_update=True, merge_lists=False):
                 dest_subkey = None
             if isinstance(dest_subkey, collections.Mapping) \
                     and isinstance(val, collections.Mapping):
-                ret = update(dest_subkey, val, merge_lists=merge_lists)
+                ret = _dict_update(dest_subkey, val, merge_lists=merge_lists)
                 dest[key] = ret
             elif isinstance(dest_subkey, list) \
                      and isinstance(val, list):


### PR DESCRIPTION
@rashmip29 FYI. Looks like we never tested for multiple items under a list heading in the topfile, so it never had to recurse deep.