### PR TITLE
Fixing exception on Debain 7

### DIFF
--- a/hubblestack/extmods/modules/pulsar.py
+++ b/hubblestack/extmods/modules/pulsar.py
@@ -271,7 +271,10 @@ def process(configfile='salt://hubblestack_pulsar/hubblestack_pulsar_config.yaml
                     sub['checksum'] = __salt__['file.get_hash'](pathname, sum_type)
                     sub['checksum_type'] = sum_type
                 if config.get('stats', False):
-                    sub['stats'] = __salt__['file.stats'](pathname)
+                    if os.path.exists(pathname):
+                        sub['stats'] = __salt__['file.stats'](pathname)
+                    else:
+                        sub['stats'] = {}
 
                 ret.append(sub)
             else:


### PR DESCRIPTION
On Debain 7:

root@eqx-temp7:/var/log# cat hubble
2018-03-06 22:02:14 [hubblestack.daemon][INFO ] Setting up the fileclient/fileserver
2018-03-06 22:02:24 [hubblestack.daemon][INFO ] Starting main loop
2018-03-06 22:02:30 [hubblestack.daemon][ERROR ] Error executing schedule
Traceback (most recent call last):
File "hubblestack/daemon.py", line 95, in main
File "hubblestack/daemon.py", line 210, in schedule
File "/opt/hubble/hubble-libs/hubblestack/extmods/modules/pulsar.py", line 274, in process
sub['stats'] = salt'file.stats'
File "/opt/hubble/hubble-libs/salt/modules/file.py", line 3375, in stats
raise CommandExecutionError('Path not found: {0}'.format(path))
CommandExecutionError: Path not found: /etc/hubble/fim_canary.tmp