### PR TITLE
 Modifying win_secedit.py to handle comma(,) in registry strings

### DIFF
--- a/hubblestack/files/hubblestack_nova/win_secedit.py
+++ b/hubblestack/files/hubblestack_nova/win_secedit.py
@@ -346,6 +346,8 @@ def _translate_value_type(current, value, evaluator, __sidaccounts__=False):
             return False
         elif current.lower().find(evaluator) != -1:
             return True
+        elif current.startswith("7,") and current.lower().find(evaluator.replace(',','","')) != -1:
+            return True
         else:
             return False
     else:

--- a/hubblestack/files/hubblestack_nova/win_secedit.py
+++ b/hubblestack/files/hubblestack_nova/win_secedit.py
@@ -346,6 +346,8 @@ def _translate_value_type(current, value, evaluator, __sidaccounts__=False):
             return False
         elif current.lower().find(evaluator) != -1:
             return True
+        # If a value is stored as REG_MULTI_SZ in registry, all commas are surrounded by double quotes
+        # in the output of 'secedit /export' command. Following elif takes care of this situation.
         elif current.startswith("7,") and current.lower().find(evaluator.replace(',','","')) != -1:
             return True
         else:


### PR DESCRIPTION
Consider the following test 
```
win_secedit:
  whitelist:
    interactive_logon_message_text_for_users_attempting_to_log_on :
      data:
        'Microsoft Windows Server 2016*':
          - 'MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\LegalNoticeText':
              tag: CIS-2.3.7.4
              match_output: 'This test would fail, because it contains a comma.'
              value_type: 'configured'
      description: (l1) configure 'interactive logon - message text for users attempting to log on'
```
It would fail even if the exact string value is set against corresponding registry key. It is happening because  output of secedit /export command would be something like this:

```
.
.
MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\LegalNoticeText=7,This test would fail"," because it contains a comma.
.
.
```
My change would handle this situation.
(I have checked for other special characters also, on comma(,) is creating probelm.)
