### PR TITLE
Add ability to fetch contents of changed files

### DIFF
--- a/hubblestack/extmods/modules/pulsar.py
+++ b/hubblestack/extmods/modules/pulsar.py
@@ -13,6 +13,7 @@ Watch files and translate the changes into salt events
 '''
 # Import Python libs
 from __future__ import absolute_import
+import base64
 import collections
 import fnmatch
 import os
@@ -758,7 +759,7 @@ def process(configfile='salt://hubblestack_pulsar/hubblestack_pulsar_config.yaml
                                 and old_checksum != new_checksum:
                             try:
                                 with open(pathname, 'r') as f:
-                                    sub['contents'] = f.read()
+                                    sub['contents'] = base64.b64encode(f.read())
                             except Exception as e:
                                 log.debug('Could not get file contents for {0}: {1}'
                                           .format(pathname, e))

--- a/hubblestack/extmods/modules/pulsar.py
+++ b/hubblestack/extmods/modules/pulsar.py
@@ -752,8 +752,8 @@ def process(configfile='salt://hubblestack_pulsar/hubblestack_pulsar_config.yaml
 
                         # File contents? Don't fetch contents for any file over
                         # 20KB or where the checksum is unchanged
-                        if (pathname in config['cpath'].get('contents', []) or
-                                os.path.dirname(pathname) in config['cpath'].get('contents', [])) \
+                        if (pathname in config[cpath].get('contents', []) or
+                                os.path.dirname(pathname) in config[cpath].get('contents', [])) \
                                 and os.path.getsize(pathname) < config.get('contents_size', 20480) \
                                 and old_checksum != new_checksum:
                             try:

--- a/hubblestack/extmods/modules/pulsar.py
+++ b/hubblestack/extmods/modules/pulsar.py
@@ -622,6 +622,8 @@ def process(configfile='salt://hubblestack_pulsar/hubblestack_pulsar_config.yaml
         checksum: sha256
         stats: True
         batch: True
+        contents_size: 20480
+        checksum_size: 104857600
 
     Note that if `batch: True`, the configured returner must support receiving
     a list of events, rather than single one-off events.
@@ -662,6 +664,8 @@ def process(configfile='salt://hubblestack_pulsar/hubblestack_pulsar_config.yaml
     exclude:
       Exclude directories or files from triggering events in the watched directory.
       Can use regex if regex is set to True
+    contents:
+      Retrieve the contents of changed files based on checksums (which must be enabled)
 
     If pillar/grains/minion config key `hubblestack:pulsar:maintenance` is set to
     True, then changes will be discarded.
@@ -793,9 +797,9 @@ def process(configfile='salt://hubblestack_pulsar/hubblestack_pulsar_config.yaml
         # TODO: make the config handle more options
         for path in config:
             excludes = lambda x: False
-            if path == 'return' or path == 'checksum' or path == 'stats' \
-                    or path == 'batch' or path == 'verbose' or path == 'paths' \
-                    or path == 'refresh_interval':
+            if path in ['return', 'checksum', 'stats', 'batch', 'verbose',
+                        'paths', 'refresh_interval', 'contents_size',
+                        'checksum_size']:
                 continue
             if isinstance(config[path], dict):
                 mask = config[path].get('mask', DEFAULT_MASK)

--- a/hubblestack/extmods/modules/pulsar.py
+++ b/hubblestack/extmods/modules/pulsar.py
@@ -757,9 +757,9 @@ def process(configfile='salt://hubblestack_pulsar/hubblestack_pulsar_config.yaml
                         try:
                             with open(abspath, 'r') as f:
                                 sub['contents'] = f.read()
-                        except:
-                            log.debug('Could not get file contents for {0}'
-                                      .format(abspath))
+                        except Exception as e:
+                            log.debug('Could not get file contents for {0}: {1}'
+                                      .format(abspath, e))
 
 
                 ret.append(sub)

--- a/hubblestack/extmods/modules/pulsar.py
+++ b/hubblestack/extmods/modules/pulsar.py
@@ -787,7 +787,7 @@ def process(configfile='salt://hubblestack_pulsar/hubblestack_pulsar_config.yaml
                     elif event.mask & pyinotify.IN_DELETE:
                         wm.rm_watch(pathname)
             else:
-                log.info('Excluding {0} from event for {1}'.format(pathname, cpath))
+                log.debug('Excluding {0} from event for {1}'.format(pathname, cpath))
         dt.fin()
 
     if update_watches:


### PR DESCRIPTION
Includes a maximum file size (defaults to 20KB). Also adds a max file
size for checksums (defaults to 100MB). Adds the size from
os.path.getsize if `stat` is set.