### PR TITLE
osquery timing + custom splunk loglevel + ssl verify for splunk + small fixes

### DIFF
--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -293,7 +293,7 @@ def schedule():
                     continue
                 log.debug('Returning job data to {0}'.format(returner))
                 returner_ret = {'id': __grains__['id'],
-                                'jid': salt.utils.jid.gen_jid(),
+                                'jid': salt.utils.jid.gen_jid(__opts__),
                                 'fun': func,
                                 'fun_args': args + ([kwargs] if kwargs else []),
                                 'return': ret}
@@ -331,7 +331,7 @@ def run_function():
         else:
             log.info('Returning job data to {0}'.format(returner))
             returner_ret = {'id': __grains__['id'],
-                            'jid': salt.utils.jid.gen_jid(),
+                            'jid': salt.utils.jid.gen_jid(__opts__),
                             'fun': __opts__['function'],
                             'fun_args': args + ([kwargs] if kwargs else []),
                             'return': ret}

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -461,7 +461,8 @@ def load_config():
                                         __opts__['log_level'],
                                         max_bytes=__opts__.get('logfile_maxbytes', 100000000),
                                         backup_count=__opts__.get('logfile_backups', 1))
-    logging.SPLUNK = 25 # logs below warning, above info
+    # splunk logs below warning, above info by default
+    logging.SPLUNK = int(__opts__.get('splunk_log_level', 25))
     logging.addLevelName(logging.SPLUNK, 'SPLUNK')
     def splunk(self, message, *args, **kwargs):
         if self.isEnabledFor(logging.SPLUNK):

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -467,6 +467,12 @@ def load_config():
         if self.isEnabledFor(logging.SPLUNK):
             self._log(logging.SPLUNK, message, args, **kwargs)
     logging.Logger.splunk = splunk
+    if __salt__['config.get']('hubblestack:splunklogging', False):
+        root_logger = logging.getLogger()
+        handler = hubblestack.splunklogging.SplunkHandler()
+        handler.setLevel(logging.SPLUNK)
+        root_logger.addHandler(handler)
+
     # 384 is 0o600 permissions, written without octal for python 2/3 compat
     os.chmod(__opts__['log_file'], 384)
     os.chmod(parsed_args.get('configfile'), 384)
@@ -477,12 +483,6 @@ def load_config():
     if __grains__.get('ip_gw', None) is False and 'fallback_fileserver_backend' in __opts__:
         log.info('No default gateway detected; using fallback_fileserver_backend.')
         __opts__['fileserver_backend'] = __opts__['fallback_fileserver_backend']
-
-    if __salt__['config.get']('hubblestack:splunklogging', False):
-        root_logger = logging.getLogger()
-        handler = hubblestack.splunklogging.SplunkHandler()
-        handler.setLevel(logging.SPLUNK)
-        root_logger.addHandler(handler)
 
 
 def refresh_grains(initial=False):

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -457,6 +457,12 @@ def load_config():
                                         __opts__['log_level'],
                                         max_bytes=__opts__.get('logfile_maxbytes', 100000000),
                                         backup_count=__opts__.get('logfile_backups', 1))
+    logging.SPLUNK = 25 # logs below warning, above info
+    logging.addLevelName(logging.SPLUNK, 'SPLUNK')
+    def splunk(self, message, *args, **kwargs):
+        if self.isEnabledFor(logging.SPLUNK):
+            self._log(logging.SPLUNK, message, args, **kwargs)
+    logging.Logger.splunk = splunk
     # 384 is 0o600 permissions, written without octal for python 2/3 compat
     os.chmod(__opts__['log_file'], 384)
     os.chmod(parsed_args.get('configfile'), 384)
@@ -471,7 +477,7 @@ def load_config():
     if __salt__['config.get']('hubblestack:splunklogging', False):
         root_logger = logging.getLogger()
         handler = hubblestack.splunklogging.SplunkHandler()
