### PR TITLE
Fix pulsar exclusion logic

### DIFF
--- a/hubblestack/extmods/modules/pulsar.py
+++ b/hubblestack/extmods/modules/pulsar.py
@@ -245,10 +245,10 @@ def process(configfile='salt://hubblestack_pulsar/hubblestack_pulsar_config.yaml
                                     _append = False
                             except:
                                 log.warn('Failed to compile regex: {0}'.format(exclude.keys()[0]))
-                                pass
+                            continue
                         else:
                             exclude = exclude.keys()[0]
-                    elif '*' in exclude:
+                    if '*' in exclude:
                         if fnmatch.fnmatch(event.pathname, exclude):
                             _append = False
                     else:


### PR DESCRIPTION
This should fix the edge case where the exclusion IS a dictionary, but IS NOT regex.