### PR TITLE
Add grain to read splunk config from hubble.d/*.conf

### DIFF
--- a/hubblestack/extmods/grains/splunkconfig.py
+++ b/hubblestack/extmods/grains/splunkconfig.py
@@ -21,7 +21,7 @@ def splunkconfig():
         for root, dirs, files in os.walk(configdir):
             for f in files:
                 if f.endswith('.conf'):
-                    fpath = os.path.join(root, fpath)
+                    fpath = os.path.join(root, f)
                     try:
                         with open(fpath, 'r') as fh:
                             config = yaml.safe_load(fh)

--- a/hubblestack/extmods/grains/splunkconfig.py
+++ b/hubblestack/extmods/grains/splunkconfig.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+'''
+Attempt to load alternate splunk config from the hubble.d/ directory and store
+in grains for use by the splunk returners. This way splunk config changes don't
+require a hubble restart.
+'''
+import os
+import yaml
+
+
+def splunkconfig():
+    '''
+    Walk the hubble.d/ directory and read in any .conf files using YAML. If
+    splunk config is found, place it in grains and return.
+    '''
+    configdir = os.path.join(os.path.dirname(__opts__['configfile']), 'hubble.d')
+    ret = {}
+    if not os.path.isdir(configdir):
+        return ret
+    try:
+        for root, dirs, files in os.walk(configdir):
+            for f in files:
+                if f.endswith('.conf'):
+                    fpath = os.path.join(root, fpath)
+                    try:
+                        with open(fpath, 'r') as fh:
+                            config = yaml.safe_load(fh)
+                        if config.get('hubblestack', {}).get('returner', {}).get('splunk'):
+                            ret = {'hubblestack': config['hubblestack']}
+                    except:
+                        pass
+    return ret

--- a/hubblestack/extmods/grains/splunkconfig.py
+++ b/hubblestack/extmods/grains/splunkconfig.py
@@ -29,4 +29,6 @@ def splunkconfig():
                             ret = {'hubblestack': config['hubblestack']}
                     except:
                         pass
+    except:
+        pass
     return ret

--- a/hubblestack/extmods/returners/splunk_nebula_return.py
+++ b/hubblestack/extmods/returners/splunk_nebula_return.py
@@ -191,7 +191,30 @@ def returner(ret):
 
 
 def _get_options():
-    if __salt__['config.get']('hubblestack:returner:splunk'):
+    if __salt__['grains.get']('hubblestack:returner:splunk'):
+        splunk_opts = []
+        returner_opts = __salt__['grains.get']('hubblestack:returner:splunk')
+        if not isinstance(returner_opts, list):
+            returner_opts = [returner_opts]
+        for opt in returner_opts:
+            processed = {}
+            processed['token'] = opt.get('token')
+            processed['indexer'] = opt.get('indexer')
+            processed['port'] = str(opt.get('port', '8088'))
+            processed['index'] = opt.get('index')
+            processed['custom_fields'] = opt.get('custom_fields', [])
+            processed['sourcetype'] = opt.get('sourcetype_nebula', 'hubble_osquery')
+            processed['add_query_to_sourcetype'] = opt.get('add_query_to_sourcetype', True)
+            processed['http_event_server_ssl'] = opt.get('hec_ssl', True)
+            processed['proxy'] = opt.get('proxy', {})
+            processed['timeout'] = opt.get('timeout', 9.05)
+            processed['http_event_collector_ssl_verify'] = opt.get('http_event_collector_ssl_verify', True)
+
+            if 'fallback_indexer' in opt and __grains__.get('ip_gw', None) is False:
+                processed['indexer'] = opt['fallback_indexer']
+            splunk_opts.append(processed)
+        return splunk_opts
+    elif __salt__['config.get']('hubblestack:returner:splunk'):
         splunk_opts = []
         returner_opts = __salt__['config.get']('hubblestack:returner:splunk')
         if not isinstance(returner_opts, list):

--- a/hubblestack/extmods/returners/splunk_nova_return.py
+++ b/hubblestack/extmods/returners/splunk_nova_return.py
@@ -292,7 +292,29 @@ def event_return(event):
 
 
 def _get_options():
-    if __salt__['config.get']('hubblestack:returner:splunk'):
+    if __salt__['grains.get']('hubblestack:returner:splunk'):
+        splunk_opts = []
+        returner_opts = __salt__['grains.get']('hubblestack:returner:splunk')
+        if not isinstance(returner_opts, list):
+            returner_opts = [returner_opts]
+        for opt in returner_opts:
+            processed = {}
+            processed['token'] = opt.get('token')
+            processed['indexer'] = opt.get('indexer')
+            processed['port'] = str(opt.get('port', '8088'))
+            processed['index'] = opt.get('index')
+            processed['custom_fields'] = opt.get('custom_fields', [])
+            processed['sourcetype'] = opt.get('sourcetype_nova', 'hubble_audit')
+            processed['http_event_server_ssl'] = opt.get('hec_ssl', True)
+            processed['proxy'] = opt.get('proxy', {})
+            processed['timeout'] = opt.get('timeout', 9.05)
+            processed['http_event_collector_ssl_verify'] = opt.get('http_event_collector_ssl_verify', True)
+
+            if 'fallback_indexer' in opt and __grains__.get('ip_gw', None) is False:
+                processed['indexer'] = opt['fallback_indexer']
+            splunk_opts.append(processed)
+        return splunk_opts
+    elif __salt__['config.get']('hubblestack:returner:splunk'):
         splunk_opts = []
         returner_opts = __salt__['config.get']('hubblestack:returner:splunk')
         if not isinstance(returner_opts, list):

--- a/hubblestack/extmods/returners/splunk_pulsar_return.py
+++ b/hubblestack/extmods/returners/splunk_pulsar_return.py
@@ -316,7 +316,28 @@ def _dedupList(l):
 
 
 def _get_options():
-    if __salt__['config.get']('hubblestack:returner:splunk'):
+    if __salt__['grains.get']('hubblestack:returner:splunk'):
+        splunk_opts = []
+        returner_opts = __salt__['grains.get']('hubblestack:returner:splunk')
+        if not isinstance(returner_opts, list):
+            returner_opts = [returner_opts]
+        for opt in returner_opts:
+            processed = {}
+            processed['token'] = opt.get('token')
+            processed['indexer'] = opt.get('indexer')
+            processed['port'] = str(opt.get('port', '8088'))
+            processed['index'] = opt.get('index')
+            processed['custom_fields'] = opt.get('custom_fields', [])
+            processed['sourcetype'] = opt.get('sourcetype_pulsar', 'hubble_fim')
+            processed['http_event_server_ssl'] = opt.get('hec_ssl', True)
+            processed['proxy'] = opt.get('proxy', {})
+            processed['timeout'] = opt.get('timeout', 9.05)
+            processed['http_event_collector_ssl_verify'] = opt.get('http_event_collector_ssl_verify', True)
+            if 'fallback_indexer' in opt and __grains__.get('ip_gw', None) is False:
+                processed['indexer'] = opt['fallback_indexer']
+            splunk_opts.append(processed)
+        return splunk_opts
+    elif __salt__['config.get']('hubblestack:returner:splunk'):
         splunk_opts = []
         returner_opts = __salt__['config.get']('hubblestack:returner:splunk')
         if not isinstance(returner_opts, list):

--- a/hubblestack/splunklogging.py
+++ b/hubblestack/splunklogging.py
@@ -197,7 +197,27 @@ class SplunkHandler(logging.Handler):
 
 
 def _get_options():
-    if __salt__['config.get']('hubblestack:returner:splunk'):
+    if __salt__['grains.get']('hubblestack:returner:splunk'):
+        splunk_opts = []
+        returner_opts = __salt__['grains.get']('hubblestack:returner:splunk')
+        if not isinstance(returner_opts, list):
+            returner_opts = [returner_opts]
+        for opt in returner_opts:
+            processed = {}
+            processed['token'] = opt.get('token')
+            processed['indexer'] = opt.get('indexer')
+            processed['port'] = str(opt.get('port', '8088'))
+            processed['index'] = opt.get('index')
+            processed['custom_fields'] = opt.get('custom_fields', [])
+            processed['sourcetype'] = opt.get('sourcetype_log', 'hubble_log')
+            processed['http_event_server_ssl'] = opt.get('hec_ssl', True)
+            processed['proxy'] = opt.get('proxy', {})
+            processed['timeout'] = opt.get('timeout', 9.05)
+            processed['index_extracted_fields'] = opt.get('index_extracted_fields', [])
+            processed['http_event_collector_ssl_verify'] = opt.get('http_event_collector_ssl_verify', True)
+            splunk_opts.append(processed)
+        return splunk_opts
+    elif __salt__['config.get']('hubblestack:returner:splunk'):
         splunk_opts = []
         returner_opts = __salt__['config.get']('hubblestack:returner:splunk')
         if not isinstance(returner_opts, list):


### PR DESCRIPTION
Also set up the splunk returners to use this config over __opts__ if it
is present. This allows for splunk config to be updated without a hubble
restart. Note that these changes should have no effect on
splunklogging.py because config is only processed on startup, but I made
the changes anyway for consistency (for when we DRY later)