-        handler.setLevel(logging.ERROR)
+        handler.setLevel(logging.SPLUNK)
         root_logger.addHandler(handler)
 
 

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -385,6 +385,9 @@ def load_config():
     __opts__.update(parsed_args)
     __opts__['conf_file'] = parsed_args.get('configfile')
 
+    # Optional sleep to wait for network
+    time.sleep(int(__opts__.get('startup_sleep', 0)))
+
     # Convert -vvv to log level
     if __opts__['log_level'] is None:
         # Default to 'error'

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -20,6 +20,7 @@ import salt.fileclient
 import salt.fileserver
 import salt.fileserver.gitfs
 import salt.utils
+import salt.utils.platform
 import salt.utils.jid
 import salt.utils.gitfs
 import salt.log.setup
@@ -355,7 +356,7 @@ def load_config():
     parsed_args = parse_args()
 
     # Load unique data for Windows or Linux
-    if salt.utils.is_windows():
+    if salt.utils.platform.is_windows():
         if parsed_args.get('configfile') is None:
             parsed_args['configfile'] = 'C:\\Program Files (x86)\\Hubble\\etc\\hubble\\hubble.conf'
         salt.config.DEFAULT_MINION_OPTS['cachedir'] = 'C:\\Program Files (x86)\\hubble\\var\\cache'

--- a/hubblestack/extmods/grains/default_gw.py
+++ b/hubblestack/extmods/grains/default_gw.py
@@ -20,6 +20,7 @@ from __future__ import absolute_import
 import logging
 
 import salt.utils
+import salt.utils.path
 
 import salt.modules.cmdmod
 
@@ -46,7 +47,7 @@ def default_gateway():
         ip_gw: True   # True if either of the above is True, False otherwise
     '''
     grains = {}
-    if not salt.utils.which('ip'):
+    if not salt.utils.path.which('ip'):
         return {}
     grains['ip_gw'] = False
     grains['ip4_gw'] = False

--- a/hubblestack/extmods/grains/fqdn.py
+++ b/hubblestack/extmods/grains/fqdn.py
@@ -4,6 +4,7 @@ Custom grains around fqdn
 '''
 import salt.modules.cmdmod
 import salt.utils
+import salt.utils.platform
 import socket
 
 __salt__ = {'cmd.run': salt.modules.cmdmod._run_quiet}
