### PR TITLE
bad indent level

### DIFF
--- a/hubblestack/files/hubblestack_nova/win_firewall.py
+++ b/hubblestack/files/hubblestack_nova/win_firewall.py
@@ -194,4 +194,4 @@ def _translate_value_type(current, value, evaluator, match):
         if match == '<':
             if int(current) < int(evaluator):
                 return True
-       return False
+        return False


### PR DESCRIPTION
I get an error on this mod, despite not running it on windows. It was driving me nuts.

```[ERROR   ] Failed to import nova /win_firewall.py, this is due most likely to a syntax error:
Traceback (most recent call last):
  File "/usr/local/python/python2.7/lib/python2.7/site-packages/hubblestack-2.2.11-py2.7.egg/hubblestack/extmods/module
s/nova_loader.py", line 1930, in _load_module
    ), fn_, fpath, desc)
  File "/var/cache/hubble/files/base/hubblestack_nova/win_firewall.py", line 197
    return False
               ^
IndentationError: unindent does not match any outer indentation level
```