### PR TITLE
Systemd service issue

### DIFF
--- a/pkg/centos7/hubble.service
+++ b/pkg/centos7/hubble.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Hubblestack
+
+[Service]
+Type=forking
+PIDFile=/var/run/hubble.pid
+ExecStart=/usr/bin/hubble -d
+
+[Install]
+WantedBy=multi-user.target

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ if distro == 'redhat' or distro == 'centos':
         data_files = [('/etc/init.d', ['pkg/hubble']),
                       ('/etc/hubble', ['conf/hubble']), ]
     elif version.startswith('7'):
-        data_files = [('/usr/lib/systemd/system', ['pkg/hubble.service']),
+        data_files = [('/usr/lib/systemd/system', ['pkg/centos7/hubble.service']),
                       ('/etc/hubble', ['conf/hubble']), ]
 elif distro == 'Amazon Linux AMI':
     data_files = [('/etc/init.d', ['pkg/hubble']),


### PR DESCRIPTION
Not sure if this is the best approach, but as it stands the binary the current hubble.service file is looking for (via /opt/hubble/hubble) doesn't exist.  It was suggested to use a symlink in a prior PR, but the binary itself is non-existent in this case. , 