@@ -16,7 +17,7 @@ def fqdn():
     '''
     grains = {}
     local_fqdn = None
-    if not salt.utils.is_windows():
+    if not salt.utils.platform.is_windows():
         local_fqdn = __salt__['cmd.run']('hostname --fqdn')
     grains['local_fqdn'] = local_fqdn if local_fqdn else socket.getfqdn()
     return grains

--- a/hubblestack/extmods/grains/hostuuid.py
+++ b/hubblestack/extmods/grains/hostuuid.py
@@ -42,8 +42,8 @@ def host_uuid():
             # TODO: once we figure out how to get a custom log level for
             # non-error splunk logs, we should move this to that log level so
             # it doesn't look like an error.
-            log.error('generating fresh uuid, no cache file found. '
-                      '(probably not a problem)')
+            log.splunk('generating fresh uuid, no cache file found. '
+                       '(probably not a problem)')
     except Exception:
         log.exception('Problem retrieving cached host uuid from file: {0}'
                       .format(cached_uuid_path))

--- a/hubblestack/extmods/grains/osqueryinfo.py
+++ b/hubblestack/extmods/grains/osqueryinfo.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import salt.utils
+import salt.utils.path
 import salt.modules.cmdmod
 
 __salt__ = {'cmd.run': salt.modules.cmdmod._run_quiet}
@@ -19,11 +20,11 @@ def osquerygrain():
     # Prefer our /opt/osquery/osqueryi if present
     osqueryipaths = ('/opt/osquery/osqueryi', 'osqueryi', '/usr/bin/osqueryi')
     for path in osqueryipaths:
-        if salt.utils.which(path):
+        if salt.utils.path.which(path):
             for item in __salt__['cmd.run']('{0} {1}'.format(path, option)).split():
                 if item[:1].isdigit():
                     grains['osqueryversion'] = item
-                    grains['osquerybinpath'] = salt.utils.which(path)
+                    grains['osquerybinpath'] = salt.utils.path.which(path)
                     break
             break
     return grains

--- a/hubblestack/extmods/modules/nebula_osquery.py
+++ b/hubblestack/extmods/modules/nebula_osquery.py
@@ -37,6 +37,7 @@ import yaml
 import collections
 
 import salt.utils
+import salt.utils.platform
 from salt.exceptions import CommandExecutionError
 from hubblestack import __version__
 
@@ -78,7 +79,7 @@ def queries(query_group,
     query_data = {}
     MAX_FILE_SIZE = 104857600
     if query_file is None:
-        if salt.utils.is_windows():
+        if salt.utils.platform.is_windows():
             query_file = 'salt://hubblestack_nebula/hubblestack_nebula_win_queries.yaml'
         else:
             query_file = 'salt://hubblestack_nebula/hubblestack_nebula_queries.yaml'
@@ -139,7 +140,7 @@ def queries(query_group,
             log.debug('osquery not installed on this host. Skipping.')
             return None
 
-    if salt.utils.is_windows():
+    if salt.utils.platform.is_windows():
         win_version = __grains__['osfullname']
         if '2008' not in win_version and '2012' not in win_version and '2016' not in win_version:
             log.error('osquery does not run on windows versions earlier than Server 2008 and Windows 7')
@@ -258,7 +259,7 @@ def top(query_group,
         verbose=False,
         report_version_with_day=True):
 
-    if salt.utils.is_windows():
+    if salt.utils.platform.is_windows():
         topfile = 'salt://hubblestack_nebula/win_top.nebula'
 
     configs = get_top_data(topfile)

--- a/hubblestack/extmods/modules/nebula_osquery.py
+++ b/hubblestack/extmods/modules/nebula_osquery.py
@@ -32,6 +32,7 @@ import copy
 import json
 import logging
 import os
+import time
 import yaml
 import collections
 
@@ -179,7 +180,10 @@ def queries(query_group,
         }
 
         cmd = [__grains__['osquerybinpath'], '--read_max', MAX_FILE_SIZE, '--json', query_sql]
+        t0 = time.time()
         res = __salt__['cmd.run_all'](cmd)
+        t1 = time.time()
+        log.splunk('osquery query \'{0}\' took {1}'.format(query_sql, t1-t0))
         if res['retcode'] == 0:
             query_ret['data'] = json.loads(res['stdout'])
         else:

--- a/hubblestack/extmods/modules/nova_loader.py
+++ b/hubblestack/extmods/modules/nova_loader.py
@@ -27,6 +27,7 @@ from salt.template import check_render_pipe_str
 from salt.utils.decorators import Depends
 from salt.utils import is_proxy
 import salt.utils.context
+import salt.utils.platform
 import salt.utils.lazy
 import salt.utils.event
 import salt.utils.odict
@@ -873,7 +874,7 @@ def grains(opts, force_refresh=False, proxy=None):
     if opts.get('grains_cache', False):
         cumask = os.umask(0o77)
         try:
-            if salt.utils.is_windows():
+            if salt.utils.platform.is_windows():
                 # Make sure cache file isn't read-only
                 __salt__['cmd.run']('attrib -R "{0}"'.format(cfn))
             with salt.utils.fopen(cfn, 'w+b') as fp_:

--- a/hubblestack/extmods/modules/pulsar.py
+++ b/hubblestack/extmods/modules/pulsar.py
@@ -23,6 +23,7 @@ from salt.exceptions import CommandExecutionError
 # Import salt libs
 import salt.ext.six
 import salt.loader
+import salt.utils.platform
 
 # Import third party libs
 try:
@@ -47,7 +48,7 @@ log = logging.getLogger(__name__)
 
 
 def __virtual__():
-    if salt.utils.is_windows():
+    if salt.utils.platform.is_windows():
         return False, 'This module only works on Linux'
     return True
 

--- a/hubblestack/extmods/modules/win_pulsar.py
+++ b/hubblestack/extmods/modules/win_pulsar.py
@@ -17,6 +17,7 @@ import yaml
 
 import salt.ext.six
 import salt.loader
+import salt.utils.platform
 
 log = logging.getLogger(__name__)
 DEFAULT_MASK = ['File create', 'File delete', 'Hard link change', 'Data extend', 
@@ -28,7 +29,7 @@ CONFIG_STALENESS = 0
 
 
 def __virtual__():
-    if not salt.utils.is_windows():
+    if not salt.utils.platform.is_windows():
         return False, 'This module only works on windows'
     win_version = __grains__['osfullname']
     if '2012' not in win_version and '2016' not in win_version:

--- a/hubblestack/extmods/modules/win_pulsar_winaudit.py
+++ b/hubblestack/extmods/modules/win_pulsar_winaudit.py
@@ -18,6 +18,7 @@ import re
 
 import salt.ext.six
 import salt.loader
+import salt.utils.platform
 
 log = logging.getLogger(__name__)
 DEFAULT_MASK = ['ExecuteFile', 'Write', 'Delete', 'DeleteSubdirectoriesAndFiles', 'ChangePermissions',
@@ -32,7 +33,7 @@ __version__ = 'v2017.8.3'
 
 
 def __virtual__():
-    if not salt.utils.is_windows():
+    if not salt.utils.platform.is_windows():
         return False, 'This module only works on windows'
     return __virtualname__
 

--- a/hubblestack/extmods/returners/splunk_nebula_return.py
+++ b/hubblestack/extmods/returners/splunk_nebula_return.py
@@ -53,7 +53,7 @@ from datetime import datetime
 import logging
 
 _max_content_bytes = 100000
-http_event_collector_SSL_verify = False
+http_event_collector_SSL_verify = True
 http_event_collector_debug = False
 
 log = logging.getLogger(__name__)

--- a/hubblestack/extmods/returners/splunk_nebula_return.py
+++ b/hubblestack/extmods/returners/splunk_nebula_return.py
@@ -95,7 +95,10 @@ def returner(ret):
             try:
                 fqdn_ip4 = __grains__['fqdn_ip4'][0]
             except IndexError:
-                fqdn_ip4 = __grains__['ipv4'][0]
+                try:
+                    fqdn_ip4 = __grains__['ipv4'][0]
+                except IndexError:
+                    raise Exception('No ipv4 grains found. Is net-tools installed?')
             if fqdn_ip4.startswith('127.'):
                 for ip4_addr in __grains__['ipv4']:
                     if ip4_addr and not ip4_addr.startswith('127.'):

--- a/hubblestack/extmods/returners/splunk_nova_return.py
+++ b/hubblestack/extmods/returners/splunk_nova_return.py
@@ -93,7 +93,10 @@ def returner(ret):
             try:
                 fqdn_ip4 = __grains__['fqdn_ip4'][0]
             except IndexError:
-                fqdn_ip4 = __grains__['ipv4'][0]
+                try:
+                    fqdn_ip4 = __grains__['ipv4'][0]
+                except IndexError:
+                    raise Exception('No ipv4 grains found. Is net-tools installed?')
             if fqdn_ip4.startswith('127.'):
                 for ip4_addr in __grains__['ipv4']:
                     if ip4_addr and not ip4_addr.startswith('127.'):

--- a/hubblestack/extmods/returners/splunk_nova_return.py
+++ b/hubblestack/extmods/returners/splunk_nova_return.py
@@ -52,7 +52,7 @@ import time
 import logging
 
 _max_content_bytes = 100000
-http_event_collector_SSL_verify = False
+http_event_collector_SSL_verify = True
 http_event_collector_debug = False
 
 log = logging.getLogger(__name__)

--- a/hubblestack/extmods/returners/splunk_pulsar_return.py
+++ b/hubblestack/extmods/returners/splunk_pulsar_return.py
@@ -103,7 +103,10 @@ def returner(ret):
             try:
                 fqdn_ip4 = __grains__['fqdn_ip4'][0]
             except IndexError:
-                fqdn_ip4 = __grains__['ipv4'][0]
+                try:
+                    fqdn_ip4 = __grains__['ipv4'][0]
+                except IndexError:
+                    raise Exception('No ipv4 grains found. Is net-tools installed?')
             if fqdn_ip4.startswith('127.'):
                 for ip4_addr in __grains__['ipv4']:
                     if ip4_addr and not ip4_addr.startswith('127.'):

--- a/hubblestack/extmods/returners/splunk_pulsar_return.py
+++ b/hubblestack/extmods/returners/splunk_pulsar_return.py
@@ -54,7 +54,7 @@ from collections import defaultdict
 import logging
 
 _max_content_bytes = 100000
-http_event_collector_SSL_verify = False
+http_event_collector_SSL_verify = True
 http_event_collector_debug = False
 
 log = logging.getLogger(__name__)

--- a/hubblestack/files/hubblestack_nova/cve_scan.py
+++ b/hubblestack/files/hubblestack_nova/cve_scan.py
@@ -10,13 +10,14 @@ HubbleStack Nova plugin for openscap scanning.
 '''
 from __future__ import absolute_import
 import salt.utils
