### PR TITLE
Remove global `hec` and some unused code

### DIFF
--- a/hubblestack/extmods/returners/splunk_nebula_return.py
+++ b/hubblestack/extmods/returners/splunk_nebula_return.py
@@ -56,8 +56,6 @@ http_event_collector_debug = False
 
 log = logging.getLogger(__name__)
 
-hec = None
-
 
 def returner(ret):
     try:
@@ -221,31 +219,6 @@ def _get_options():
         splunk_opts['add_query_to_sourcetype'] = __salt__['config.get']('hubblestack:nebula:returner:splunk:add_query_to_sourcetype', True)
 
         return [splunk_opts]
-
-
-def send_splunk(event, index_override=None, sourcetype_override=None):
-    # Get Splunk Options
-    # init the payload
-    payload = {}
-
-    # Set up the event metadata
-    if index_override is None:
-        payload.update({'index': opts['index']})
-    else:
-        payload.update({'index': index_override})
-
-    if sourcetype_override is None:
-        payload.update({'sourcetype': opts['sourcetype']})
-    else:
-        payload.update({'sourcetype': sourcetype_override})
-
-    # Add the event
-    payload.update({'event': event})
-    logging.info('Payload: %s' % json.dumps(payload))
-
-    # fire it off
-    hec.batchEvent(payload)
-    return True
 
 
 # Thanks to George Starcher for the http_event_collector class (https://github.com/georgestarcher/)

--- a/hubblestack/extmods/returners/splunk_nova_return.py
+++ b/hubblestack/extmods/returners/splunk_nova_return.py
@@ -55,8 +55,6 @@ http_event_collector_debug = False
 
 log = logging.getLogger(__name__)
 
-hec = None
-
 
 def returner(ret):
     try:
@@ -323,31 +321,6 @@ def _get_options():
         splunk_opts['index_extracted_fields'] = __salt__['config.get']('hubblestack:nova:returner:splunk:index_extracted_fields', [])
 
         return [splunk_opts]
-
-
-def send_splunk(event, index_override=None, sourcetype_override=None):
-    # Get Splunk Options
-    # init the payload
-    payload = {}
-
-    # Set up the event metadata
-    if index_override is None:
-        payload.update({'index': opts['index']})
-    else:
-        payload.update({'index': index_override})
-
-    if sourcetype_override is None:
-        payload.update({'sourcetype': opts['sourcetype']})
-    else:
-        payload.update({'sourcetype': sourcetype_override})
-
-    # Add the event
-    payload.update({'event': event})
-    log.info('Payload: %s' % json.dumps(payload))
-
-    # fire it off
-    hec.batchEvent(payload)
-    return True
 
 
 # Thanks to George Starcher for the http_event_collector class (https://github.com/georgestarcher/)

--- a/hubblestack/extmods/returners/splunk_pulsar_return.py
+++ b/hubblestack/extmods/returners/splunk_pulsar_return.py
@@ -57,8 +57,6 @@ http_event_collector_debug = False
 
 log = logging.getLogger(__name__)
 
-hec = None
-
 
 def returner(ret):
     try:


### PR DESCRIPTION
This PR doesn't alter logic in any way. Because we're assigning to `hec` without using a `global` keyword, we're creating a local variable that shadows the global anyway. But since we're not using the global, we should still get rid of it since it's misleading.