### PR TITLE
Another fix dump

### DIFF
--- a/conf/hubble
+++ b/conf/hubble
@@ -106,6 +106,7 @@ fileserver_backend:
 #        sourcetype_pulsar: hubble_fim
 #        sourcetype_log: hubble_log
 #  splunklogging: True
+#splunk_index_extracted_fields: []
 
 ## If you are instead using the slack returner, you'll need a block similar to
 ## this:

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -512,6 +512,13 @@ def load_config():
         handler = hubblestack.splunklogging.SplunkHandler()
         handler.setLevel(logging.SPLUNK)
         root_logger.addHandler(handler)
+        class MockRecord(object):
+            def __init__(self, message, levelname, asctime, name):
+                self.message = message
+                self.levelname = levelname
+                self.asctime = asctime
+                self.name = name
+        handler.emit(MockRecord(__grains__, 'INFO', time.asctime(), 'hubblestack.grains_report'))
 
 
 def refresh_grains(initial=False):

--- a/hubblestack/extmods/grains/systemuuid.py
+++ b/hubblestack/extmods/grains/systemuuid.py
@@ -19,6 +19,7 @@ def get_system_uuid():
 
     # Prefer our /opt/osquery/osqueryi if present
     osqueryipaths = ('/opt/osquery/osqueryi', 'osqueryi', '/usr/bin/osqueryi')
+    grains = {}
     for path in osqueryipaths:
         if salt.utils.path.which(path):
             out = __salt__['cmd.run']('{0} {1}'.format(path, options))

