### PR TITLE
make a global out of __context__ and pass it to the module loader

### DIFF
--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -442,6 +442,10 @@ def refresh_grains(initial=False):
     global __salt__
     global __pillar__
     global __returners__
+    global __context__
+
+    if initial:
+        __context__ = {}
     if 'grains' in __opts__:
         __opts__.pop('grains')
     if 'pillar' in __opts__:
@@ -453,10 +457,16 @@ def refresh_grains(initial=False):
     __opts__['grains'] = __grains__
     __opts__['pillar'] = __pillar__
     __utils__ = salt.loader.utils(__opts__)
-    __salt__ = salt.loader.minion_mods(__opts__, utils=__utils__)
+    __salt__ = salt.loader.minion_mods(__opts__, utils=__utils__, context=__context__)
     __returners__ = salt.loader.returners(__opts__, __salt__)
+
+    # the only things that turn up in here (and that get preserved)
+    # are pulsar.queue, pulsar.notifier and cp.fileclient_###########
+    # log.debug('keys in __context__: {}'.format(list(__context__)))
+
     hubblestack.splunklogging.__grains__ = __grains__
     hubblestack.splunklogging.__salt__ = __salt__
+
     if not initial and __salt__['config.get']('hubblestack:splunklogging', False):
         class MockRecord(object):
             def __init__(self, message, levelname, asctime, name):


### PR DESCRIPTION
This change is needed to preserve `pulsar.queue`, `pulsar.notifier` ... and the `cp.fileclient_########`.

I'm still testing it under `grains_refresh_frequency: 10` in my hubble config; but it seems to do the job.