+import salt.utils.path
 import logging
 
 log = logging.getLogger(__name__)
 
 
 def __virtual__():
-    if salt.utils.is_linux() and salt.utils.which('oscap'):
+    if salt.utils.is_linux() and salt.utils.path.which('oscap'):
         return True
     return False, 'This module requires Linux and the oscap binary'
 

--- a/hubblestack/files/hubblestack_nova/cve_scan_v2.py
+++ b/hubblestack/files/hubblestack_nova/cve_scan_v2.py
@@ -98,12 +98,13 @@ from zipfile import ZipFile
 
 import salt
 import salt.utils
+import salt.utils.platform
 
 log = logging.getLogger(__name__)
 
 
 def __virtual__():
-    return not salt.utils.is_windows()
+    return not salt.utils.platform.is_windows()
 
 
 def audit(data_list, tags, debug=False, **kwargs):

--- a/hubblestack/files/hubblestack_nova/firewall.py
+++ b/hubblestack/files/hubblestack_nova/firewall.py
@@ -84,6 +84,7 @@ import logging
 import fnmatch
 import copy
 import salt.utils
+import salt.utils.platform
 import salt.utils.path
 
 log = logging.getLogger(__name__)
@@ -93,7 +94,7 @@ __data__ = None
 
 
 def __virtual__():
