### PR TITLE
pidfile issues (check_pidfile() to see if Hubble is already running)

### DIFF
--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -50,9 +50,11 @@ def run():
         sys.exit(0)
 
     if __opts__['daemonize']:
-        check_pidfile()
+        check_pidfile(kill_other=True)
         salt.utils.daemonize()
         create_pidfile()
+    else:
+        check_pidfile(kill_other=False)
 
     signal.signal(signal.SIGTERM, clean_up_process)
     signal.signal(signal.SIGINT, clean_up_process)
@@ -467,10 +469,15 @@ def parse_args():
                         help='Any arguments necessary for a single function run')
     return vars(parser.parse_args())
 
-def check_pidfile():
+def check_pidfile(kill_other=False):
     '''
     Check to see if there's already a pidfile. If so, check to see if the
     indicated process is alive and is Hubble.
+
+    kill_other
+        Default false, if set to true, attempt to kill detected running Hubble
+        processes; otherwise exit with an error.
+
     '''
     pidfile = __opts__['pidfile']
     if os.path.isfile(pidfile):
@@ -487,14 +494,18 @@ def check_pidfile():
                     with open("/proc/{pid}/cmdline".format(pid=xpid),'r') as f2:
                         cmdline = f2.readline().strip().strip('\x00').replace('\x00',' ')
                         if 'hubble' in cmdline:
-                            log.warn("process seems to still be alive and is hubble, attempting to shutdown")
-                            os.kill(int(xpid), signal.SIGTERM)
-                            time.sleep(1)
-                            if os.path.isdir("/proc/{pid}".format(pid=xpid)):
-                                log.error("failed to shutdown process successfully; abnormal program exit")
-                                exit(1)
+                            if kill_other:
+                                log.warn("process seems to still be alive and is hubble, attempting to shutdown")
+                                os.kill(int(xpid), signal.SIGTERM)
+                                time.sleep(1)
+                                if os.path.isdir("/proc/{pid}".format(pid=xpid)):
+                                    log.error("failed to shutdown process successfully; abnormal program exit")
+                                    exit(1)
+                                else:
+                                    log.info("shutdown seems to have succeeded, proceeding with startup")
                             else:
-                                log.info("shutdown seems to have succeeded, proceeding with startup")
+                                log.error("refusing to run while another hubble instance is running")
+                                exit(1)
                         else:
                             log.info("process does not appear to be hubble, ignoring")
 

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -50,10 +50,14 @@ def run():
         sys.exit(0)
 
     if __opts__['daemonize']:
+        # before becoming a daemon, check for other procs and possibly send
+        # then a signal 15 (otherwise refuse to run)
         check_pidfile(kill_other=True)
         salt.utils.daemonize()
         create_pidfile()
-    else:
+    elif not __opts__['function']:
+        # check the pidfile and possibly refuse to run
+        # (assuming this isn't a single function call)
         check_pidfile(kill_other=False)
 
     signal.signal(signal.SIGTERM, clean_up_process)

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -50,6 +50,7 @@ def run():
         sys.exit(0)
 
     if __opts__['daemonize']:
+        check_pidfile()
         salt.utils.daemonize()
         create_pidfile()
 
@@ -466,6 +467,36 @@ def parse_args():
                         help='Any arguments necessary for a single function run')
     return vars(parser.parse_args())
 
+def check_pidfile():
+    '''
+    Check to see if there's already a pidfile. If so, check to see if the
+    indicated process is alive and is Hubble.
+    '''
+    pidfile = __opts__['pidfile']
+    if os.path.isfile(pidfile):
+        with open(pidfile, 'r') as f:
+            xpid = f.readline().strip()
+            try:
+                xpid = int(xpid)
+            except:
+                xpid = 0
+                log.warn('unable to parse pid="{pid}" in pidfile={file}'.format(pid=xpid,file=pidfile))
+            if xpid:
+                log.warn('pidfile={file} exists and contains pid={pid}'.format(file=pidfile, pid=xpid))
+                if os.path.isdir("/proc/{pid}".format(pid=xpid)):
+                    with open("/proc/{pid}/cmdline".format(pid=xpid),'r') as f2:
+                        cmdline = f2.readline().strip().strip('\x00').replace('\x00',' ')
+                        if 'hubble' in cmdline:
+                            log.warn("process seems to still be alive and is hubble, attempting to shutdown")
+                            os.kill(int(xpid), signal.SIGTERM)
+                            time.sleep(1)
+                            if os.path.isdir("/proc/{pid}".format(pid=xpid)):
+                                log.error("failed to shutdown process successfully; abnormal program exit")
+                                exit(1)
+                            else:
+                                log.info("shutdown seems to have succeeded, proceeding with startup")
+                        else:
+                            log.info("process does not appear to be hubble, ignoring")
 
 def create_pidfile():
     '''


### PR DESCRIPTION
If there's a pidfile, check to see if it's hubble. If it is, kill the other one or die.

My thinking is that if we `hubble -d` we wish to start or restart. Writing and checking pidfiles does us no good at all if we're in systemd's simple process tracking mode though — in which mode, hubble would be started without the '-d' and would never attempt to daemonize.