--- a/hubblestack/extmods/modules/nebula_osquery.py
+++ b/hubblestack/extmods/modules/nebula_osquery.py
@@ -171,6 +171,7 @@ def queries(query_group,
 
     ret = []
     timing = {}
+    schedule_time = time.time()
     for query in query_data:
         name = query.get('query_name')
         query_sql = query.get('query')
@@ -186,7 +187,7 @@ def queries(query_group,
         t0 = time.time()
         res = __salt__['cmd.run_all'](cmd)
         t1 = time.time()
-        timing[name] = t0 - t1
+        timing[name] = t1-t0
         if res['retcode'] == 0:
             query_ret['data'] = json.loads(res['stdout'])
         else:
@@ -205,7 +206,9 @@ def queries(query_group,
         hubblestack.splunklogging.__grains__ = __grains__
         hubblestack.splunklogging.__salt__ = __salt__
         handler = hubblestack.splunklogging.SplunkHandler()
-        handler.emit_data(timing)
+        timing_data = {'query_run_length': timing,
+                       'schedule_time' : schedule_time}
+        handler.emit_data(timing_data)
 
     if query_group == 'day' and report_version_with_day:
         ret.append(hubble_versions())

--- a/hubblestack/extmods/returners/splunk_nebula_return.py
+++ b/hubblestack/extmods/returners/splunk_nebula_return.py
@@ -64,7 +64,7 @@ def returner(ret):
         opts_list = _get_options()
 
         for opts in opts_list:
-            logging.info('Options: %s' % json.dumps(opts))
+            logging.debug('Options: %s' % json.dumps(opts))
             http_event_collector_key = opts['token']
             http_event_collector_host = opts['indexer']
             http_event_collector_port = opts['port']

--- a/hubblestack/extmods/returners/splunk_nebula_return.py
+++ b/hubblestack/extmods/returners/splunk_nebula_return.py
@@ -133,7 +133,7 @@ def returner(ret):
                             event.update({'dest_host': fqdn})
                             event.update({'dest_ip': fqdn_ip4})
                             event.update({'dest_fqdn': local_fqdn})
-                            event.update({'system_uuid': __grains__['system_uuid']})
+                            event.update({'system_uuid': __grains__.get('system_uuid')})
 
                             event.update(cloud_details)
 

--- a/hubblestack/extmods/returners/splunk_nebula_return.py
+++ b/hubblestack/extmods/returners/splunk_nebula_return.py
@@ -75,9 +75,9 @@ def returner(ret):
 
             # Set up the fields to be extracted at index time. The field values must be strings.
             # Note that these fields will also still be available in the event data
-            index_extracted_fields = ['aws_instance_id', 'aws_account_id', 'azure_vmId', 'azure_subscriptionId']
+            index_extracted_fields = []
             try:
-                index_extracted_fields.extend(opts['index_extracted_fields'])
+                index_extracted_fields.extend(__opts__get('splunk_index_extracted_fields', []))
             except TypeError:
                 pass
 

--- a/hubblestack/extmods/returners/splunk_nebula_return.py
+++ b/hubblestack/extmods/returners/splunk_nebula_return.py
@@ -74,7 +74,6 @@ def returner(ret):
             custom_fields = opts['custom_fields']
 
             # Set up the fields to be extracted at index time. The field values must be strings.
-            # Note that these fields will also still be available in the event data
             index_extracted_fields = []
             try:
                 index_extracted_fields.extend(__opts__get('splunk_index_extracted_fields', []))

--- a/hubblestack/extmods/returners/splunk_nova_return.py
+++ b/hubblestack/extmods/returners/splunk_nova_return.py
@@ -73,7 +73,6 @@ def returner(ret):
             custom_fields = opts['custom_fields']
 
             # Set up the fields to be extracted at index time. The field values must be strings.
-            # Note that these fields will also still be available in the event data
             index_extracted_fields = []
             try:
                 index_extracted_fields.extend(__opts__get('splunk_index_extracted_fields', []))

--- a/hubblestack/extmods/returners/splunk_nova_return.py
+++ b/hubblestack/extmods/returners/splunk_nova_return.py
@@ -63,7 +63,7 @@ def returner(ret):
         opts_list = _get_options()
 
         for opts in opts_list:
-            log.info('Options: %s' % json.dumps(opts))
+            log.debug('Options: %s' % json.dumps(opts))
             http_event_collector_key = opts['token']
             http_event_collector_host = opts['indexer']
             http_event_collector_port = opts['port']

--- a/hubblestack/extmods/returners/splunk_nova_return.py
+++ b/hubblestack/extmods/returners/splunk_nova_return.py
@@ -143,7 +143,7 @@ def returner(ret):
                 event.update({'dest_host': fqdn})
                 event.update({'dest_ip': fqdn_ip4})
                 event.update({'dest_fqdn': local_fqdn})
-                event.update({'system_uuid': __grains__['system_uuid']})
+                event.update({'system_uuid': __grains__.get('system_uuid')})
 
                 event.update(cloud_details)
 
@@ -189,7 +189,7 @@ def returner(ret):
                 event.update({'dest_host': fqdn})
                 event.update({'dest_ip': fqdn_ip4})
                 event.update({'dest_fqdn': local_fqdn})
-                event.update({'system_uuid': __grains__['system_uuid']})
+                event.update({'system_uuid': __grains__.get('system_uuid')})
 
                 event.update(cloud_details)
 
@@ -233,7 +233,7 @@ def returner(ret):
                 event.update({'dest_host': fqdn})
                 event.update({'dest_ip': fqdn_ip4})
                 event.update({'dest_fqdn': local_fqdn})
-                event.update({'system_uuid': __grains__['system_uuid']})
+                event.update({'system_uuid': __grains__.get('system_uuid')})
 
                 event.update(cloud_details)
 

--- a/hubblestack/extmods/returners/splunk_nova_return.py
+++ b/hubblestack/extmods/returners/splunk_nova_return.py
@@ -74,9 +74,9 @@ def returner(ret):
 
             # Set up the fields to be extracted at index time. The field values must be strings.
             # Note that these fields will also still be available in the event data
-            index_extracted_fields = ['aws_instance_id', 'aws_account_id', 'azure_vmId', 'azure_subscriptionId']
+            index_extracted_fields = []
             try:
-                index_extracted_fields.extend(opts['index_extracted_fields'])
+                index_extracted_fields.extend(__opts__get('splunk_index_extracted_fields', []))
             except TypeError:
                 pass
 

--- a/hubblestack/extmods/returners/splunk_pulsar_return.py
+++ b/hubblestack/extmods/returners/splunk_pulsar_return.py
@@ -230,7 +230,7 @@ def returner(ret):
                 event.update({'dest_host': fqdn})
                 event.update({'dest_ip': fqdn_ip4})
                 event.update({'dest_fqdn': local_fqdn})
-                event.update({'system_uuid': __grains__['system_uuid']})
+                event.update({'system_uuid': __grains__.get('system_uuid')})
 
                 event.update(cloud_details)
 

--- a/hubblestack/extmods/returners/splunk_pulsar_return.py
+++ b/hubblestack/extmods/returners/splunk_pulsar_return.py
@@ -69,7 +69,7 @@ def returner(ret):
         opts_list = _get_options()
 
         for opts in opts_list:
-            logging.info('Options: %s' % json.dumps(opts))
+            logging.debug('Options: %s' % json.dumps(opts))
             http_event_collector_key = opts['token']
             http_event_collector_host = opts['indexer']
             http_event_collector_port = opts['port']

--- a/hubblestack/extmods/returners/splunk_pulsar_return.py
+++ b/hubblestack/extmods/returners/splunk_pulsar_return.py
@@ -79,7 +79,6 @@ def returner(ret):
             custom_fields = opts['custom_fields']
 
             # Set up the fields to be extracted at index time. The field values must be strings.
-            # Note that these fields will also still be available in the event data
             index_extracted_fields = []
             try:
                 index_extracted_fields.extend(__opts__get('splunk_index_extracted_fields', []))

--- a/hubblestack/extmods/returners/splunk_pulsar_return.py
+++ b/hubblestack/extmods/returners/splunk_pulsar_return.py
@@ -80,9 +80,9 @@ def returner(ret):
 
             # Set up the fields to be extracted at index time. The field values must be strings.
             # Note that these fields will also still be available in the event data
-            index_extracted_fields = ['aws_instance_id', 'aws_account_id', 'azure_vmId', 'azure_subscriptionId']
+            index_extracted_fields = []
             try:
-                index_extracted_fields.extend(opts['index_extracted_fields'])
+                index_extracted_fields.extend(__opts__get('splunk_index_extracted_fields', []))
             except TypeError:
                 pass
 

--- a/hubblestack/splunklogging.py
+++ b/hubblestack/splunklogging.py
@@ -75,7 +75,6 @@ class SplunkHandler(logging.Handler):
             custom_fields = opts['custom_fields']
 
             # Set up the fields to be extracted at index time. The field values must be strings.
-            # Note that these fields will also still be available in the event data
             index_extracted_fields = []
             try:
                 index_extracted_fields.extend(__opts__get('splunk_index_extracted_fields', []))

--- a/hubblestack/splunklogging.py
+++ b/hubblestack/splunklogging.py
@@ -78,7 +78,7 @@ class SplunkHandler(logging.Handler):
             # Note that these fields will also still be available in the event data
             index_extracted_fields = []
             try:
-                index_extracted_fields.extend(opts['index_extracted_fields'])
+                index_extracted_fields.extend(__opts__get('splunk_index_extracted_fields', []))
             except TypeError:
                 pass
 


### PR DESCRIPTION
* Fix systemuuid grain for missing osquery
* Don't assume we have system_uuid in grains for splunk returner
* Log splunk options at debug level to better protect token
* Move splunk_index_extracted_fields to the top level of the config
* Fix osquery timing for better formatting for splunk
* Fix negative times in osquery timing