### PR TITLE
output file for single run function results

### DIFF
--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -312,6 +312,14 @@ def run_function():
     else:
         print(ret)
 
+    if(__opts__['outfile']):
+        log.info('Writing output to file {0}'.format(__opts__['outfile']))
+        try:
+            outputfile = open(__opts__['outfile'], "w")
+            outputfile.write(json.dumps(ret))
+        except IOError:
+            log.error("Could not write output to file. Check if file path is valid.")
+
 
 def load_config():
     '''
@@ -500,6 +508,9 @@ def parse_args():
     parser.add_argument('args',
                         nargs='*',
                         help='Any arguments necessary for a single function run')
+    parser.add_argument('-o', '--outfile',
+                        default=None,
+                        help='Optional file path to get the ouput of single-function run')
     return vars(parser.parse_args())
 
 def check_pidfile(kill_other=False):

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -317,8 +317,9 @@ def run_function():
         try:
             outputfile = open(__opts__['outfile'], "w")
             outputfile.write(json.dumps(ret))
+            outputfile.close()
         except IOError:
-            log.error("Could not write output to file. Check if file path is valid.")
+            log.error("Error occurred writing output to file (One possible reason: Invalid path).")                   
 
 
 def load_config():

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -14,6 +14,7 @@ import random
 import signal
 import sys
 import uuid
+import json
 
 import salt.fileclient
 import salt.utils

--- a/pkg/scripts/pyinstaller-requirements.txt
+++ b/pkg/scripts/pyinstaller-requirements.txt
@@ -14,7 +14,3 @@ gitpython
 pyinotify
 cffi
 azure
-pympler
-guppy
-memory_profiler
-objgraph


### PR DESCRIPTION
When running single run functions, user can give an optional output file path where the results will be written (in json form).

New option -o <file-path> has been added for this purpose.
Example command: hubble hubble.audit -o C:\Users\HubbleTest\auditout.txt

In the above command, the results of hubble.audit will be writted to the mentioned file.