-    if salt.utils.is_windows():
+    if salt.utils.platform.is_windows():
         return False, 'This audit module only runs on linux'
     if not salt.utils.path.which('iptables'):
         return (False, 'The iptables execution module cannot be loaded: iptables not installed.')

--- a/hubblestack/files/hubblestack_nova/firewall.py
+++ b/hubblestack/files/hubblestack_nova/firewall.py
@@ -84,6 +84,7 @@ import logging
 import fnmatch
 import copy
 import salt.utils
+import salt.utils.path
 
 log = logging.getLogger(__name__)
 
@@ -94,7 +95,7 @@ __data__ = None
 def __virtual__():
     if salt.utils.is_windows():
         return False, 'This audit module only runs on linux'
-    if not salt.utils.which('iptables'):
+    if not salt.utils.path.which('iptables'):
         return (False, 'The iptables execution module cannot be loaded: iptables not installed.')
     return True
 

--- a/hubblestack/files/hubblestack_nova/grep.py
+++ b/hubblestack/files/hubblestack_nova/grep.py
@@ -60,6 +60,7 @@ import fnmatch
 import os
 import copy
 import salt.utils
+import salt.utils.platform
 import re
 
 from distutils.version import LooseVersion
@@ -68,7 +69,7 @@ log = logging.getLogger(__name__)
 
 
 def __virtual__():
