### PR TITLE
print output of single run functions in json format

### DIFF
--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -14,6 +14,7 @@ import random
 import signal
 import sys
 import uuid
+import json
 
 import salt.fileclient
 import salt.utils
@@ -310,7 +311,7 @@ def run_function():
     if(__opts__['no_pprint']):
         pprint.pprint(ret)
     else:
-        print(ret)
+        print(json.dumps(ret))
 
 
 def load_config():


### PR DESCRIPTION
This change is for printing the result of single run function in json format when the function is run with -p arguement, eg:

hubble hubble.audit -vv -p

(By default 'no_pprint' flag is True, hence pprint (pretty print) is used. -p parameter sets no_pprint flag to false and hence print method of python is used.)