### PR TITLE
Add local_fqdn grain and add dest_fqdn to splunk events

### DIFF
--- a/hubblestack/extmods/grains/fqdn.py
+++ b/hubblestack/extmods/grains/fqdn.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+'''
+Custom grains around fqdn
+'''
+import salt.modules.cmdmod
+import salt.utils
+import socket
+
+__salt__ = {'cmd.run': salt.modules.cmdmod._run_quiet}
+
+
+def fqdn():
+    '''
+    Generate a secondary fqdn with `hostname --fqdn` since socket.getfqdn()
+    appears to be susceptible to issues with DNS
+    '''
+    grains = {}
+    local_fqdn = None
+    if not salt.utils.is_windows():
+        local_fqdn = __salt__['cmd.run']('hostname --fqdn')
+    grains['local_fqdn'] = local_fqdn if local_fqdn else socket.getfqdn()
+    return grains

--- a/hubblestack/extmods/returners/splunk_nebula_return.py
+++ b/hubblestack/extmods/returners/splunk_nebula_return.py
@@ -104,6 +104,7 @@ def returner(ret):
                     if ip4_addr and not ip4_addr.startswith('127.'):
                         fqdn_ip4 = ip4_addr
                         break
+            local_fqdn = __grains__.get('local_fqdn', __grains__['fqdn'])
 
             if not data:
                 return
@@ -120,6 +121,7 @@ def returner(ret):
                             event.update({'minion_id': minion_id})
                             event.update({'dest_host': fqdn})
                             event.update({'dest_ip': fqdn_ip4})
+                            event.update({'dest_fqdn': local_fqdn})
 
                             for cloud in clouds:
                                 event.update(cloud)

--- a/hubblestack/extmods/returners/splunk_nova_return.py
+++ b/hubblestack/extmods/returners/splunk_nova_return.py
@@ -102,6 +102,7 @@ def returner(ret):
                     if ip4_addr and not ip4_addr.startswith('127.'):
                         fqdn_ip4 = ip4_addr
                         break
+            local_fqdn = __grains__.get('local_fqdn', __grains__['fqdn'])
 
             if __grains__['master']:
                 master = __grains__['master']
@@ -130,6 +131,7 @@ def returner(ret):
                 event.update({'minion_id': minion_id})
                 event.update({'dest_host': fqdn})
                 event.update({'dest_ip': fqdn_ip4})
+                event.update({'dest_fqdn': local_fqdn})
 
                 for cloud in clouds:
                     event.update(cloud)
@@ -175,6 +177,7 @@ def returner(ret):
                 event.update({'minion_id': minion_id})
                 event.update({'dest_host': fqdn})
                 event.update({'dest_ip': fqdn_ip4})
+                event.update({'dest_fqdn': local_fqdn})
 
                 for cloud in clouds:
                     event.update(cloud)
@@ -218,6 +221,7 @@ def returner(ret):
                 event.update({'minion_id': minion_id})
                 event.update({'dest_host': fqdn})
                 event.update({'dest_ip': fqdn_ip4})
+                event.update({'dest_fqdn': local_fqdn})
 
                 for cloud in clouds:
                     event.update(cloud)

--- a/hubblestack/extmods/returners/splunk_pulsar_return.py
+++ b/hubblestack/extmods/returners/splunk_pulsar_return.py
@@ -111,6 +111,7 @@ def returner(ret):
                     if ip4_addr and not ip4_addr.startswith('127.'):
                         fqdn_ip4 = ip4_addr
                         break
+            local_fqdn = __grains__.get('local_fqdn', __grains__['fqdn'])
 
             alerts = []
             for item in data:
@@ -214,6 +215,7 @@ def returner(ret):
                 event.update({'minion_id': minion_id})
                 event.update({'dest_host': fqdn})
                 event.update({'dest_ip': fqdn_ip4})
+                event.update({'dest_fqdn': local_fqdn})
 
                 for cloud in clouds:
                     event.update(cloud)


### PR DESCRIPTION
Apparently `socket.getfqdn()` has some reliance on DNS being configured correctly. We ran into this on a host whose reverse IP lookup was resolving to both the host, and the host's load balancer. This resulted in inconsistent results from `socket.getfqdn()`, but it appears that `hostname --fqdn` is consistent even under these circumstances.

So I added a new custom grain, `local_fqdn`, using `hostname --fqdn`.

@madchills Because I don't know the workings of the `hostname` command on Windows, I have it defaulting to `socket.fqdn()`. At some point we should add windows-specific code here to try to avoid similar issues on Windows.