### PR TITLE
Add a few fqdn/ip-related grains changes

### DIFF
--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -569,6 +569,11 @@ def refresh_grains(initial=False):
     global __returners__
     global __context__
 
+    persist = {}
+    for grain in __opts__.get('grains_persist', []):
+        if grain in __grains__:
+            persist[grain] = __grains__[grain]
+
     if initial:
         __context__ = {}
     if 'grains' in __opts__:
@@ -576,6 +581,7 @@ def refresh_grains(initial=False):
     if 'pillar' in __opts__:
         __opts__.pop('pillar')
     __grains__ = salt.loader.grains(__opts__)
+    __grains__.update(persist)
     __grains__['session_uuid'] = SESSION_UUID
     __opts__['hubble_uuid'] = __grains__.get('hubble_uuid', None)
     __pillar__ = {}

--- a/hubblestack/extmods/grains/fqdn.py
+++ b/hubblestack/extmods/grains/fqdn.py
@@ -65,12 +65,12 @@ def dest_ip():
     # Use .*0 if present
     for interface, ips in filtered_interfaces.iteritems():
         if '0' in interface:
-            for ip in ips
+            for ip in ips:
                 if ip != '127.0.0.1':
                     return {'local_ip4', ip}
     # Use whatever isn't 127.0.0.1
     for interface, ips in filtered_interfaces.iteritems():
-        for ip in ips
+        for ip in ips:
             if ip != '127.0.0.1':
                 return {'local_ip4', ip}
     # Give up

--- a/hubblestack/extmods/grains/fqdn.py
+++ b/hubblestack/extmods/grains/fqdn.py
@@ -47,7 +47,7 @@ def dest_ip():
             if interface and interface in interfaces and interfaces[interface]:
                 for ip in interfaces[interface]:
                     if ip != '127.0.0.1':
-                        return {'local_ip4', ip}
+                        return {'local_ip4': ip}
     except:
         pass
 
@@ -64,17 +64,17 @@ def dest_ip():
     if 'eth0' in filtered_interfaces:
         for ip in filtered_interfaces['eth0']:
             if ip != '127.0.0.1':
-                return {'local_ip4', ip}
+                return {'local_ip4': ip}
     # Use .*0 if present
     for interface, ips in filtered_interfaces.iteritems():
         if '0' in interface:
             for ip in ips:
                 if ip != '127.0.0.1':
-                    return {'local_ip4', ip}
+                    return {'local_ip4': ip}
     # Use whatever isn't 127.0.0.1
     for interface, ips in filtered_interfaces.iteritems():
         for ip in ips:
             if ip != '127.0.0.1':
-                return {'local_ip4', ip}
+                return {'local_ip4': ip}
     # Give up
     return {'local_ip4', ''}

--- a/hubblestack/extmods/grains/fqdn.py
+++ b/hubblestack/extmods/grains/fqdn.py
@@ -35,7 +35,7 @@ def dest_ip():
     various IPs due to round robin DNS.
     '''
     grains = {}
-    interfaces = salt.grains.core.ip4_interfaces()
+    interfaces = salt.grains.core.ip4_interfaces()['ip4_interfaces']
     try:
         ret = __salt__['cmd.run_all']('ip route show to 0/0')
         if ret['retcode'] == 0:

--- a/hubblestack/extmods/grains/fqdn.py
+++ b/hubblestack/extmods/grains/fqdn.py
@@ -8,8 +8,8 @@ import salt.utils
 import salt.utils.platform
 import socket
 
-__salt__ = {'cmd.run': salt.modules.cmdmod._run_quiet}
-__salt__ = {'cmd.run_all': salt.modules.cmdmod.run_all}
+__salt__ = {'cmd.run': salt.modules.cmdmod._run_quiet,
+            'cmd.run_all': salt.modules.cmdmod.run_all}
 
 
 def fqdn():
@@ -36,17 +36,20 @@ def dest_ip():
     '''
     grains = {}
     interfaces = salt.grains.core.ip4_interfaces()
-    ret = __salt__['cmd.run_all']('ip route show to 0/0')
-    if ret['retcode'] == 0:
-        interface = None
-        try:
-            interface = ret['stdout'].split(' ')[4]
-        except:
-            pass
-        if interface and interface in interfaces and interfaces[interface]:
-            for ip in interfaces[interface]:
-                if ip != '127.0.0.1':
-                    return {'local_ip4', ip}
+    try:
+        ret = __salt__['cmd.run_all']('ip route show to 0/0')
+        if ret['retcode'] == 0:
+            interface = None
+            try:
+                interface = ret['stdout'].split(' ')[4]
+            except:
+                pass
+            if interface and interface in interfaces and interfaces[interface]:
+                for ip in interfaces[interface]:
+                    if ip != '127.0.0.1':
+                        return {'local_ip4', ip}
+    except:
+        pass
 
     # Fallback to "best guess"
     filtered_interfaces = {}

--- a/hubblestack/extmods/grains/fqdn.py
+++ b/hubblestack/extmods/grains/fqdn.py
@@ -2,12 +2,14 @@
 '''
 Custom grains around fqdn
 '''
+import salt.grains.core
 import salt.modules.cmdmod
 import salt.utils
 import salt.utils.platform
 import socket
 
 __salt__ = {'cmd.run': salt.modules.cmdmod._run_quiet}
