### PR TITLE
Adding azure dependencies in hook file

### DIFF
--- a/pkg/hook-hubblestack.py
+++ b/pkg/hook-hubblestack.py
@@ -30,6 +30,8 @@ HIDDEN_IMPORTS = [
     'traceback',
     'pygit2',
     'Queue',
+    'azure.storage.common',
+    'azure.storage.blob',
 ]
 DATAS = []
 binaries = []


### PR DESCRIPTION
Hubble is not able to load azurefs modules because of the changes in its dependencies. This should fix it.