### PR TITLE
Don't tell splunk to index more things

### DIFF
--- a/hubblestack/extmods/returners/splunk_nebula_return.py
+++ b/hubblestack/extmods/returners/splunk_nebula_return.py
@@ -74,14 +74,6 @@ def returner(ret):
             timeout = opts['timeout']
             custom_fields = opts['custom_fields']
 
-            # Set up the fields to be extracted at index time. The field values must be strings.
-            # Note that these fields will also still be available in the event data
-            index_extracted_fields = ['aws_instance_id', 'aws_account_id', 'azure_vmId', 'azure_subscriptionId']
-            try:
-                index_extracted_fields.extend(opts['index_extracted_fields'])
-            except TypeError:
-                pass
-
             # Set up the collector
             hec = http_event_collector(http_event_collector_key, http_event_collector_host, http_event_port=http_event_collector_port, http_event_server_ssl=hec_ssl, proxy=proxy, timeout=timeout)
 
@@ -157,14 +149,6 @@ def returner(ret):
 
                             payload.update({'event': event})
 
-                            # Potentially add metadata fields:
-                            fields = {}
-                            for item in index_extracted_fields:
-                                if item in payload['event'] and not isinstance(payload['event'][item], (list, dict, tuple)):
-                                    fields[item] = str(payload['event'][item])
-                            if fields:
-                                payload.update({'fields': fields})
-
                             # If the osquery query includes a field called 'time' it will be checked.
                             # If it's within the last year, it will be used as the eventtime.
                             event_time = query_result.get('time', '')
@@ -200,7 +184,6 @@ def _get_options():
             processed['http_event_server_ssl'] = opt.get('hec_ssl', True)
             processed['proxy'] = opt.get('proxy', {})
             processed['timeout'] = opt.get('timeout', 9.05)
-            processed['index_extracted_fields'] = opt.get('index_extracted_fields', [])
             splunk_opts.append(processed)
         return splunk_opts
     else:
@@ -214,7 +197,6 @@ def _get_options():
         splunk_opts['http_event_server_ssl'] = __salt__['config.get']('hubblestack:nebula:returner:splunk:hec_ssl', True)
         splunk_opts['proxy'] = __salt__['config.get']('hubblestack:nebula:returner:splunk:proxy', {})
         splunk_opts['timeout'] = __salt__['config.get']('hubblestack:nebula:returner:splunk:timeout', 9.05)
-        splunk_opts['index_extracted_fields'] = __salt__['config.get']('hubblestack:nebula:returner:splunk:index_extracted_fields', [])
 
         splunk_opts['add_query_to_sourcetype'] = __salt__['config.get']('hubblestack:nebula:returner:splunk:add_query_to_sourcetype', True)
 

--- a/hubblestack/extmods/returners/splunk_nova_return.py
+++ b/hubblestack/extmods/returners/splunk_nova_return.py
@@ -73,14 +73,6 @@ def returner(ret):
             timeout = opts['timeout']
             custom_fields = opts['custom_fields']
 
-            # Set up the fields to be extracted at index time. The field values must be strings.
-            # Note that these fields will also still be available in the event data
-            index_extracted_fields = ['aws_instance_id', 'aws_account_id', 'azure_vmId', 'azure_subscriptionId']
-            try:
-                index_extracted_fields.extend(opts['index_extracted_fields'])
-            except TypeError:
-                pass
-
             # Set up the collector
             hec = http_event_collector(http_event_collector_key, http_event_collector_host, http_event_port=http_event_collector_port, http_event_server_ssl=hec_ssl, proxy=proxy, timeout=timeout)
             # st = 'salt:hubble:nova'
@@ -158,14 +150,6 @@ def returner(ret):
                 payload.update({'sourcetype': opts['sourcetype']})
                 payload.update({'event': event})
 
-                # Potentially add metadata fields:
-                fields = {}
-                for item in index_extracted_fields:
-                    if item in payload['event'] and not isinstance(payload['event'][item], (list, dict, tuple)):
-                        fields[item] = str(payload['event'][item])
-                if fields:
-                    payload.update({'fields': fields})
-
                 hec.batchEvent(payload)
 
             for suc in data.get('Success', []):
@@ -212,14 +196,6 @@ def returner(ret):
 
                 payload.update({'event': event})
 
-                # Potentially add metadata fields:
-                fields = {}
-                for item in index_extracted_fields:
-                    if item in payload['event'] and not isinstance(payload['event'][item], (list, dict, tuple)):
-                        fields[item] = str(payload['event'][item])
-                if fields:
-                    payload.update({'fields': fields})
-
                 hec.batchEvent(payload)
 
             if data.get('Compliance', None):
@@ -251,14 +227,6 @@ def returner(ret):
                 payload.update({'sourcetype': opts['sourcetype']})
                 payload.update({'index': opts['index']})
                 payload.update({'event': event})
-
-                # Potentially add metadata fields:
-                fields = {}
-                for item in index_extracted_fields:
-                    if item in payload['event'] and not isinstance(payload['event'][item], (list, dict, tuple)):
-                        fields[item] = str(payload['event'][item])
-                if fields:
-                    payload.update({'fields': fields})
 
                 hec.batchEvent(payload)
 
@@ -304,7 +272,6 @@ def _get_options():
             processed['http_event_server_ssl'] = opt.get('hec_ssl', True)
             processed['proxy'] = opt.get('proxy', {})
             processed['timeout'] = opt.get('timeout', 9.05)
-            processed['index_extracted_fields'] = opt.get('index_extracted_fields', [])
             splunk_opts.append(processed)
         return splunk_opts
     else:
