### PR TITLE
Move cloud_details to a grain and normalize names

### DIFF
--- a/hubblestack/extmods/grains/cloud_details.py
+++ b/hubblestack/extmods/grains/cloud_details.py
@@ -1,5 +1,5 @@
 '''
-HubbleStack Cloud Details
+HubbleStack Cloud Details Grain
 
 :maintainer: HubbleStack
 :platform: All
@@ -12,57 +12,67 @@ import requests
 def get_cloud_details():
     # Gather all cloud details and return them, along with the fieldnames
 
-    ret = []
+    grains = {'cloud_host': False}
 
     aws = _get_aws_details()
     azure = _get_azure_details()
 
-    if aws:
-        ret.append(aws)
-    if azure:
-        ret.append(azure)
+    if aws['cloud_details']:
+        grains['cloud_host'] = True
+        grains.update(aws)
+    if azure['cloud_details']:
+        grains['cloud_host'] = True
+        grains.update(azure)
 
-    return ret
+    return grains
 
 
 def _get_aws_details():
     # Gather amazon information if present
+    ret = {}
     aws = {}
     aws['aws_ami_id'] = None
-    aws['aws_instance_id'] = None
-    aws['aws_account_id'] = None
+    aws['cloud_instance_id'] = None
+    aws['cloud_account_id'] = None
+    aws['cloud_type'] = 'aws'
 
     try:
-        aws['aws_account_id'] = requests.get('http://169.254.169.254/latest/dynamic/instance-identity/document',
-                                             timeout=1).json().get('accountId', 'unknown')
+        aws['cloud_account_id'] = requests.get('http://169.254.169.254/latest/dynamic/instance-identity/document',
+                                               timeout=1).json().get('accountId', 'unknown')
         # AWS account id is always an integer number
         # So if it's an aws machine it must be a valid integer number
         # Else it will throw an Exception
-        aws['aws_account_id'] = int(aws['aws_account_id'])
+        aws['cloud_account_id'] = int(aws['cloud_account_id'])
 
         aws['aws_ami_id'] = requests.get('http://169.254.169.254/latest/meta-data/ami-id',
                                          timeout=1).text
-        aws['aws_instance_id'] = requests.get('http://169.254.169.254/latest/meta-data/instance-id',
-                                              timeout=1).text
+        aws['cloud_instance_id'] = requests.get('http://169.254.169.254/latest/meta-data/instance-id',
+                                                timeout=1).text
     except (requests.exceptions.RequestException, ValueError):
         # Not on an AWS box
         aws = None
-    return aws
+
+    ret['cloud_details'] = aws
+    return ret
 
 
 def _get_azure_details():
     # Gather azure information if present
+    ret = {}
     azure = {}
-    azure['azure_vmId'] = None
-    azure['azure_subscriptionId'] = None
+    azure['cloud_instance_id'] = None
+    azure['cloud_account_id'] = None
+    azure['cloud_type'] = 'azure'
     azureHeader = {'Metadata': 'true'}
     try:
         id = requests.get('http://169.254.169.254/metadata/instance/compute?api-version=2017-08-01',
                           headers=azureHeader, timeout=1).json()
-        azure['azure_vmId'] = id['vmId']
-        azure['azure_subscriptionId'] = id['subscriptionId']
+        azure['cloud_instance_id'] = id['vmId']
+        azure['cloud_account_id'] = id['subscriptionId']
 
     except (requests.exceptions.RequestException, ValueError):
         # Not on an Azure box
         azure = None
-    return azure
+
+    ret['cloud_details'] = azure
+    return ret

--- a/hubblestack/extmods/returners/logstash_nebula_return.py
+++ b/hubblestack/extmods/returners/logstash_nebula_return.py
@@ -31,7 +31,6 @@ import json
 import time
 import requests
 from datetime import datetime
-from hubblestack.cloud_details import get_cloud_details
 from requests.auth import HTTPBasicAuth
 
 
@@ -40,7 +39,8 @@ def returner(ret):
     '''
     opts_list = _get_options()
 
-    clouds = get_cloud_details()
+    # Get cloud details
+    cloud_details = __grains__.get('cloud_details', {})
 
     for opts in opts_list:
         proxy = opts['proxy']
@@ -85,8 +85,7 @@ def returner(ret):
                         event.update({'dest_host': fqdn})
                         event.update({'dest_ip': fqdn_ip4})
 
-                        for cloud in clouds:
-                            event.update(cloud)
+                        event.update(cloud_details)
 
                         for custom_field in custom_fields:
                             custom_field_name = 'custom_' + custom_field

