### PR TITLE
Hec exception handlers

### DIFF
--- a/hubblestack/extmods/returners/splunk_nebula_return.py
+++ b/hubblestack/extmods/returners/splunk_nebula_return.py
@@ -382,6 +382,5 @@ class http_event_collector:
                     server[1] = False
                 except Exception as e:
                     log.error('Request to splunk threw an error: {0}'.format(e))
-
             self.batchEvents = []
             self.currentByteLength = 0

--- a/hubblestack/extmods/returners/splunk_nebula_return.py
+++ b/hubblestack/extmods/returners/splunk_nebula_return.py
@@ -371,10 +371,17 @@ class http_event_collector:
                     r.raise_for_status()
                     server[1] = True
                     break
-                except requests.exceptions.RequestException:
-                    log.info('Request to splunk server "%s" failed. Marking as bad.' % server[0])
+                except requests.exceptions.Timeout as timeout_err:
+                    log.info('Connection timed out to splunk server {0}: {1}'.format(unicode(server[0]), unicode(timeout_err)))
+                except requests.exceptions.ConnectionError as connect_err:
+                    log.info('Error establishing connection to splunk server {0}: {1}'.format(unicode(server[0]), unicode(connect_err)))
+                except requests.exceptions.HTTPError as http_err:
+                    log.info('HTTP Error received while connecting to splunk server {0}: {1}'.format(unicode(server[0]), unicode(http_err)))
+                except requests.exceptions.RequestException as gen_err:
+                    log.info('Request to splunk server {0} failed: {1}'.format(unicode(server[0]), unicode(gen_err)))
                     server[1] = False
                 except Exception as e:
                     log.error('Request to splunk threw an error: {0}'.format(e))
+
             self.batchEvents = []
             self.currentByteLength = 0


### PR DESCRIPTION
Example of exception log:

2018-06-14 16:32:04 [salt.loaded.ext.returner.splunk_nova_return][INFO    ] Error establishing connection to splunk server https://bad-host:8088/services/collector/event failed: ('Connection aborted.', gaierror(-2, 'Name or service not known')

Fixes #403 