### PR TITLE
Add hash cache invalidation to azurefs

### DIFF
--- a/hubblestack/extmods/fileserver/azurefs.py
+++ b/hubblestack/extmods/fileserver/azurefs.py
@@ -262,6 +262,11 @@ def update():
             os.unlink(lk_fn)
         except Exception:
             pass
+        try:
+            hash_cachedir = os.path.join(__opts__['cachedir'], 'azurefs', 'hashes')
+            shutil.rmtree(hash_cachedir)
+        except Exception:
+            log.exception('Problem occurred trying to invalidate hash cach for azurefs')
 
 
 def file_hash(load, fnd):


### PR DESCRIPTION
This was causing azurefs hosts to only take the first version of a file unless the cache is cleared manually.