-    if salt.utils.is_windows():
+    if salt.utils.platform.is_windows():
         return False, 'This audit module only runs on linux'
     return True
 

--- a/hubblestack/files/hubblestack_nova/mount.py
+++ b/hubblestack/files/hubblestack_nova/mount.py
@@ -37,6 +37,7 @@ import fnmatch
 import os
 import copy
 import salt.utils
+import salt.utils.platform
 
 from distutils.version import LooseVersion
 
@@ -44,7 +45,7 @@ log = logging.getLogger(__name__)
 
 
 def __virtual__():
-    if salt.utils.is_windows():
+    if salt.utils.platform.is_windows():
         return False, 'This audit module only runs on linux'
     return True
 

--- a/hubblestack/files/hubblestack_nova/openssl.py
+++ b/hubblestack/files/hubblestack_nova/openssl.py
@@ -73,6 +73,7 @@ import logging
 import fnmatch
 import copy
 import salt.utils
+import salt.utils.platform
 import datetime
 import time
 
@@ -92,7 +93,7 @@ __data__ = None
 
 
 def __virtual__():
-    if salt.utils.is_windows():
+    if salt.utils.platform.is_windows():
         return False, 'This audit module only runs on linux'
     if not _HAS_OPENSSL:
         return (False, 'The python-OpenSSL library is missing')

--- a/hubblestack/files/hubblestack_nova/pkg.py
+++ b/hubblestack/files/hubblestack_nova/pkg.py
@@ -65,6 +65,7 @@ import logging
 import fnmatch
 import copy
 import salt.utils
+import salt.utils.platform
 
 from distutils.version import LooseVersion
 
@@ -72,7 +73,7 @@ log = logging.getLogger(__name__)
 
 
 def __virtual__():
-    if salt.utils.is_windows():
+    if salt.utils.platform.is_windows():
         return False, 'This audit module only runs on linux'
     return True
 

--- a/hubblestack/files/hubblestack_nova/service.py
+++ b/hubblestack/files/hubblestack_nova/service.py
@@ -57,6 +57,7 @@ import logging
 
 import fnmatch
 import salt.utils
+import salt.utils.platform
 
 from distutils.version import LooseVersion
 
@@ -64,7 +65,7 @@ log = logging.getLogger(__name__)
 
 
 def __virtual__():
-    if salt.utils.is_windows():
+    if salt.utils.platform.is_windows():
         return False, 'This audit module only runs on linux'
     return True
 

--- a/hubblestack/files/hubblestack_nova/stat_nova.py
+++ b/hubblestack/files/hubblestack_nova/stat_nova.py
@@ -45,6 +45,7 @@ import logging
 import fnmatch
 import copy
 import salt.utils
+import salt.utils.platform
 
 from distutils.version import LooseVersion
 
@@ -54,7 +55,7 @@ __virtualname__ = 'stat'
 
 
 def __virtual__():
-    if salt.utils.is_windows():
+    if salt.utils.platform.is_windows():
         return False, 'This audit module only runs on linux'
     return True
 

--- a/hubblestack/files/hubblestack_nova/sysctl.py
+++ b/hubblestack/files/hubblestack_nova/sysctl.py
@@ -35,6 +35,7 @@ import logging
 import fnmatch
 import copy
 import salt.utils
+import salt.utils.platform
 
 from distutils.version import LooseVersion
 
@@ -42,7 +43,7 @@ log = logging.getLogger(__name__)
 
 
 def __virtual__():
-    if salt.utils.is_windows():
+    if salt.utils.platform.is_windows():
         return False, 'This audit module only runs on linux'
     return True
 

--- a/hubblestack/files/hubblestack_nova/systemctl.py
+++ b/hubblestack/files/hubblestack_nova/systemctl.py
@@ -36,6 +36,7 @@ import logging
 import fnmatch
 import copy
 import salt.utils