+__salt__ = {'cmd.run_all': salt.modules.cmdmod.run_all}
 
 
 def fqdn():
@@ -19,5 +21,57 @@ def fqdn():
     local_fqdn = None
     if not salt.utils.platform.is_windows():
         local_fqdn = __salt__['cmd.run']('hostname --fqdn')
-    grains['local_fqdn'] = local_fqdn if local_fqdn else socket.getfqdn()
+    if not local_fqdn or 'hostname: ' in local_fqdn:
+        grains['local_fqdn'] = ''
+    else:
+        grains['local_fqdn'] = local_fqdn
     return grains
+
+
+def dest_ip():
+    '''
+    Generate a best-guess at the IP on the interface that is the default
+    gateway for the host. This is because the current methods can result in
+    various IPs due to round robin DNS.
+    '''
+    grains = {}
+    interfaces = salt.grains.core.ip4_interfaces()
+    ret = __salt__['cmd.run_all']('ip route show to 0/0')
+    if ret['retcode'] == 0:
+        interface = None
+        try:
+            interface = ret['stdout'].split(' ')[4]
+        except:
+            pass
+        if interface and interface in interfaces and interfaces[interface]:
+            for ip in interfaces[interface]:
+                if ip != '127.0.0.1':
+                    return {'local_ip4', ip}
+
+    # Fallback to "best guess"
+    filtered_interfaces = {}
+    # filter out empty, lo, and docker0
+    for interface, ips in interfaces.iteritems():
+        if not ips:
+            continue
+        if interface in ('lo', 'docker0'):
+            continue
+        filtered_interfaces[interface] = ips
+    # Use eth0 if present
+    if 'eth0' in filtered_interfaces:
+        for ip in filtered_interfaces['eth0']:
+            if ip != '127.0.0.1':
+                return {'local_ip4', ip}
+    # Use .*0 if present
+    for interface, ips in filtered_interfaces.iteritems():
+        if '0' in interface:
+            for ip in ips
+                if ip != '127.0.0.1':
+                    return {'local_ip4', ip}
+    # Use whatever isn't 127.0.0.1
+    for interface, ips in filtered_interfaces.iteritems():
+        for ip in ips
+            if ip != '127.0.0.1':
+                return {'local_ip4', ip}
+    # Give up
+    return {'local_ip4', ''}

--- a/hubblestack/extmods/returners/splunk_nebula_return.py
+++ b/hubblestack/extmods/returners/splunk_nebula_return.py
@@ -98,7 +98,9 @@ def returner(ret):
             # Sometimes fqdn is blank. If it is, replace it with minion_id
             fqdn = fqdn if fqdn else minion_id
             try:
-                fqdn_ip4 = __grains__['fqdn_ip4'][0]
+                fqdn_ip4 = __grains__.get('local_ip4')
+                if not fqdn_ip4:
+                    fqdn_ip4 = __grains__['fqdn_ip4'][0]
             except IndexError:
                 try:
                     fqdn_ip4 = __grains__['ipv4'][0]

--- a/hubblestack/extmods/returners/splunk_nova_return.py
+++ b/hubblestack/extmods/returners/splunk_nova_return.py
@@ -96,7 +96,9 @@ def returner(ret):
             fqdn = fqdn if fqdn else minion_id
             master = __grains__['master']
             try:
-                fqdn_ip4 = __grains__['fqdn_ip4'][0]
+                fqdn_ip4 = __grains__.get('local_ip4')
+                if not fqdn_ip4:
+                    fqdn_ip4 = __grains__['fqdn_ip4'][0]
             except IndexError:
                 try:
                     fqdn_ip4 = __grains__['ipv4'][0]

--- a/hubblestack/extmods/returners/splunk_pulsar_return.py
+++ b/hubblestack/extmods/returners/splunk_pulsar_return.py
@@ -106,7 +106,9 @@ def returner(ret):
             fqdn = fqdn if fqdn else minion_id
             master = __grains__['master']
             try:
-                fqdn_ip4 = __grains__['fqdn_ip4'][0]
+                fqdn_ip4 = __grains__.get('local_ip4')
+                if not fqdn_ip4:
+                    fqdn_ip4 = __grains__['fqdn_ip4'][0]
             except IndexError:
                 try:
                     fqdn_ip4 = __grains__['ipv4'][0]

--- a/hubblestack/splunklogging.py
+++ b/hubblestack/splunklogging.py
@@ -95,7 +95,9 @@ class SplunkHandler(logging.Handler):
             # Sometimes fqdn is blank. If it is, replace it with minion_id
             fqdn = fqdn if fqdn else minion_id
             try:
-                fqdn_ip4 = __grains__['fqdn_ip4'][0]
+                fqdn_ip4 = __grains__.get('local_ip4')
+                if not fqdn_ip4:
+                    fqdn_ip4 = __grains__['fqdn_ip4'][0]
             except IndexError:
                 try:
                     fqdn_ip4 = __grains__['ipv4'][0]


### PR DESCRIPTION
* Adds `grains_persist` config for list of grains to persist across
refreshes
* Adds 'local_ip4' grain that best-guesses the ip address of the default
gateway interface
* Adds error filtering to local_fqdn grain