--- a/hubblestack/extmods/returners/logstash_nova_return.py
+++ b/hubblestack/extmods/returners/logstash_nova_return.py
@@ -30,7 +30,6 @@ plugin. Required config/pillar settings:
 import json
 import socket
 import requests
-from hubblestack.cloud_details import get_cloud_details
 from requests.auth import HTTPBasicAuth
 
 
@@ -39,7 +38,8 @@ def returner(ret):
     '''
     opts_list = _get_options()
 
-    clouds = get_cloud_details()
+    # Get cloud details
+    cloud_details = __grains__.get('cloud_details', {})
 
     for opts in opts_list:
         proxy = opts['proxy']
@@ -96,8 +96,7 @@ def returner(ret):
             event.update({'dest_host': fqdn})
             event.update({'dest_ip': fqdn_ip4})
 
-            for cloud in clouds:
-                event.update(cloud)
+            event.update(cloud_details)
 
             for custom_field in custom_fields:
                 custom_field_name = 'custom_' + custom_field
@@ -134,8 +133,7 @@ def returner(ret):
             event.update({'dest_host': fqdn})
             event.update({'dest_ip': fqdn_ip4})
 
-            for cloud in clouds:
-                event.update(cloud)
+            event.update(cloud_details)
 
             for custom_field in custom_fields:
                 custom_field_name = 'custom_' + custom_field
@@ -164,8 +162,7 @@ def returner(ret):
             event.update({'dest_host': fqdn})
             event.update({'dest_ip': fqdn_ip4})
 
-            for cloud in clouds:
-                event.update(cloud)
+            event.update(cloud_details)
 
             for custom_field in custom_fields:
                 custom_field_name = 'custom_' + custom_field

--- a/hubblestack/extmods/returners/logstash_pulsar_return.py
+++ b/hubblestack/extmods/returners/logstash_pulsar_return.py
@@ -31,7 +31,6 @@ import os
 import json
 import requests
 from collections import defaultdict
-from hubblestack.cloud_details import get_cloud_details
 from requests.auth import HTTPBasicAuth
 
 
@@ -51,7 +50,8 @@ def returner(ret):
 
     opts_list = _get_options()
 
-    clouds = get_cloud_details()
+    # Get cloud details
+    cloud_details = __grains__.get('cloud_details', {})
 
     for opts in opts_list:
         proxy = opts['proxy']
@@ -179,8 +179,7 @@ def returner(ret):
             event.update({'dest_host': fqdn})
             event.update({'dest_ip': fqdn_ip4})
 
-            for cloud in clouds:
-                event.update(cloud)
+            event.update(cloud_details)
 
             payload.update({'host': fqdn})
             payload.update({'index': opts['index']})

--- a/hubblestack/extmods/returners/splunk_nebula_return.py
+++ b/hubblestack/extmods/returners/splunk_nebula_return.py
@@ -39,8 +39,6 @@ be skipped:
               - product_group
 '''
 import socket
-# Import cloud details
-from hubblestack.cloud_details import get_cloud_details
 
 # Imports for http event forwarder
 import requests
@@ -60,9 +58,6 @@ log = logging.getLogger(__name__)
 def returner(ret):
     try:
         opts_list = _get_options()
-
-        # Get cloud details
-        clouds = get_cloud_details()
 
         for opts in opts_list:
             logging.info('Options: %s' % json.dumps(opts))
@@ -112,6 +107,9 @@ def returner(ret):
                     new_fqdn = fqdn_ip4
                 fqdn = new_fqdn
 
+            # Get cloud details
+            cloud_details = __grains__.get('cloud_details', {})
+
             if not data:
                 return
             else:
@@ -131,8 +129,7 @@ def returner(ret):
                             event.update({'host_uuid': __grains__['host_uuid']})
                             event.update({'session_uuid': __grains__['session_uuid']})
 
-                            for cloud in clouds:
-                                event.update(cloud)
+                            event.update(cloud_details)
 
                             for custom_field in custom_fields:
                                 custom_field_name = 'custom_' + custom_field

