### PR TITLE
Clear cache of azurefs containers which are not accessible anymore

### DIFF
--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -375,6 +375,7 @@ def load_config():
     salt.config.DEFAULT_MINION_OPTS['default_include'] = 'hubble.d/*.conf'
     salt.config.DEFAULT_MINION_OPTS['logfile_maxbytes'] = 100000000 # 100MB
     salt.config.DEFAULT_MINION_OPTS['logfile_backups'] = 1 # maximum rotated logs
+    salt.config.DEFAULT_MINION_OPTS['delete_on_unavailable'] = False
 
     global __opts__
 

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -375,7 +375,7 @@ def load_config():
     salt.config.DEFAULT_MINION_OPTS['default_include'] = 'hubble.d/*.conf'
     salt.config.DEFAULT_MINION_OPTS['logfile_maxbytes'] = 100000000 # 100MB
     salt.config.DEFAULT_MINION_OPTS['logfile_backups'] = 1 # maximum rotated logs
-    salt.config.DEFAULT_MINION_OPTS['delete_on_unavailable'] = False
+    salt.config.DEFAULT_MINION_OPTS['delete_inaccessible_azure_containers'] = False
 
     global __opts__
 

--- a/hubblestack/extmods/fileserver/azurefs.py
+++ b/hubblestack/extmods/fileserver/azurefs.py
@@ -63,7 +63,6 @@ import salt.utils
 try:
     import azure.storage.common
     import azure.storage.blob
-    from azure.storage.common import AzureHttpError
     HAS_AZURE = True
 except ImportError:
     HAS_AZURE = False
@@ -202,24 +201,21 @@ def update():
         except Exception as exc:
             log.exception('Error occurred fetching blob list for azurefs')
 
-            if not __opts__['delete_on_unavailable'] or not "<class 'azure.common.AzureHttpError'>" in type(exc) :
+            if not __opts__['delete_inaccessible_azure_containers'] or not "<class 'azure.common.AzureHttpError'>" in str(type(exc)) :
                 continue
-            if '<AuthenticationErrorDetail>Signature did not match.' in exc.message:
+            if '<AuthenticationErrorDetail>Signature did not match.' in str(exc):
                 log.debug('Could not connect to azure container "{0}"'.format(name))
-                if container == __opts__['azurefs'][-1]: 
-                    log.debug('Its the last container in azurefs. So, not deleting its cache.')
-                else:
-                    container_cache_folder = _get_container_path(container) 
-                    print 'Trying to delete the cache of container "{0}"'.format(name)
-                    try:
-                        container_cachedir = os.path.join(__opts__['cachedir'], 'azurefs',container_cache_folder)
-                        container_filelist = container_cachedir + '.list'
-                        if os.path.exists(container_cachedir):
-                            shutil.rmtree(container_cachedir)
-                        if os.path.exists(container_filelist):
-                            os.remove(container_filelist)
-                    except Exception:
-                        log.exception('Problem occurred trying to invalidate cache for container "{0}"'.format(name))
+                container_cache_folder = _get_container_path(container) 
+                log.debug('Trying to delete the cache of container "{0}"'.format(name))
+                try:
+                    container_cachedir = os.path.join(__opts__['cachedir'], 'azurefs',container_cache_folder)
+                    container_filelist = container_cachedir + '.list'
+                    if os.path.exists(container_cachedir):
+                        shutil.rmtree(container_cachedir)
+                    if os.path.exists(container_filelist):
+                        os.remove(container_filelist)
+                except Exception:
+                    log.exception('Problem occurred trying to invalidate cache for container "{0}"'.format(name))
             continue
 
         # Walk the cache directory searching for deletions
@@ -284,6 +280,7 @@ def update():
         except Exception:
             pass
         try:
+            #Do not move this statement above 'delete_inaccessible_azure_containers' logic.
             hash_cachedir = os.path.join(__opts__['cachedir'], 'azurefs', 'hashes')
             if os.path.exists(hash_cachedir):
                 shutil.rmtree(hash_cachedir)


### PR DESCRIPTION
If an azurefs container is not accessible for hubble host, it's cache folder is deleted so that the stale files are not served from that container anymore.

NOTE: In case all the containers are inaccessible, cache folder will deleted for all containers. But in this case, the code will not reach the part where 'hashes' directory is deleted. As a result, hubble will keep serving the file from the last azurefs state if all the containers are inaccessible.