+import salt.utils.platform
 
 from distutils.version import LooseVersion
 
@@ -43,7 +44,7 @@ log = logging.getLogger(__name__)
 
 
 def __virtual__():
-    if salt.utils.is_windows():
+    if salt.utils.platform.is_windows():
         return False, 'This audit module only runs on linux'
     return True
 

--- a/hubblestack/files/hubblestack_nova/win_auditpol.py
+++ b/hubblestack/files/hubblestack_nova/win_auditpol.py
@@ -14,6 +14,7 @@ import csv
 import fnmatch
 import logging
 import salt.utils
+import salt.utils.platform
 
 
 log = logging.getLogger(__name__)
@@ -21,7 +22,7 @@ __virtualname__ = 'win_auditpol'
 
 
 def __virtual__():
-    if not salt.utils.is_windows():
+    if not salt.utils.platform.is_windows():
         return False, 'This audit module only runs on windows'
     return True
 

--- a/hubblestack/files/hubblestack_nova/win_firewall.py
+++ b/hubblestack/files/hubblestack_nova/win_firewall.py
@@ -14,6 +14,7 @@ import copy
 import fnmatch
 import logging
 import salt.utils
+import salt.utils.platform
 
 
 log = logging.getLogger(__name__)
@@ -21,7 +22,7 @@ __virtualname__ = 'win_firewall'
 
 
 def __virtual__():
-    if not salt.utils.is_windows():
+    if not salt.utils.platform.is_windows():
         return False, 'This audit module only runs on windows'
     if '2008' in __grains__['osfullname']:
         return False, 'The Powershell firewall module only works on 2012 or higher'

--- a/hubblestack/files/hubblestack_nova/win_gp.py
+++ b/hubblestack/files/hubblestack_nova/win_gp.py
@@ -13,6 +13,7 @@ import copy
 import fnmatch
 import logging
 import salt.utils
+import salt.utils.platform
 
 
 log = logging.getLogger(__name__)
@@ -20,7 +21,7 @@ __virtualname__ = 'win_gp'
 
 
 def __virtual__():
-    if not salt.utils.is_windows():
+    if not salt.utils.platform.is_windows():
         return False, 'This audit module only runs on windows'
     return True
 

--- a/hubblestack/files/hubblestack_nova/win_pkg.py
+++ b/hubblestack/files/hubblestack_nova/win_pkg.py
@@ -13,6 +13,7 @@ import copy
 import fnmatch
 import logging
 import salt.utils
+import salt.utils.platform
 from salt.exceptions import CommandExecutionError
 from distutils.version import LooseVersion
 
@@ -22,7 +23,7 @@ __virtualname__ = 'win_pkg'
 
 
 def __virtual__():
-    if not salt.utils.is_windows():
+    if not salt.utils.platform.is_windows():
         return False, 'This audit module only runs on windows'
     return True
 

--- a/hubblestack/files/hubblestack_nova/win_reg.py
+++ b/hubblestack/files/hubblestack_nova/win_reg.py
@@ -13,6 +13,7 @@ import copy
 import fnmatch
 import logging
 import salt.utils
+import salt.utils.platform
 
 
 log = logging.getLogger(__name__)
@@ -20,7 +21,7 @@ __virtualname__ = 'win_reg'
 
 
 def __virtual__():
-    if not salt.utils.is_windows():
+    if not salt.utils.platform.is_windows():
         return False, 'This audit module only runs on windows'
     return True
 

--- a/hubblestack/files/hubblestack_nova/win_secedit.py
+++ b/hubblestack/files/hubblestack_nova/win_secedit.py
@@ -13,6 +13,7 @@ import copy
 import fnmatch
 import logging
 import salt.utils
+import salt.utils.platform
 
 try:
     import codecs
@@ -26,7 +27,7 @@ __virtualname__ = 'win_secedit'
 
 
 def __virtual__():