--- a/hubblestack/extmods/returners/splunk_nova_return.py
+++ b/hubblestack/extmods/returners/splunk_nova_return.py
@@ -39,8 +39,6 @@ be skipped:
               - product_group
 '''
 import socket
-# Import cloud details
-from hubblestack.cloud_details import get_cloud_details
 
 # Imports for http event forwarder
 import requests
@@ -59,9 +57,6 @@ log = logging.getLogger(__name__)
 def returner(ret):
     try:
         opts_list = _get_options()
-
-        # Get cloud details
-        clouds = get_cloud_details()
 
         for opts in opts_list:
             log.info('Options: %s' % json.dumps(opts))
@@ -120,6 +115,9 @@ def returner(ret):
                           'dict:\n{0}'.format(data))
                 return
 
+            # Get cloud details
+            cloud_details = __grains__.get('cloud_details', {})
+
             for fai in data.get('Failure', []):
                 check_id = fai.keys()[0]
                 payload = {}
@@ -141,8 +139,7 @@ def returner(ret):
                 event.update({'host_uuid': __grains__['host_uuid']})
                 event.update({'session_uuid': __grains__['session_uuid']})
 
-                for cloud in clouds:
-                    event.update(cloud)
+                event.update(cloud_details)
 
                 for custom_field in custom_fields:
                     custom_field_name = 'custom_' + custom_field
@@ -189,8 +186,7 @@ def returner(ret):
                 event.update({'host_uuid': __grains__['host_uuid']})
                 event.update({'session_uuid': __grains__['session_uuid']})
 
-                for cloud in clouds:
-                    event.update(cloud)
+                event.update(cloud_details)
 
                 for custom_field in custom_fields:
                     custom_field_name = 'custom_' + custom_field
@@ -235,8 +231,7 @@ def returner(ret):
                 event.update({'host_uuid': __grains__['host_uuid']})
                 event.update({'session_uuid': __grains__['session_uuid']})
 
-                for cloud in clouds:
-                    event.update(cloud)
+                event.update(cloud_details)
 
                 for custom_field in custom_fields:
                     custom_field_name = 'custom_' + custom_field

--- a/hubblestack/extmods/returners/splunk_pulsar_return.py
+++ b/hubblestack/extmods/returners/splunk_pulsar_return.py
@@ -39,8 +39,6 @@ be skipped:
               - product_group
 '''
 import socket
-# Import cloud details
-from hubblestack.cloud_details import get_cloud_details
 
 # Imports for http event forwarder
 import requests
@@ -65,8 +63,6 @@ def returner(ret):
             return
 
         opts_list = _get_options()
-        # Get cloud details
-        clouds = get_cloud_details()
 
         for opts in opts_list:
             logging.info('Options: %s' % json.dumps(opts))
@@ -118,6 +114,9 @@ def returner(ret):
                 if '.' not in new_fqdn:
                     new_fqdn = fqdn_ip4
                 fqdn = new_fqdn
+
+            # Get cloud details
+            cloud_details = __grains__.get('cloud_details', {})
 
             alerts = []
             for item in data:
@@ -227,8 +226,7 @@ def returner(ret):
                 event.update({'host_uuid': __grains__['host_uuid']})
                 event.update({'session_uuid': __grains__['session_uuid']})
 
-                for cloud in clouds:
-                    event.update(cloud)
+                event.update(cloud_details)
 
                 for custom_field in custom_fields:
                     custom_field_name = 'custom_' + custom_field

--- a/hubblestack/splunklogging.py
+++ b/hubblestack/splunklogging.py
@@ -35,8 +35,6 @@ be skipped:
               - product_group
 '''
 import socket
-# Import cloud details
-from hubblestack.cloud_details import get_cloud_details
 
 # Imports for http event forwarder
 import requests
@@ -62,8 +60,10 @@ class SplunkHandler(logging.Handler):
         super(SplunkHandler, self).__init__()
 
         self.opts_list = _get_options()
-        self.clouds = get_cloud_details()
         self.endpoint_list = []
+
+        # Get cloud details
+        cloud_details = __grains__.get('cloud_details', {})
 
         for opts in self.opts_list:
             http_event_collector_key = opts['token']
@@ -106,8 +106,7 @@ class SplunkHandler(logging.Handler):
             event.update({'dest_host': fqdn})
             event.update({'dest_ip': fqdn_ip4})
 
-            for cloud in self.clouds:
-                event.update(cloud)
+            event.update(cloud_details)
 
             for custom_field in custom_fields:
                 custom_field_name = 'custom_' + custom_field


### PR DESCRIPTION
NOTE: This will change the values that go into Splunk. Instead of cloud specific data, we'll get normalized (where possible) data. 

    aws_instance_id --> cloud_instance_id
    aws_account_id --> cloud_account_id
    azure_vmId --> cloud_instance_id
    azure_subscription_id --> cloud_account_id

etc.