@@ -318,7 +285,6 @@ def _get_options():
         splunk_opts['http_event_server_ssl'] = __salt__['config.get']('hubblestack:nova:returner:splunk:hec_ssl', True)
         splunk_opts['proxy'] = __salt__['config.get']('hubblestack:nova:returner:splunk:proxy', {})
         splunk_opts['timeout'] = __salt__['config.get']('hubblestack:nova:returner:splunk:timeout', 9.05)
-        splunk_opts['index_extracted_fields'] = __salt__['config.get']('hubblestack:nova:returner:splunk:index_extracted_fields', [])
 
         return [splunk_opts]
 

--- a/hubblestack/extmods/returners/splunk_pulsar_return.py
+++ b/hubblestack/extmods/returners/splunk_pulsar_return.py
@@ -78,14 +78,6 @@ def returner(ret):
             timeout = opts['timeout']
             custom_fields = opts['custom_fields']
 
-            # Set up the fields to be extracted at index time. The field values must be strings.
-            # Note that these fields will also still be available in the event data
-            index_extracted_fields = ['aws_instance_id', 'aws_account_id', 'azure_vmId', 'azure_subscriptionId']
-            try:
-                index_extracted_fields.extend(opts['index_extracted_fields'])
-            except TypeError:
-                pass
-
             # Set up the collector
             hec = http_event_collector(http_event_collector_key, http_event_collector_host, http_event_port=http_event_collector_port, http_event_server_ssl=hec_ssl, proxy=proxy, timeout=timeout)
             # Check whether or not data is batched:
@@ -250,14 +242,6 @@ def returner(ret):
 
                 payload.update({'event': event})
 
-                # Potentially add metadata fields:
-                fields = {}
-                for item in index_extracted_fields:
-                    if item in payload['event'] and not isinstance(payload['event'][item], (list, dict, tuple)):
-                        fields[item] = str(payload['event'][item])
-                if fields:
-                    payload.update({'fields': fields})
-
                 hec.batchEvent(payload)
 
             hec.flushBatch()
@@ -291,7 +275,6 @@ def _get_options():
             processed['http_event_server_ssl'] = opt.get('hec_ssl', True)
             processed['proxy'] = opt.get('proxy', {})
             processed['timeout'] = opt.get('timeout', 9.05)
-            processed['index_extracted_fields'] = opt.get('index_extracted_fields', [])
             splunk_opts.append(processed)
         return splunk_opts
     else:
@@ -305,7 +288,6 @@ def _get_options():
         splunk_opts['http_event_server_ssl'] = __salt__['config.get']('hubblestack:pulsar:returner:splunk:hec_ssl', True)
         splunk_opts['proxy'] = __salt__['config.get']('hubblestack:pulsar:returner:splunk:proxy', {})
         splunk_opts['timeout'] = __salt__['config.get']('hubblestack:pulsar:returner:splunk:timeout', 9.05)
-        splunk_opts['index_extracted_fields'] = __salt__['config.get']('hubblestack:pulsar:returner:splunk:index_extracted_fields', [])
 
         return [splunk_opts]
 

--- a/hubblestack/splunklogging.py
+++ b/hubblestack/splunklogging.py
@@ -74,14 +74,6 @@ class SplunkHandler(logging.Handler):
             timeout = opts['timeout']
             custom_fields = opts['custom_fields']
 
-            # Set up the fields to be extracted at index time. The field values must be strings.
-            # Note that these fields will also still be available in the event data
-            index_extracted_fields = ['aws_instance_id', 'aws_account_id', 'azure_vmId', 'azure_subscriptionId']
-            try:
-                index_extracted_fields.extend(opts['index_extracted_fields'])
-            except TypeError:
-                pass
-
             # Set up the collector
             hec = http_event_collector(http_event_collector_key, http_event_collector_host, http_event_port=http_event_collector_port, http_event_server_ssl=hec_ssl, proxy=proxy, timeout=timeout)
 
@@ -122,14 +114,6 @@ class SplunkHandler(logging.Handler):
             payload.update({'host': fqdn})
             payload.update({'index': opts['index']})
             payload.update({'sourcetype': opts['sourcetype']})
-
-            # Potentially add metadata fields:
-            fields = {}
-            for item in index_extracted_fields:
-                if item in event and not isinstance(event[item], (list, dict, tuple)):
-                    fields[item] = str(event[item])
-            if fields:
-                payload.update({'fields': fields})
 
             self.endpoint_list.append((hec, event, payload))
 
@@ -178,7 +162,6 @@ def _get_options():
             processed['http_event_server_ssl'] = opt.get('hec_ssl', True)
             processed['proxy'] = opt.get('proxy', {})
             processed['timeout'] = opt.get('timeout', 9.05)
-            processed['index_extracted_fields'] = opt.get('index_extracted_fields', [])
             splunk_opts.append(processed)
         return splunk_opts
     else:


### PR DESCRIPTION
There probably isn't ever a good time to tell Splunk to index extra fields.

The changes to the indexed fields intended by the removed code have to be
accompanied by changes to the fields configuration in Splunk or oddball
problems will occur (e.g., duplicate field indexing). The best plan (if you
really really need extra index fields) is to ask the Splunk admins to add them
to the index through their usual methods.

This affords them the opportunity to say, "that's not a good idea because ____"
and prevents the data from getting wonky in their indexes.

There are certainly fields one might wish to add to the index. It's best to
coordinate them carefully with the Splunk admins. (And these fields are more
rare than you'd think if you're accustomed to traditional databases.)