### PR TITLE
Adding --buildinfo arguement to hubble

### DIFF
--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -637,6 +637,9 @@ def parse_args():
     parser.add_argument('--version',
                         action='store_true',
                         help='Show version information')
+    parser.add_argument('--buildinfo',
+                        action='store_true',
+                        help='Show build information')
     parser.add_argument('function',
                         nargs='?',
                         default=None,

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -58,6 +58,15 @@ def run():
         clean_up_process(None, None)
         sys.exit(0)
 
+    if __opts__['buildinfo']:
+        try:
+            from hubblestack import __buildinfo__
+        except ImportError:
+            __buildinfo__ = 'NOT SET'
+        print(__buildinfo__)
+        clean_up_process(None, None)
+        sys.exit(0)
+
     if __opts__['daemonize']:
         # before becoming a daemon, check for other procs and possibly send
         # then a signal 15 (otherwise refuse to run)

--- a/pkg/dev/centos7/Dockerfile
+++ b/pkg/dev/centos7/Dockerfile
@@ -143,7 +143,7 @@ RUN mkdir /data
 VOLUME /data
 WORKDIR /hubble_build
 ENTRYPOINT [ "/bin/bash", "-o", "xtrace", "-c" ]
-CMD [ "if [ -f /data/hubble_buildinfo ] ; then echo "" >> /hubble_build/hubblestack/__init__.py ; cat /data/hubble_buildinfo >> /hubble_build/hubblestack/__init__.py; fi \
+CMD [ "if [ -f /data/hubble_buildinfo ] ; then echo \"\" >> /hubble_build/hubblestack/__init__.py ; cat /data/hubble_buildinfo >> /hubble_build/hubblestack/__init__.py; fi \
     && pyinstaller --onedir --noconfirm --log-level ${_BINARY_LOG_LEVEL} --additional-hooks-dir=${_HOOK_DIR} --runtime-hook=pkg/pyinstaller-runtimehooks/pathopthubble.py hubble.py \
     && cp /hubble_build/conf/osquery.conf /etc/osquery/ \
     && cp /hubble_build/conf/osquery.flags /etc/osquery/ \

--- a/pkg/dev/centos7/Dockerfile
+++ b/pkg/dev/centos7/Dockerfile
@@ -143,7 +143,8 @@ RUN mkdir /data
 VOLUME /data
 WORKDIR /hubble_build
 ENTRYPOINT [ "/bin/bash", "-o", "xtrace", "-c" ]
-CMD [ "pyinstaller --onedir --noconfirm --log-level ${_BINARY_LOG_LEVEL} --additional-hooks-dir=${_HOOK_DIR} --runtime-hook=pkg/pyinstaller-runtimehooks/pathopthubble.py hubble.py \
+CMD [ "if [ -f /data/hubble_buildinfo ] ; then echo "" >> /hubble_build/hubblestack/__init__.py ; cat /data/hubble_buildinfo >> /hubble_build/hubblestack/__init__.py; fi \
+    && pyinstaller --onedir --noconfirm --log-level ${_BINARY_LOG_LEVEL} --additional-hooks-dir=${_HOOK_DIR} --runtime-hook=pkg/pyinstaller-runtimehooks/pathopthubble.py hubble.py \
     && cp /hubble_build/conf/osquery.conf /etc/osquery/ \
     && cp /hubble_build/conf/osquery.flags /etc/osquery/ \
 # hubble default configuration file


### PR DESCRIPTION
With these changes, we can add build info to a hubble build. We simply need to place file named "hubble_buildinfo " in the directory which is to be mounted as "/data"

The file should contain ```__buildinfo__``` object in standard python format. For example:
```
[root@ip-10-36-1-20 tmp]# cat hubble_buildinfo 
__buildinfo__ = { 'version' : '1.1.26',
                  'creator' : 'yash',
                  'date' : '06.04.2018',
                  'branch' : 'develop',
                 'flavor' : 'dme' }
```


If this file is found in /data , it's contents are appended to ```hubblestack/__init__.py``` file. The resultant file looks something like this:
```
[root@ip-10-36-1-20 centos7]# cat /opt/hubble/hubble-libs/hubblestack/__init__.py 
__version__ = "2.3.4-2-8-g6e5c919"

__buildinfo__ = { 'version' : '1.1.26',
                  'creator' : 'yash',
                  'date' : '06.04.2018',
                  'branch' : 'develop',
                 'flavor' : 'dme' }
[root@ip-10-36-1-20 centos7]# 
```


If everything goes right, this is the output of "hubble --buildinfo" command:
```
[root@ip-10-36-1-20 centos7]# hubble --buildinfo
{'date': '06.04.2018', 'flavor': 'dme', 'version': '1.1.26', 'branch': 'develop', 'creator': 'yash'}
```

In case you don't provide "hubble_buildinfo" file in /data, you get this:
```
[root@ip-10-36-1-20 centos7]# hubble --buildinfo
NOT SET
```