### PR TITLE
Adding option to fetch custom grains and pillar

### DIFF
--- a/conf/hubble
+++ b/conf/hubble
@@ -28,17 +28,6 @@ fileserver_backend:
 #  - roots
 #  - git
 
-##############################################
-## For fetching custom garins and pillar info
-##############################################
-
-#custom_grains_pillar:
-#      grains:
-#        - selinux: selinux:enabled
-#        - release: osrelease
-#      pillar:
-#        - ntpserver: network_services:ntpserver
-
 #################################
 ## Scheduler Config
 #################################
@@ -126,3 +115,15 @@ fileserver_backend:
 #  username: calculon
 #  channel: channel
 #  api_key: xoxb-xxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxx
+
+########################################################
+## For fetching local salt custom grains and pillar data
+########################################################
+
+#custom_grains_pillar:
+#  grains:
+#    - selinux: selinux:enabled
+#    - release: osrelease
+#  pillar:
+#    - ntpserver: network_services:ntpserver
+

--- a/conf/hubble
+++ b/conf/hubble
@@ -28,6 +28,16 @@ fileserver_backend:
 #  - roots
 #  - git
 
+##############################################
+## For fetching custom garins and pillar info
+##############################################
+
+#custom_grains_pillar:
+#      grains:
+#        - selinux: selinux:enabled
+#        - release: osrelease
+#      pillar:
+#        - ntpserver: network_services:ntpserver
 
 #################################
 ## Scheduler Config

--- a/hubblestack/extmods/grains/custom_grains_pillar.py
+++ b/hubblestack/extmods/grains/custom_grains_pillar.py
@@ -1,6 +1,9 @@
 '''
 HubbleStack Custom Grains and Pillar
 
+Allows for fetching custom grain and pillar data from a local salt-minion via
+salt-call
+
 :maintainer: HubbleStack
 :platform: All
 :requires: SaltStack
@@ -20,27 +23,31 @@ __salt__ = {
 
 def populate_custom_grains_and_pillar():
     '''
-    To return grains and pillar fields values as specified in config file.
+    Populate local salt-minion grains and pillar fields values as specified in
+    config file.
+
     For example:
