### PR TITLE
nix the defaults

### DIFF
--- a/hubblestack/splunklogging.py
+++ b/hubblestack/splunklogging.py
@@ -77,7 +77,6 @@ class SplunkHandler(logging.Handler):
             # Set up the fields to be extracted at index time. The field values must be strings.
             # Note that these fields will also still be available in the event data
             index_extracted_fields = []
-            # nixed defaults 4/2/18 # ['aws_instance_id', 'aws_account_id', 'azure_vmId', 'azure_subscriptionId']
             try:
                 index_extracted_fields.extend(opts['index_extracted_fields'])
             except TypeError:

--- a/hubblestack/splunklogging.py
+++ b/hubblestack/splunklogging.py
@@ -76,7 +76,8 @@ class SplunkHandler(logging.Handler):
 
             # Set up the fields to be extracted at index time. The field values must be strings.
             # Note that these fields will also still be available in the event data
-            index_extracted_fields = ['aws_instance_id', 'aws_account_id', 'azure_vmId', 'azure_subscriptionId']
+            index_extracted_fields = []
+            # nixed defaults 4/2/18 # ['aws_instance_id', 'aws_account_id', 'azure_vmId', 'azure_subscriptionId']
             try:
                 index_extracted_fields.extend(opts['index_extracted_fields'])
             except TypeError:


### PR DESCRIPTION
… but continue to allow maintainers to add index time fields from hubble config.

(I had accidentally pushed this branch to the hubblestack repo, rather than my own repo... when I deleted the branch, it killed PR #293 — so I just submitted a new one.)