### PR TITLE
Add periodic grains refresh and session/host UUIDs

### DIFF
--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -302,7 +302,7 @@ def load_config():
     salt.config.DEFAULT_MINION_OPTS['log_level'] = None
     salt.config.DEFAULT_MINION_OPTS['file_client'] = 'local'
     salt.config.DEFAULT_MINION_OPTS['fileserver_update_frequency'] = 43200  # 12 hours
-    salt.config.DEFAULT_MINION_OPTS['grains_refresh_frequency'] = 3600  # 12 hours
+    salt.config.DEFAULT_MINION_OPTS['grains_refresh_frequency'] = 3600  # 1 hour
     salt.config.DEFAULT_MINION_OPTS['scheduler_sleep_frequency'] = 0.5
     salt.config.DEFAULT_MINION_OPTS['default_include'] = 'hubble.d/*.conf'
 
@@ -428,7 +428,7 @@ def refresh_grains(initial=False):
                 self.asctime = asctime
                 self.name = name
         handler = hubblestack.splunklogging.SplunkHandler()
-        handler.emit(MockRecord(str(__grains__), 'INFO', time.asctime(), 'hubblestack.grains_report'))
+        handler.emit(MockRecord(__grains__, 'INFO', time.asctime(), 'hubblestack.grains_report'))
 
 
 def parse_args():

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -13,6 +13,7 @@ import os
 import random
 import signal
 import sys
+import uuid
 
 import salt.fileclient
 import salt.utils
@@ -24,6 +25,8 @@ from hubblestack import __version__
 log = logging.getLogger(__name__)
 
 __opts__ = {}
+# This should work fine until we go to multiprocessing
+SESSION_UUID = uuid.uuid4()
 
 
 def run():
@@ -80,6 +83,8 @@ def main():
         run_function()
         sys.exit(0)
 
+    last_grains_refresh = time.time()
+
     log.info('Starting main loop')
     while True:
         # Check if fileserver needs update
@@ -89,6 +94,9 @@ def main():
                 last_fc_update = time.time()
             except Exception as exc:
                 log.exception('Exception thrown trying to update fileclient.')
+
+        if time.time() - last_grains_refresh >= __opts__['grains_refresh_frequency']:
+            refresh_grains()
 
         try:
             log.debug('Executing schedule')
@@ -292,15 +300,11 @@ def load_config():
     salt.config.DEFAULT_MINION_OPTS['log_level'] = None
     salt.config.DEFAULT_MINION_OPTS['file_client'] = 'local'
     salt.config.DEFAULT_MINION_OPTS['fileserver_update_frequency'] = 43200  # 12 hours
+    salt.config.DEFAULT_MINION_OPTS['grains_refresh_frequency'] = 3600  # 12 hours
     salt.config.DEFAULT_MINION_OPTS['scheduler_sleep_frequency'] = 0.5
     salt.config.DEFAULT_MINION_OPTS['default_include'] = 'hubble.d/*.conf'
 
     global __opts__
-    global __grains__
-    global __utils__
-    global __salt__
-    global __pillar__
-    global __returners__
 
     __opts__ = salt.config.minion_config(parsed_args.get('configfile'))
     __opts__.update(parsed_args)
@@ -381,21 +385,44 @@ def load_config():
     os.chmod(__opts__['log_file'], 384)
     os.chmod(parsed_args.get('configfile'), 384)
 
+    refresh_grains()
+
+    if __salt__['config.get']('hubblestack:splunklogging', False):
+        root_logger = logging.getLogger()
+        handler = hubblestack.splunklogging.SplunkHandler()
+        handler.setLevel(logging.ERROR)
+        root_logger.addHandler(handler)
+
+
+def refresh_grains():
+    '''
+    Refresh the grains, pillar, utils, modules, and returners
+    '''
+    global __opts__
+    global __grains__
+    global __utils__
+    global __salt__
+    global __pillar__
+    global __returners__
+    __opts__.pop('grains')
+    __opts__.pop('pillar')
     __grains__ = salt.loader.grains(__opts__)
+    __grains__['session_uuid'] = SESSION_UUID
     __pillar__ = {}
     __opts__['grains'] = __grains__
     __opts__['pillar'] = __pillar__
     __utils__ = salt.loader.utils(__opts__)
     __salt__ = salt.loader.minion_mods(__opts__, utils=__utils__)
     __returners__ = salt.loader.returners(__opts__, __salt__)
