### PR TITLE
Making changes to improve windows pulsar performance

### DIFF
--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -253,7 +253,8 @@ def schedule():
             log.debug('Executing scheduled function {0}'.format(func))
             jobdata['last_run'] = time.time()
             ret = __salt__[func](*args, **kwargs)
-            log.debug('Job returned:\n{0}'.format(ret))
+            if __opts__['log_level'] == 'debug':
+                log.debug('Job returned:\n{0}'.format(ret))
             for returner in returners:
                 returner = '{0}.returner'.format(returner)
                 if returner not in __returners__:


### PR DESCRIPTION
We are facing memory problem on windows machines. If a large number of file operations are going on the system, hubble's memory increases to more than 1GB. So this PR contains following changes:

1. Avoiding to print a large object ( more explanation in daemon.py )
2. Hash is calculated for all the objects returned by _pull_events() irrespective of where the object is to be monitored or not. This has been handled in this PR ( more explanation in win_pulsar_winaudit.py )
3. It seems that win_pulsar.py was replaced with a very old version in the commit https://github.com/hubblestack/hubble/commit/7cccf7b9e92dfbc32c0253bc3d63418962852dcd
. So I have tried to put back the changes which were lost in that commit. 

Please don't merge this PR today. We are waiting for tomorrow to verify the performance results. We will let you know tomorrow if this PR is good to merge. It would be nice if the PR could be reviewed meanwhile. 

I have noticed that azurefs.py has also been changed. It would be nice if you could verify in the next build that azurefs is still working properly as our team heavily relies on it.