### PR TITLE
Avoid setting fqdn to localhost at all costs

### DIFF
--- a/hubblestack/extmods/returners/splunk_nebula_return.py
+++ b/hubblestack/extmods/returners/splunk_nebula_return.py
@@ -106,6 +106,14 @@ def returner(ret):
                         break
             local_fqdn = __grains__.get('local_fqdn', __grains__['fqdn'])
 
+            # Sometimes fqdn reports a value of localhost. If that happens, try another method.
+            bad_fqdns = ['localhost', 'localhost.localdomain', 'localhost6.localdomain6']
+            if fqdn in bad_fqdns:
+                new_fqdn = socket.gethostname()
+                if '.' not in new_fqdn:
+                    new_fqdn = fqdn_ip4
+                fqdn = new_fqdn
+
             if not data:
                 return
             else:

--- a/hubblestack/extmods/returners/splunk_nova_return.py
+++ b/hubblestack/extmods/returners/splunk_nova_return.py
@@ -104,6 +104,14 @@ def returner(ret):
                         break
             local_fqdn = __grains__.get('local_fqdn', __grains__['fqdn'])
 
+            # Sometimes fqdn reports a value of localhost. If that happens, try another method.
+            bad_fqdns = ['localhost', 'localhost.localdomain', 'localhost6.localdomain6']
+            if fqdn in bad_fqdns:
+                new_fqdn = socket.gethostname()
+                if '.' not in new_fqdn:
+                    new_fqdn = fqdn_ip4
+                fqdn = new_fqdn
+
             if __grains__['master']:
                 master = __grains__['master']
             else:

--- a/hubblestack/extmods/returners/splunk_pulsar_return.py
+++ b/hubblestack/extmods/returners/splunk_pulsar_return.py
@@ -113,6 +113,14 @@ def returner(ret):
                         break
             local_fqdn = __grains__.get('local_fqdn', __grains__['fqdn'])
 
+            # Sometimes fqdn reports a value of localhost. If that happens, try another method.
+            bad_fqdns = ['localhost', 'localhost.localdomain', 'localhost6.localdomain6']
+            if fqdn in bad_fqdns:
+                new_fqdn = socket.gethostname()
+                if '.' not in new_fqdn:
+                    new_fqdn = fqdn_ip4
+                fqdn = new_fqdn
+
             alerts = []
             for item in data:
                 events = item['return']


### PR DESCRIPTION
We're getting lots of events where Hubble thinks the hostname is "localhost.localdomain." I posted about the problem here https://stackoverflow.com/questions/48230377/why-does-pythons-socket-getfqdn-return-localhost-localdomain-sometimes
This should at least prevent the weird hostnames from appearing. Better to have the IP address than just "localhost."

I don't have any hosts that are having this problem, so I wasn't able to test this change.