-    if not salt.utils.is_windows() or not HAS_WINDOWS_MODULES:
+    if not salt.utils.platform.is_windows() or not HAS_WINDOWS_MODULES:
         return False, 'This audit module only runs on windows'
     return True
 

--- a/hubblestack/splunklogging.py
+++ b/hubblestack/splunklogging.py
@@ -46,7 +46,7 @@ import copy
 import logging
 
 _max_content_bytes = 100000
-http_event_collector_SSL_verify = False
+http_event_collector_SSL_verify = True
 http_event_collector_debug = False
 
 hec = None

--- a/hubblestack/splunklogging.py
+++ b/hubblestack/splunklogging.py
@@ -150,6 +150,20 @@ class SplunkHandler(logging.Handler):
             hec.flushBatch()
         return True
 
+    def emit_data(self, data):
+        '''
+        Add the given data (in dict format!) to the event template and emit as
+        usual
+        '''
+        for hec, event, payload in self.endpoint_list:
+            event = copy.deepcopy(event)
+            payload = copy.deepcopy(payload)
+            event.update(data)
+            payload['event'] = event
+            hec.batchEvent(payload, eventtime=time.time())
+            hec.flushBatch()
+        return True
+
     def format_record(self, record):
         '''
         Format the log record into a dictionary for easy insertion into a

--- a/hubblestack/splunklogging.py
+++ b/hubblestack/splunklogging.py
@@ -152,11 +152,17 @@ class SplunkHandler(logging.Handler):
         Format the log record into a dictionary for easy insertion into a
         splunk event dictionary
         '''
-        log_entry = {'message': record.message,
-                     'level': record.levelname,
-                     'timestamp': record.asctime,
-                     'loggername': record.name,
-                     }
+        try:
+            log_entry = {'message': record.message,
+                         'level': record.levelname,
+                         'timestamp': record.asctime,
+                         'loggername': record.name,
+                         }
+        except:
+            log_entry = {'message': record.msg,
+                         'level': record.levelname,
+                         'loggername': record.name,
+                         }
         return log_entry
 
 

--- a/hubblestack/splunklogging.py
+++ b/hubblestack/splunklogging.py
@@ -93,7 +93,10 @@ class SplunkHandler(logging.Handler):
             try:
                 fqdn_ip4 = __grains__['fqdn_ip4'][0]
             except IndexError:
-                fqdn_ip4 = __grains__['ipv4'][0]
+                try:
+                    fqdn_ip4 = __grains__['ipv4'][0]
+                except IndexError:
+                    raise Exception('No ipv4 grains found. Is net-tools installed?')
             if fqdn_ip4.startswith('127.'):
                 for ip4_addr in __grains__['ipv4']:
                     if ip4_addr and not ip4_addr.startswith('127.'):

--- a/pkg/hubble.service
+++ b/pkg/hubble.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Hubblestack
+Requires=network-online.target
+After=network-online.target
 
 [Service]
 Type=forking


### PR DESCRIPTION
This PR kind of spiraled out of control a little bit. It does a bunch of things.

# Top changes

* Time the osquery queries and report to splunk if splunklogging=True
* Add new loglevel for splunk reporting (`splunk`)
* **Turn on SSL verify for the splunk returners and splunklogging.py**

# Other changes

* Migrates to salt.utils.path.which (salt 2018.3)
* Migrates to salt.utils.platform.is_windows (salt 2018.3)
* Fixes gen_jid calls (salt 2018.3)
* Improves error reporting if net-tools is not installed on centos
* Fixes a transient issue related to salt's custom log records
* Adds network requires to systemd unit file
* Adds optional sleep on startup as a backup for network startup issues

@sumanmehta The SSL verify change is potentially a big one and should be tested against your splunk endpoints. If they don't have good certificates, we should either fix that or make the SSL verify configurable and silence the warnings (or else they get logged to splunk, which triggers a new warning, which gets logged to splunk...bad loop).