-    custom_grains_pillar:
-      grains:
-        - selinux: selinux:enabled
-        - release: osrelease
-      pillar:
-        - ntpserver: network_services:ntpserver
+
+        custom_grains_pillar:
+          grains:
+            - selinux: selinux:enabled
+            - release: osrelease
+          pillar:
+            - ntpserver: network_services:ntpserver
+
+    Note that the core grains are already included in hubble grains -- this
+    is only necessary for custom grains and pillar data.
     '''
     log.debug('Fetching custom grains and pillar details')
     grains = {}
     salt.modules.config.__opts__ = __opts__
-    if __salt__['config.get']('custom_grains_pillar:grains'):
-        custom_grains = __salt__['config.get']('custom_grains_pillar:grains')
+    custom_grains = __salt__['config.get']('custom_grains_pillar:grains', [])
     for grain in custom_grains:
         for key in grain:
             if _valid_command(grain[key]):
                 value = __salt__['cmd.run']('salt-call grains.get {0}'.format(grain[key])).split('\n')[1].strip()
                 grains[key] = value
-    if __salt__['config.get']('custom_grains_pillar:pillar'):
-        custom_pillar = __salt__['config.get']('custom_grains_pillar:pillar')
+    custom_pillar = __salt__['config.get']('custom_grains_pillar:pillar', [])
     for pillar in custom_pillar:
         for key in pillar:
             if _valid_command(pillar[key]):
@@ -51,6 +58,9 @@ def populate_custom_grains_and_pillar():
 
 
 def _valid_command(string):
+    '''
+    Check for invalid characters in the pillar or grains key
+    '''
     invalid_characters = re.findall('[^a-zA-Z0-9:_-]',string)
     if len(invalid_characters) > 0:
         log.info("Command: {0} contains invalid characters: {1}".format(string, invalid_characters))

--- a/hubblestack/extmods/grains/custom_grains_pillar.py
+++ b/hubblestack/extmods/grains/custom_grains_pillar.py
@@ -1,0 +1,59 @@
+'''
+HubbleStack Custom Grains and Pillar
+
+:maintainer: HubbleStack
+:platform: All
+:requires: SaltStack
+'''
+
+import re
+import salt.modules.cmdmod
+import logging
+
+log = logging.getLogger(__name__)
+
+__salt__ = {
+        'cmd.run': salt.modules.cmdmod._run_quiet,
+        'config.get': salt.modules.config.get,
+}
+
+
+def populate_custom_grains_and_pillar():
+    '''
+    To return grains and pillar fields values as specified in config file.
+    For example:
+    custom_grains_pillar:
+      grains:
+        - selinux: selinux:enabled
+        - release: osrelease
+      pillar:
+        - ntpserver: network_services:ntpserver
+    '''
+    log.debug('Fetching custom grains and pillar details')
+    grains = {}
+    salt.modules.config.__opts__ = __opts__
+    if __salt__['config.get']('custom_grains_pillar:grains'):
+        custom_grains = __salt__['config.get']('custom_grains_pillar:grains')
+    for grain in custom_grains:
+        for key in grain:
+            if _valid_command(grain[key]):
+                value = __salt__['cmd.run']('salt-call grains.get {0}'.format(grain[key])).split('\n')[1].strip()
+                grains[key] = value
+    if __salt__['config.get']('custom_grains_pillar:pillar'):
+        custom_pillar = __salt__['config.get']('custom_grains_pillar:pillar')
+    for pillar in custom_pillar:
+        for key in pillar:
+            if _valid_command(pillar[key]):
+                value = __salt__['cmd.run']('salt-call pillar.get {0}'.format(pillar[key])).split('\n')[1].strip()
+                grains[key] = value
+    log.debug('Done with fetching custom grains and pillar details')
+    return grains
+
+
+def _valid_command(string):
+    invalid_characters = re.findall('[^a-zA-Z0-9:_-]',string)
+    if len(invalid_characters) > 0:
+        log.info("Command: {0} contains invalid characters: {1}".format(string, invalid_characters))
+        return False
+    else:
+        return True

--- a/hubblestack/extmods/grains/custom_grains_pillar.py
+++ b/hubblestack/extmods/grains/custom_grains_pillar.py
@@ -44,26 +44,12 @@ def populate_custom_grains_and_pillar():
     custom_grains = __salt__['config.get']('custom_grains_pillar:grains', [])
     for grain in custom_grains:
         for key in grain:
-            if _valid_command(grain[key]):
-                value = __salt__['cmd.run']('salt-call grains.get {0}'.format(grain[key])).split('\n')[1].strip()
-                grains[key] = value
+            value = __salt__['cmd.run'](['salt-call', 'grains.get', grain[key]]).split('\n')[1].strip()
+            grains[key] = value
     custom_pillar = __salt__['config.get']('custom_grains_pillar:pillar', [])
     for pillar in custom_pillar:
         for key in pillar:
-            if _valid_command(pillar[key]):
-                value = __salt__['cmd.run']('salt-call pillar.get {0}'.format(pillar[key])).split('\n')[1].strip()
-                grains[key] = value
+            value = __salt__['cmd.run'](['salt-call', 'pillar.get', pillar[key]]).split('\n')[1].strip()
+            grains[key] = value
     log.debug('Done with fetching custom grains and pillar details')
     return grains
-
-
-def _valid_command(string):
-    '''
-    Check for invalid characters in the pillar or grains key
-    '''
-    invalid_characters = re.findall('[^a-zA-Z0-9:_-]',string)
-    if len(invalid_characters) > 0:
-        log.info("Command: {0} contains invalid characters: {1}".format(string, invalid_characters))
-        return False
-    else:
-        return True


### PR DESCRIPTION
Needs to add the following sort of section in config file:

```

##############################################
## For fetching custom garins and pillar info
##############################################

custom_grains_pillar:
      grains:
        - selinux: selinux:enabled
        - release: osrelease
      pillar:
        - ntpserver: network_services:ntpserver
```

To add any of these fields with each log, user can use custom_fields option, for ex to add release and ntpserver with each log:


```
hubblestack:
  returner:
    splunk:
      - token: <token>
        indexer: <indexer>
        index: hubble
        sourcetype_nova: hubble_audit
        sourcetype_nebula: hubble_osquery
        sourcetype_pulsar: hubble_fim
        sourcetype_log: hubble_log
        custom_fields:
          - release
          - ntpserver
  splunklogging: True
```