### PR TITLE
Fix configgrains to separate from hubblestack returner config

### DIFF
--- a/conf/hubble
+++ b/conf/hubble
@@ -107,6 +107,9 @@ fileserver_backend:
 #  splunklogging: True
 #splunk_index_extracted_fields: []
 
+#config_to_grains:
+#  - splunkindex: "hubblestack:returner:splunk:0:index"
+
 ## If you are instead using the slack returner, you'll need a block similar to
 ## this:
 
@@ -126,4 +129,3 @@ fileserver_backend:
 #    - release: osrelease
 #  pillar:
 #    - ntpserver: network_services:ntpserver
-

--- a/conf/hubble
+++ b/conf/hubble
@@ -104,7 +104,7 @@ fileserver_backend:
 #        sourcetype_nebula: hubble_osquery
 #        sourcetype_pulsar: hubble_fim
 #        sourcetype_log: hubble_log
-#  splunklogging: True
+#splunklogging: True
 #splunk_index_extracted_fields: []
 
 #config_to_grains:

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -507,7 +507,7 @@ def load_config():
         if self.isEnabledFor(logging.SPLUNK):
             self._log(logging.SPLUNK, message, args, **kwargs)
     logging.Logger.splunk = splunk
-    if __salt__['config.get']('hubblestack:splunklogging', False):
+    if __salt__['config.get']('splunklogging', False):
         root_logger = logging.getLogger()
         handler = hubblestack.splunklogging.SplunkHandler()
         handler.setLevel(logging.SPLUNK)
@@ -557,7 +557,7 @@ def refresh_grains(initial=False):
     hubblestack.splunklogging.__salt__ = __salt__
     hubblestack.splunklogging.__opts__ = __opts__
 
-    if not initial and __salt__['config.get']('hubblestack:splunklogging', False):
+    if not initial and __salt__['config.get']('splunklogging', False):
         class MockRecord(object):
             def __init__(self, message, levelname, asctime, name):
                 self.message = message

--- a/hubblestack/extmods/grains/configgrains.py
+++ b/hubblestack/extmods/grains/configgrains.py
@@ -2,26 +2,22 @@
 '''
 Custom config-defined grains module
 
-:maintainer: HubbleStack
-:platform: All
-:requires: SaltStack
+Allow users to collect a list of config directives and set them as custom
+grains.  The list should be defined under the `config_to_grains` key.
 
-Allow users to collect a list of config directives and set them as custom grains.
-The list should be defined under the `hubblestack` key.
-
-The `grains` value should be a list of dictionaries. Each dictionary should have
-a single key which will be set as the grain name. The dictionary's value will
-be the grain's value.
+The `config_grains` value should be a list of dictionaries. Each dictionary
+should have a single key which will be set as the grain name. The dictionary's
+value will be the grain's value.
 
 hubblestack:
-  grains:
-    - splunkindex: "hubblestack:returner:splunk:index"
   returner:
     splunk:
       - token: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
         indexer: splunk-indexer.domain.tld
         index: hubble
         sourcetype_nova: hubble_audit
+config_to_grains:
+  - splunkindex: "hubblestack:returner:splunk:0:index"
 '''
 
 import salt.modules.config
@@ -38,14 +34,14 @@ def configgrains():
     The list comes from config.
 
     Example:
-    hubblestack:
-      grains:
-        - splunkindex: "hubblestack:returner:splunk:index"
+
+    config_to_grains:
+      - splunkindex: "hubblestack:returner:splunk:0:index"
     '''
     grains = {}
     salt.modules.config.__opts__ = __opts__
 
-    grains_to_make = __salt__['config.get']('hubblestack:grains', default=[])
+    grains_to_make = __salt__['config.get']('config_to_grains', default=[])
     for grain in grains_to_make:
         for k, v in grain.iteritems():
             grain_value = __salt__['config.get'](v, default=None)

--- a/hubblestack/extmods/modules/nebula_osquery.py
+++ b/hubblestack/extmods/modules/nebula_osquery.py
@@ -201,7 +201,7 @@ def queries(query_group,
         else:
             ret.append({name: query_ret})
 
-    if __salt__['config.get']('hubblestack:splunklogging', False):
+    if __salt__['config.get']('splunklogging', False):
         log.info('Logging osquery timing data to splunk')
         hubblestack.splunklogging.__grains__ = __grains__
         hubblestack.splunklogging.__salt__ = __salt__

--- a/hubblestack/splunklogging.py
+++ b/hubblestack/splunklogging.py
@@ -116,6 +116,7 @@ class SplunkHandler(logging.Handler):
             event.update({'minion_id': minion_id})
             event.update({'dest_host': fqdn})
             event.update({'dest_ip': fqdn_ip4})
+            event.update({'system_uuid': __grains__.get('system_uuid')})
 
             event.update(cloud_details)
 


### PR DESCRIPTION
Same with the splunklogging