-
-    if __salt__['config.get']('hubblestack:splunklogging', False):
-        hubblestack.splunklogging.__grains__ = __grains__
-        hubblestack.splunklogging.__salt__ = __salt__
-        root_logger = logging.getLogger()
-        handler = hubblestack.splunklogging.SplunkHandler()
-        handler.setLevel(logging.ERROR)
-        root_logger.addHandler(handler)
+    hubblestack.splunklogging.__grains__ = __grains__
+    hubblestack.splunklogging.__salt__ = __salt__
+    class MockRecord(object):
+        def __init__(self, message, levelname, asctime, name):
+            self.message = message
+            self.levelname = levelname
+            self.asctime = asctime
+            self.name = name
+    hubblestack.splunklogging.emit(MockRecord(str(__grains__), 'INFO', time.asctime(), __name__))
 
 
 def parse_args():

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -96,6 +96,7 @@ def main():
                 log.exception('Exception thrown trying to update fileclient.')
 
         if time.time() - last_grains_refresh >= __opts__['grains_refresh_frequency']:
+            log.info('Refreshing grains')
             refresh_grains()
             last_grains_refresh = time.time()
 
@@ -427,7 +428,7 @@ def refresh_grains(initial=False):
                 self.asctime = asctime
                 self.name = name
         handler = hubblestack.splunklogging.SplunkHandler()
-        handler.emit(MockRecord(str(__grains__), 'INFO', time.asctime(), __name__))
+        handler.emit(MockRecord(str(__grains__), 'INFO', time.asctime(), 'hubblestack.grains_report'))
 
 
 def parse_args():

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -404,8 +404,10 @@ def refresh_grains():
     global __salt__
     global __pillar__
     global __returners__
-    __opts__.pop('grains')
-    __opts__.pop('pillar')
+    if 'grains' in __opts__:
+        __opts__.pop('grains')
+    if 'pillar' in __opts__:
+        __opts__.pop('pillar')
     __grains__ = salt.loader.grains(__opts__)
     __grains__['session_uuid'] = SESSION_UUID
     __pillar__ = {}

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -424,7 +424,8 @@ def refresh_grains():
             self.levelname = levelname
             self.asctime = asctime
             self.name = name
-    hubblestack.splunklogging.emit(MockRecord(str(__grains__), 'INFO', time.asctime(), __name__))
+    handler = hubblestack.splunklogging.SplunkHandler()
+    handler.emit(MockRecord(str(__grains__), 'INFO', time.asctime(), __name__))
 
 
 def parse_args():

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -412,6 +412,7 @@ def refresh_grains(initial=False):
         __opts__.pop('pillar')
     __grains__ = salt.loader.grains(__opts__)
     __grains__['session_uuid'] = SESSION_UUID
+    __opts__['host_uuid'] = __grains__.get('host_uuid', None)
     __pillar__ = {}
     __opts__['grains'] = __grains__
     __opts__['pillar'] = __pillar__

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -420,7 +420,7 @@ def refresh_grains(initial=False):
     __returners__ = salt.loader.returners(__opts__, __salt__)
     hubblestack.splunklogging.__grains__ = __grains__
     hubblestack.splunklogging.__salt__ = __salt__
-    if not initial:
+    if not initial and __salt__['config.get']('hubblestack:splunklogging', False):
         class MockRecord(object):
             def __init__(self, message, levelname, asctime, name):
                 self.message = message

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -97,6 +97,7 @@ def main():
 
         if time.time() - last_grains_refresh >= __opts__['grains_refresh_frequency']:
             refresh_grains()
+            last_grains_refresh = time.time()
 
         try:
             log.debug('Executing schedule')

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -26,7 +26,7 @@ log = logging.getLogger(__name__)
 
 __opts__ = {}
 # This should work fine until we go to multiprocessing
-SESSION_UUID = uuid.uuid4()
+SESSION_UUID = str(uuid.uuid4())
 
 
 def run():

--- a/hubblestack/extmods/grains/hostuuid.py
+++ b/hubblestack/extmods/grains/hostuuid.py
@@ -31,6 +31,12 @@ def host_uuid():
         elif existing_uuid:
             log.error('host_uuid was previously generated, but the cached '
                       'file is no longer present: {0}'.format(cached_uuid_path))
+        else:
+            # TODO: once we figure out how to get a custom log level for
+            # non-error splunk logs, we should move this to that log level so
+            # it doesn't look like an error.
+            log.error('generating fresh uuid, no cache file found. '
+                      '(probably not a problem)')
     except Exception:
         log.exception('Problem retrieving cached host uuid from file: {0}'
                       .format(cached_uuid_path))

--- a/hubblestack/extmods/grains/hostuuid.py
+++ b/hubblestack/extmods/grains/hostuuid.py
@@ -22,7 +22,7 @@ def host_uuid():
                 return {'host_uuid': f.read()}
     except Exception as exc:
         log.exception('Problem retrieving cached host uuid')
