### PR TITLE
labelling of tests in profiles

### DIFF
--- a/hubblestack/files/hubblestack_nova/pkg.py
+++ b/hubblestack/files/hubblestack_nova/pkg.py
@@ -29,6 +29,9 @@ pkg:
           - 'telnet': 'telnet-bad'
       # description/alert/trigger are currently ignored, but may be used in the future
       description: 'Telnet is evil'
+      labels:
+        - critical
+        - raiseticket
       alert: email
       trigger: state
   # Must be installed, no version checking (yet)
@@ -76,6 +79,18 @@ def __virtual__():
         return False, 'This audit module only runs on linux'
     return True
 
+def apply_labels(__data__, labels):
+    if labels:
+        for topkey in ('blacklist', 'whitelist'):
+            if topkey in __data__.get('pkg', {}):
+                labelled_test_cases=[]
+                for test_case in __data__['pkg'].get(topkey, []):
+                    # each test case is a dictionary with just one key-val pair. key=test name, val=test data, description etc
+                    if isinstance(test_case, dict) and test_case:
+                        test_case_body = test_case.get(next(iter(test_case)))
+                        if set(labels).issubset(set(test_case_body.get('labels',[]))):
+                            labelled_test_cases.append(test_case)
+                __data__['pkg'][topkey]=labelled_test_cases
 
 def audit(data_list, tags, debug=False, **kwargs):
     '''
@@ -84,6 +99,7 @@ def audit(data_list, tags, debug=False, **kwargs):
     __data__ = {}
     for profile, data in data_list:
         _merge_yaml(__data__, data, profile)
+    apply_labels(__data__, labels)
     __tags__ = _get_tags(__data__)
 
     if debug:

--- a/hubblestack/files/hubblestack_nova/stat_nova.py
+++ b/hubblestack/files/hubblestack_nova/stat_nova.py
@@ -36,6 +36,9 @@ stat:
             gid: 0
     # The rest of these attributes are optional, and currently not used
     description: 'Grub must be owned by root'
+    labels:
+      - critical
+      - raiseticket
     alert: email
     trigger: state
 
@@ -66,6 +69,16 @@ def __virtual__():
         return False, 'This audit module only runs on linux'
     return True
 
+def apply_labels(__data__, labels):
+    if labels:
+        labelled_test_cases=[]
+        for test_case in __data__.get('stat', []):
+            # each test case is a dictionary with just one key-val pair. key=test name, val=test data, description etc
+            if isinstance(test_case, dict) and test_case:
+                test_case_body = test_case.get(next(iter(test_case)))
+                if set(labels).issubset(set(test_case_body.get('labels',[]))):
+                    labelled_test_cases.append(test_case)
+        __data__['stat']=labelled_test_cases
 
 def audit(data_list, tags, debug=False, **kwargs):
     '''
@@ -74,6 +87,7 @@ def audit(data_list, tags, debug=False, **kwargs):
     __data__ = {}
     for profile, data in data_list:
         _merge_yaml(__data__, data, profile)
+    apply_labels(__data__, labels)
     __tags__ = _get_tags(__data__)
 
     if debug:


### PR DESCRIPTION
This is related to labelling/categorising of test cases in profiles. Field called 'label' can be added to profile tests which can be used to filter out or run only specific test cases. While running audit, user can specify the labels and only those tests would be run which have those labels defined.

Since the structure of tests varies across nova modules, a generic solution to filter labelled tests is hard to implement and can be error prone. I am currently thinking of making the changes to each of the modules.

For this pull request, changes have been made to 'pkg' and 'stat' modules. If these look good, I will go ahead and make changes to other modules as well. 

**This is just for review, kindly do not merge.**