-    generated = uuid.uuid4()
+    generated = str(uuid.uuid4())
     with open(cached_uuid, 'w') as f:
         f.write(generated)
     return {'host_uuid': generated}

--- a/hubblestack/extmods/grains/hostuuid.py
+++ b/hubblestack/extmods/grains/hostuuid.py
@@ -7,7 +7,7 @@ import logging
 import os
 import uuid
 
-log = logging.get_logger(__name__)
+log = logging.getLogger(__name__)
 
 
 def host_uuid():

--- a/hubblestack/extmods/grains/hostuuid.py
+++ b/hubblestack/extmods/grains/hostuuid.py
@@ -24,5 +24,5 @@ def host_uuid():
         log.exception('Problem retrieving cached host uuid')
     generated = uuid.uuid4()
     with open(cached_uuid, 'w') as f:
-        f.write(cached_uuid)
+        f.write(generated)
     return {'host_uuid': generated}

--- a/hubblestack/extmods/grains/hostuuid.py
+++ b/hubblestack/extmods/grains/hostuuid.py
@@ -15,14 +15,36 @@ def host_uuid():
     Generate a unique uuid for this host, storing it on disk so it persists
     across restarts
     '''
-    cached_uuid = os.path.join(os.path.dirname(__opts__['configfile']), 'hubble_cached_uuid')
+    cached_uuid_path = os.path.join(os.path.dirname(__opts__['configfile']), 'hubble_cached_uuid')
+    existing_uuid = __opts__.get('host_uuid', None)
     try:
-        if os.path.isfile(cached_uuid):
-            with open(cached_uuid, 'r') as f:
-                return {'host_uuid': f.read()}
-    except Exception as exc:
-        log.exception('Problem retrieving cached host uuid')
-    generated = str(uuid.uuid4())
-    with open(cached_uuid, 'w') as f:
-        f.write(generated)
-    return {'host_uuid': generated}
+        if os.path.isfile(cached_uuid_path):
+            with open(cached_uuid_path, 'r') as f:
+                cached_uuid = f.read()
+                # Check if it's changed out from under us -- problem!
+                if existing_uuid and cached_uuid != existing_uuid:
+                    log.error('host_uuid changed on disk unexpectedly!'
+                              '\nPrevious: {0}\nNew: {1}\nKeeping previous.'
+                              .format(existing_uuid, cached_uuid))
+                    return {'host_uuid': existing_uuid}
+                return {'host_uuid': cached_uuid}
+        elif existing_uuid:
+            log.error('host_uuid was previously generated, but the cached '
+                      'file is no longer present: {0}'.format(cached_uuid_path))
+    except Exception:
+        log.exception('Problem retrieving cached host uuid from file: {0}'
+                      .format(cached_uuid_path))
+
+    # Generate a fresh one if needed
+    if not existing_uuid:
+        existing_uuid = str(uuid.uuid4())
+
+    # Cache the new (or old if it needs re-caching) uuid
+    try:
+        with open(cached_uuid_path, 'w') as f:
+            f.write(existing_uuid)
+    except Exception:
+        log.exception('Problem writing cached host uuid to file: {0}'
+                      .format(cached_uuid_path))
+
+    return {'host_uuid': existing_uuid}

--- a/hubblestack/extmods/grains/hostuuid.py
+++ b/hubblestack/extmods/grains/hostuuid.py
@@ -26,6 +26,13 @@ def host_uuid():
                     log.error('host_uuid changed on disk unexpectedly!'
                               '\nPrevious: {0}\nNew: {1}\nKeeping previous.'
                               .format(existing_uuid, cached_uuid))
+                    # Write the previous UUID to the cache file
+                    try:
+                        with open(cached_uuid_path, 'w') as f:
+                            f.write(existing_uuid)
+                    except Exception:
+                        log.exception('Problem writing cached host uuid to file: {0}'
+                                      .format(cached_uuid_path))
                     return {'host_uuid': existing_uuid}
                 return {'host_uuid': cached_uuid}
         elif existing_uuid:

--- a/hubblestack/extmods/grains/hostuuid.py
+++ b/hubblestack/extmods/grains/hostuuid.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+'''
+Generate a unique uuid for this host, storing it on disk so it persists across
+restarts
+'''
+import logging
+import os
+import uuid
+
+log = logging.get_logger(__name__)
+
+
+def host_uuid():
+    '''
+    Generate a unique uuid for this host, storing it on disk so it persists
+    across restarts
+    '''
+    cached_uuid = os.path.join(os.path.dirname(__opts__['configfile']), 'hubble_cached_uuid')
+    try:
+        if os.path.isfile(cached_uuid):
+            with open(cached_uuid, 'r') as f:
+                return {'host_uuid': f.read()}
+    except Exception as exc:
+        log.exception('Problem retrieving cached host uuid')
+    generated = uuid.uuid4()
+    with open(cached_uuid, 'w') as f:
+        f.write(cached_uuid)
+    return {'host_uuid': generated}

--- a/hubblestack/extmods/returners/splunk_nebula_return.py
+++ b/hubblestack/extmods/returners/splunk_nebula_return.py
@@ -122,6 +122,8 @@ def returner(ret):
                             event.update({'dest_host': fqdn})
                             event.update({'dest_ip': fqdn_ip4})
                             event.update({'dest_fqdn': local_fqdn})
+                            event.update({'host_uuid': __grains__['host_uuid']})
+                            event.update({'session_uuid': __grains__['session_uuid']})
 
                             for cloud in clouds:
                                 event.update(cloud)

--- a/hubblestack/extmods/returners/splunk_nova_return.py
+++ b/hubblestack/extmods/returners/splunk_nova_return.py
@@ -132,6 +132,8 @@ def returner(ret):
                 event.update({'dest_host': fqdn})
                 event.update({'dest_ip': fqdn_ip4})
                 event.update({'dest_fqdn': local_fqdn})
+                event.update({'host_uuid': __grains__['host_uuid']})
+                event.update({'session_uuid': __grains__['session_uuid']})
 
                 for cloud in clouds:
                     event.update(cloud)
@@ -178,6 +180,8 @@ def returner(ret):
                 event.update({'dest_host': fqdn})
                 event.update({'dest_ip': fqdn_ip4})
                 event.update({'dest_fqdn': local_fqdn})
+                event.update({'host_uuid': __grains__['host_uuid']})
+                event.update({'session_uuid': __grains__['session_uuid']})
 
                 for cloud in clouds:
                     event.update(cloud)
@@ -222,6 +226,8 @@ def returner(ret):
                 event.update({'dest_host': fqdn})
                 event.update({'dest_ip': fqdn_ip4})
                 event.update({'dest_fqdn': local_fqdn})
+                event.update({'host_uuid': __grains__['host_uuid']})
+                event.update({'session_uuid': __grains__['session_uuid']})
 
                 for cloud in clouds:
                     event.update(cloud)

--- a/hubblestack/extmods/returners/splunk_pulsar_return.py
+++ b/hubblestack/extmods/returners/splunk_pulsar_return.py
@@ -216,6 +216,8 @@ def returner(ret):
                 event.update({'dest_host': fqdn})
                 event.update({'dest_ip': fqdn_ip4})
                 event.update({'dest_fqdn': local_fqdn})
+                event.update({'host_uuid': __grains__['host_uuid']})
+                event.update({'session_uuid': __grains__['session_uuid']})
 
                 for cloud in clouds:
                     event.update(cloud)

--- a/hubblestack/splunklogging.py
+++ b/hubblestack/splunklogging.py
@@ -298,5 +298,6 @@ class http_event_collector:
                     server[1] = False
                 except Exception as e:
                     #log.error('Request to splunk threw an error: {0}'.format(e))
+                    pass
             self.batchEvents = []
             self.currentByteLength = 0

--- a/hubblestack/splunklogging.py
+++ b/hubblestack/splunklogging.py
@@ -294,9 +294,9 @@ class http_event_collector:
                     server[1] = True
                     break
                 except requests.exceptions.RequestException:
-                    log.info('Request to splunk server "%s" failed. Marking as bad.' % server[0])
+                    #log.info('Request to splunk server "%s" failed. Marking as bad.' % server[0])
                     server[1] = False
                 except Exception as e:
-                    log.error('Request to splunk threw an error: {0}'.format(e))
+                    #log.error('Request to splunk threw an error: {0}'.format(e))
             self.batchEvents = []
             self.currentByteLength = 0


### PR DESCRIPTION
This deserves a fair amount of review. @fossam to make sure this hits all his bullet points WRT unique IDs for sessions and hosts. @madchills for any problems you see regarding the python.

Defaulting to hourly grains refreshes, and sending those to splunk as well if configured with splunk_logging

@mew1033 and @fossam is there a good way to get the data structure to nest in the splunk event? Right now the grains are just hitting splunk as a giant string:

https://www.dropbox.com/s/1fcpct1la3xaye6/Screenshot%202017-12-14%2011.43.17.png?dl=0

I would love to get them as a nice nested thing so you can query the fields. I tried just sticking the dictionary in the message field as an actual dictionary, but the event never made it to splunk. Do I need to shove them in as top-level fields?

Also note that in future events the loggername will be hubblestack.grains_report, not hubblestack.daemon like it's showing in that screenshot.