### PR TITLE
dev dockerfiles: minor version bumps for osquery and deps

### DIFF
--- a/pkg/dev/amazonlinux2016.09/Dockerfile
+++ b/pkg/dev/amazonlinux2016.09/Dockerfile
@@ -17,7 +17,7 @@ RUN mkdir -p /etc/osquery /var/log/osquery /etc/hubble/hubble.d /opt/hubble /opt
 #osquery should be built first since requirements for other packages can interfere with osquery dependencies
 #to build, osquery scripts want sudo and a user to sudo with.
 #to pin to a different version change the following envirnment variable
-ENV OSQUERY_SRC_VERSION=a338c86170947344ddd23e80e4e3f636ff8eb5ab
+ENV OSQUERY_SRC_VERSION=1ed050147ac88a7314c172e15e86f8886206dd06
 ENV OSQUERY_BUILD_USER=osquerybuilder
 ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
 RUN yum -y install git make python ruby sudo which
@@ -58,7 +58,7 @@ RUN yum -y install  \
 #install libcurl to avoid depending on host version
 #requires autoconf libtool libssh2-devel zlib-devel autoconf
 ENV LIBCURL_SRC_URL=https://github.com/curl/curl.git
-ENV LIBCURL_SRC_VERSION=curl-7_60_0
+ENV LIBCURL_SRC_VERSION=curl-7_61_0
 ENV LIBCURL_TEMP=/tmp/libcurl
 ENV PATH=/opt/hubble/bin/:/opt/hubble/include:/opt/hubble/lib:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 RUN mkdir -p "$LIBCURL_TEMP" \
@@ -75,7 +75,7 @@ RUN mkdir -p "$LIBCURL_TEMP" \
 #install git so that git package won't be a package dependency
 #requires make git libcurl-devel autoconf zlib-devel gcc
 ENV GIT_SRC_URL=https://github.com/git/git.git
-ENV GIT_SRC_VERSION=v2.16.3
+ENV GIT_SRC_VERSION=v2.16.4
 ENV GITTEMP=/tmp/gittemp
 RUN mkdir -p "$GITTEMP" \
  && cd "$GITTEMP" \
@@ -96,10 +96,10 @@ RUN rm /opt/hubble/bin/curl* \
 
 #libgit2 install start
 #must precede pyinstaller requirements
-ENV LIBGIT2_SRC_URL=https://github.com/libgit2/libgit2/archive/v0.26.3.tar.gz
+ENV LIBGIT2_SRC_URL=https://github.com/libgit2/libgit2/archive/v0.26.5.tar.gz
 #it turns out github provided release files can change. so even though the code hopefully hasn't changed, the hash has.
-ENV LIBGIT2_SRC_SHA256=0da4e211dfb63c22e5f43f2a4a5373e86a140afa88a25ca6ba3cc2cae58263d2
-ENV LIBGIT2_SRC_VERSION=0.26.3
+ENV LIBGIT2_SRC_SHA256=52e28a5166564bc4365a2e4112f5e5c6e334708dbf13596241b2fd34efc1b0a9
+ENV LIBGIT2_SRC_VERSION=0.26.5
 ENV LIBGIT2TEMP=/tmp/libgit2temp
 RUN mkdir -p "$LIBGIT2TEMP" \
  && cd "$LIBGIT2TEMP" \

--- a/pkg/dev/amazonlinux2016.09/pyinstaller-requirements.txt
+++ b/pkg/dev/amazonlinux2016.09/pyinstaller-requirements.txt
@@ -1,4 +1,4 @@
-pyinstaller==3.3.1 # currently 3.2.1 version is not supported because of botocore exception
+pyinstaller==3.3.1
 Crypto
 pyopenssl>=16.2.0
 argparse

--- a/pkg/dev/centos6/Dockerfile
+++ b/pkg/dev/centos6/Dockerfile
@@ -17,7 +17,7 @@ RUN mkdir -p /etc/osquery /var/log/osquery /etc/hubble/hubble.d /opt/hubble /opt
 #osquery should be built first since requirements for other packages can interfere with osquery dependencies
 #to build, osquery scripts want sudo and a user to sudo with.
 #to pin to a different version change the following envirnment variable
-ENV OSQUERY_SRC_VERSION=a338c86170947344ddd23e80e4e3f636ff8eb5ab
+ENV OSQUERY_SRC_VERSION=1ed050147ac88a7314c172e15e86f8886206dd06
 ENV OSQUERY_BUILD_USER=osquerybuilder
 ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
 RUN yum -y install xz git make python ruby sudo which python-argparse
@@ -57,7 +57,7 @@ RUN yum -y install  \
 #install libcurl to avoid depending on host version
 #requires autoconf libtool libssh2-devel zlib-devel autoconf
 ENV LIBCURL_SRC_URL=https://github.com/curl/curl.git
-ENV LIBCURL_SRC_VERSION=curl-7_60_0
+ENV LIBCURL_SRC_VERSION=curl-7_61_0
 ENV LIBCURL_TEMP=/tmp/libcurl
 ENV PATH=/opt/hubble/bin/:/opt/hubble/include:/opt/hubble/lib:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 RUN mkdir -p "$LIBCURL_TEMP" \
@@ -74,7 +74,7 @@ RUN mkdir -p "$LIBCURL_TEMP" \
 #install git so that git package won't be a package dependency
 #requires make git libcurl-devel autoconf zlib-devel gcc
 ENV GIT_SRC_URL=https://github.com/git/git.git
-ENV GIT_SRC_VERSION=v2.16.3
+ENV GIT_SRC_VERSION=v2.16.4
 ENV GITTEMP=/tmp/gittemp
 RUN mkdir -p "$GITTEMP" \
  && cd "$GITTEMP" \
@@ -95,10 +95,10 @@ RUN rm /opt/hubble/bin/curl* \
 
 #libgit2 install start
 #must precede pyinstaller requirements
-ENV LIBGIT2_SRC_URL=https://github.com/libgit2/libgit2/archive/v0.26.3.tar.gz
+ENV LIBGIT2_SRC_URL=https://github.com/libgit2/libgit2/archive/v0.26.5.tar.gz
 #it turns out github provided release files can change. so even though the code hopefully hasn't changed, the hash has.
-ENV LIBGIT2_SRC_SHA256=0da4e211dfb63c22e5f43f2a4a5373e86a140afa88a25ca6ba3cc2cae58263d2
-ENV LIBGIT2_SRC_VERSION=0.26.3
+ENV LIBGIT2_SRC_SHA256=52e28a5166564bc4365a2e4112f5e5c6e334708dbf13596241b2fd34efc1b0a9
+ENV LIBGIT2_SRC_VERSION=0.26.5
 ENV LIBGIT2TEMP=/tmp/libgit2temp
 RUN mkdir -p "$LIBGIT2TEMP" \
  && cd "$LIBGIT2TEMP" \

--- a/pkg/dev/centos6/pyinstaller-requirements.txt
+++ b/pkg/dev/centos6/pyinstaller-requirements.txt
@@ -1,4 +1,4 @@
-pyinstaller==3.3.1 # currently 3.2.1 version is not supported because of botocore exception
+pyinstaller==3.3.1
 Crypto
 pyopenssl>=16.2.0
 argparse

--- a/pkg/dev/coreos/Dockerfile
+++ b/pkg/dev/coreos/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update     \
 RUN mkdir -p /etc/osquery /var/log/osquery /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/osquery
 
 #patchelf build start
-#must precent osquery as at the moment, osquery won't build without patchelf
+#must precede osquery as at the moment, osquery won't build without patchelf
 ENV PATCHELF_GIT_URL=https://github.com/NixOS/patchelf.git
 ENV PATCHELF_TEMP=/tmp/patchelf
 RUN apt-get -y install autoconf git make g++
@@ -33,7 +33,7 @@ RUN mkdir -p "$PATCHELF_TEMP" \
 #osquery should be built first since requirements for other packages can interfere with osquery dependencies
 #to build, osquery scripts want sudo and a user to sudo with.
 #to pin to a different version change the following envirnment variable
-ENV OSQUERY_SRC_VERSION=a338c86170947344ddd23e80e4e3f636ff8eb5ab
+ENV OSQUERY_SRC_VERSION=1ed050147ac88a7314c172e15e86f8886206dd06
 ENV OSQUERY_BUILD_USER=osquerybuilder
 ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
 RUN apt-get -y install git make python ruby sudo curl
@@ -75,7 +75,7 @@ RUN apt-get -y install  \
 #install libcurl to avoid depending on host version
 #requires autoconf libtool libssh2-devel zlib-devel autoconf
 ENV LIBCURL_SRC_URL=https://github.com/curl/curl.git
-ENV LIBCURL_SRC_VERSION=curl-7_60_0
+ENV LIBCURL_SRC_VERSION=curl-7_61_0
 ENV LIBCURL_TEMP=/tmp/libcurl
 ENV PATH=/opt/hubble/bin/:/opt/hubble/include:/opt/hubble/lib:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 RUN mkdir -p "$LIBCURL_TEMP" \
@@ -92,7 +92,7 @@ RUN mkdir -p "$LIBCURL_TEMP" \
 #install git so that git package won't be a package dependency
 #requires make git libcurl-devel autoconf zlib-devel gcc
 ENV GIT_SRC_URL=https://github.com/git/git.git
-ENV GIT_SRC_VERSION=v2.16.3
+ENV GIT_SRC_VERSION=v2.16.4
 ENV GITTEMP=/tmp/gittemp
 RUN mkdir -p "$GITTEMP" \
  && cd "$GITTEMP" \
@@ -113,10 +113,10 @@ RUN rm /opt/hubble/bin/curl* \
 
 #libgit2 install start
 #must precede pyinstaller requirements
-ENV LIBGIT2_SRC_URL=https://github.com/libgit2/libgit2/archive/v0.26.3.tar.gz
+ENV LIBGIT2_SRC_URL=https://github.com/libgit2/libgit2/archive/v0.26.5.tar.gz
 #it turns out github provided release files can change. so even though the code hopefully hasn't changed, the hash has.
-ENV LIBGIT2_SRC_SHA256=0da4e211dfb63c22e5f43f2a4a5373e86a140afa88a25ca6ba3cc2cae58263d2
-ENV LIBGIT2_SRC_VERSION=0.26.3
+ENV LIBGIT2_SRC_SHA256=52e28a5166564bc4365a2e4112f5e5c6e334708dbf13596241b2fd34efc1b0a9
+ENV LIBGIT2_SRC_VERSION=0.26.5
 ENV LIBGIT2TEMP=/tmp/libgit2temp
 RUN mkdir -p "$LIBGIT2TEMP" \
  && cd "$LIBGIT2TEMP" \

--- a/pkg/dev/coreos/pyinstaller-requirements.txt
+++ b/pkg/dev/coreos/pyinstaller-requirements.txt
@@ -1,4 +1,4 @@
-pyinstaller==3.2 # currently 3.2.1 version is not supported because of botocore exception
+pyinstaller==3.3.1
 Crypto
 pyopenssl>=16.2.0
 argparse

--- a/pkg/dev/debian7/Dockerfile
+++ b/pkg/dev/debian7/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update     \
 RUN mkdir -p /etc/osquery /var/log/osquery /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/osquery
 
 #patchelf build start
-#must precent osquery as at the moment, osquery won't build without patchelf
+#must precede osquery as at the moment, osquery won't build without patchelf
 ENV PATCHELF_GIT_URL=https://github.com/NixOS/patchelf.git
 ENV PATCHELF_TEMP=/tmp/patchelf
 RUN apt-get -y install autoconf git make g++
@@ -33,7 +33,7 @@ RUN mkdir -p "$PATCHELF_TEMP" \
 #osquery should be built first since requirements for other packages can interfere with osquery dependencies
 #to build, osquery scripts want sudo and a user to sudo with.
 #to pin to a different version change the following envirnment variable
-ENV OSQUERY_SRC_VERSION=a338c86170947344ddd23e80e4e3f636ff8eb5ab
+ENV OSQUERY_SRC_VERSION=1ed050147ac88a7314c172e15e86f8886206dd06
 ENV OSQUERY_BUILD_USER=osquerybuilder
 ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
 RUN apt-get -y install git make python ruby sudo locales curl
@@ -95,7 +95,7 @@ RUN mkdir -p "$CMAKE_TEMP" \
 #install libcurl to avoid depending on host version
 #requires autoconf libtool libssh2-devel zlib-devel autoconf
 ENV LIBCURL_SRC_URL=https://github.com/curl/curl.git
-ENV LIBCURL_SRC_VERSION=curl-7_60_0
+ENV LIBCURL_SRC_VERSION=curl-7_61_0
 ENV LIBCURL_TEMP=/tmp/libcurl
 ENV PATH=/opt/hubble/bin/:/opt/hubble/include:/opt/hubble/lib:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 RUN mkdir -p "$LIBCURL_TEMP" \
@@ -112,7 +112,7 @@ RUN mkdir -p "$LIBCURL_TEMP" \
 #install git so that git package won't be a package dependency
 #requires make git libcurl-devel autoconf zlib-devel gcc
 ENV GIT_SRC_URL=https://github.com/git/git.git
-ENV GIT_SRC_VERSION=v2.16.3
+ENV GIT_SRC_VERSION=v2.16.4
 ENV GITTEMP=/tmp/gittemp
 RUN mkdir -p "$GITTEMP" \
  && cd "$GITTEMP" \
@@ -134,10 +134,10 @@ RUN rm /opt/hubble/bin/curl* \
 #libgit2 install start
 #must be preceded by cmake install
 #must precede pyinstaller requirements
-ENV LIBGIT2_SRC_URL=https://github.com/libgit2/libgit2/archive/v0.26.3.tar.gz
+ENV LIBGIT2_SRC_URL=https://github.com/libgit2/libgit2/archive/v0.26.5.tar.gz
 #it turns out github provided release files can change. so even though the code hopefully hasn't changed, the hash has.
-ENV LIBGIT2_SRC_SHA256=0da4e211dfb63c22e5f43f2a4a5373e86a140afa88a25ca6ba3cc2cae58263d2
-ENV LIBGIT2_SRC_VERSION=0.26.3
+ENV LIBGIT2_SRC_SHA256=52e28a5166564bc4365a2e4112f5e5c6e334708dbf13596241b2fd34efc1b0a9
+ENV LIBGIT2_SRC_VERSION=0.26.5
 ENV LIBGIT2TEMP=/tmp/libgit2temp
 RUN mkdir -p "$LIBGIT2TEMP" \
  && cd "$LIBGIT2TEMP" \
@@ -166,7 +166,7 @@ RUN apt-get install -y ruby ruby-dev rubygems gcc make \
 #use the following variables to choose the version of hubble
 ARG HUBBLE_CHECKOUT=develop
 ARG HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
-ENV HUBBLE_VERSION=2.3.4
+ENV HUBBLE_VERSION=2.3.4_develop
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_SRC_PATH=/hubble_src
 ENV _HOOK_DIR="./pkg/"

--- a/pkg/dev/debian7/pyinstaller-requirements.txt
+++ b/pkg/dev/debian7/pyinstaller-requirements.txt
@@ -1,4 +1,5 @@
-pyinstaller==3.2 # currently 3.2.1 version is not supported because of botocore exception
+pyinstaller==3.3.1
+Tornado>=4.0.0,<5.0.0
 Crypto
 pyopenssl>=16.2.0
 argparse

--- a/pkg/dev/debian8/Dockerfile
+++ b/pkg/dev/debian8/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update     \
 RUN mkdir -p /etc/osquery /var/log/osquery /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/osquery
 
 #patchelf build start
-#must precent osquery as at the moment, osquery won't build without patchelf
+#must precede osquery as at the moment, osquery won't build without patchelf
 ENV PATCHELF_GIT_URL=https://github.com/NixOS/patchelf.git
 ENV PATCHELF_TEMP=/tmp/patchelf
 RUN apt-get -y install autoconf git make g++
@@ -33,7 +33,7 @@ RUN mkdir -p "$PATCHELF_TEMP" \
 #osquery should be built first since requirements for other packages can interfere with osquery dependencies
 #to build, osquery scripts want sudo and a user to sudo with.
 #to pin to a different version change the following envirnment variable
-ENV OSQUERY_SRC_VERSION=a338c86170947344ddd23e80e4e3f636ff8eb5ab
+ENV OSQUERY_SRC_VERSION=1ed050147ac88a7314c172e15e86f8886206dd06
 ENV OSQUERY_BUILD_USER=osquerybuilder
 ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
 RUN apt-get -y install git make python ruby sudo locales curl xz-utils
@@ -77,7 +77,7 @@ RUN apt-get -y install  \
 #install libcurl to avoid depending on host version
 #requires autoconf libtool libssh2-devel zlib-devel autoconf
 ENV LIBCURL_SRC_URL=https://github.com/curl/curl.git
-ENV LIBCURL_SRC_VERSION=curl-7_60_0
+ENV LIBCURL_SRC_VERSION=curl-7_61_0
 ENV LIBCURL_TEMP=/tmp/libcurl
 ENV PATH=/opt/hubble/bin/:/opt/hubble/include:/opt/hubble/lib:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 RUN mkdir -p "$LIBCURL_TEMP" \
@@ -94,7 +94,7 @@ RUN mkdir -p "$LIBCURL_TEMP" \
 #install git so that git package won't be a package dependency
 #requires make git libcurl-devel autoconf zlib-devel gcc
 ENV GIT_SRC_URL=https://github.com/git/git.git
-ENV GIT_SRC_VERSION=v2.16.3
+ENV GIT_SRC_VERSION=v2.16.4
 ENV GITTEMP=/tmp/gittemp
 RUN mkdir -p "$GITTEMP" \
  && cd "$GITTEMP" \
@@ -115,10 +115,10 @@ RUN rm /opt/hubble/bin/curl* \
 
 #libgit2 install start
 #must precede pyinstaller requirements
-ENV LIBGIT2_SRC_URL=https://github.com/libgit2/libgit2/archive/v0.26.3.tar.gz
+ENV LIBGIT2_SRC_URL=https://github.com/libgit2/libgit2/archive/v0.26.5.tar.gz
 #it turns out github provided release files can change. so even though the code hopefully hasn't changed, the hash has.
-ENV LIBGIT2_SRC_SHA256=0da4e211dfb63c22e5f43f2a4a5373e86a140afa88a25ca6ba3cc2cae58263d2
-ENV LIBGIT2_SRC_VERSION=0.26.3
+ENV LIBGIT2_SRC_SHA256=52e28a5166564bc4365a2e4112f5e5c6e334708dbf13596241b2fd34efc1b0a9
+ENV LIBGIT2_SRC_VERSION=0.26.5
 ENV LIBGIT2TEMP=/tmp/libgit2temp
 RUN mkdir -p "$LIBGIT2TEMP" \
  && cd "$LIBGIT2TEMP" \
@@ -148,7 +148,7 @@ RUN apt-get install -y ruby ruby-dev rubygems gcc make \
 #use the following variables to choose the version of hubble
 ARG HUBBLE_CHECKOUT=develop
 ARG HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
-ENV HUBBLE_VERSION=2.3.4
+ENV HUBBLE_VERSION=2.3.4_develop
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_SRC_PATH=/hubble_src
 ENV _HOOK_DIR="./pkg/"

--- a/pkg/dev/debian8/pyinstaller-requirements.txt
+++ b/pkg/dev/debian8/pyinstaller-requirements.txt
@@ -1,4 +1,4 @@
-pyinstaller==3.2 # currently 3.2.1 version is not supported because of botocore exception
+pyinstaller==3.3.1
 Crypto
 pyopenssl>=16.2.0
 argparse

--- a/pkg/dev/debian9/Dockerfile
+++ b/pkg/dev/debian9/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update     \
 RUN mkdir -p /etc/osquery /var/log/osquery /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/osquery
 
 #patchelf build start
-#must precent osquery as at the moment, osquery won't build without patchelf
+#must precede osquery as at the moment, osquery won't build without patchelf
 ENV PATCHELF_GIT_URL=https://github.com/NixOS/patchelf.git
 ENV PATCHELF_TEMP=/tmp/patchelf
 RUN apt-get -y install autoconf git make g++
@@ -33,7 +33,7 @@ RUN mkdir -p "$PATCHELF_TEMP" \
 #osquery should be built first since requirements for other packages can interfere with osquery dependencies
 #to build, osquery scripts want sudo and a user to sudo with.
 #to pin to a different version change the following envirnment variable
-ENV OSQUERY_SRC_VERSION=a338c86170947344ddd23e80e4e3f636ff8eb5ab
+ENV OSQUERY_SRC_VERSION=1ed050147ac88a7314c172e15e86f8886206dd06
 ENV OSQUERY_BUILD_USER=osquerybuilder
 ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
 RUN apt-get -y install git make python ruby sudo curl
@@ -75,7 +75,7 @@ RUN apt-get -y install  \
 #install libcurl to avoid depending on host version
 #requires autoconf libtool libssh2-devel zlib-devel autoconf
 ENV LIBCURL_SRC_URL=https://github.com/curl/curl.git
-ENV LIBCURL_SRC_VERSION=curl-7_60_0
+ENV LIBCURL_SRC_VERSION=curl-7_61_0
 ENV LIBCURL_TEMP=/tmp/libcurl
 ENV PATH=/opt/hubble/bin/:/opt/hubble/include:/opt/hubble/lib:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 RUN mkdir -p "$LIBCURL_TEMP" \
@@ -92,7 +92,7 @@ RUN mkdir -p "$LIBCURL_TEMP" \
 #install git so that git package won't be a package dependency
 #requires make git libcurl-devel autoconf zlib-devel gcc
 ENV GIT_SRC_URL=https://github.com/git/git.git
-ENV GIT_SRC_VERSION=v2.16.3
+ENV GIT_SRC_VERSION=v2.16.4
 ENV GITTEMP=/tmp/gittemp
 RUN mkdir -p "$GITTEMP" \
  && cd "$GITTEMP" \
@@ -113,10 +113,10 @@ RUN rm /opt/hubble/bin/curl* \
 
 #libgit2 install start
 #must precede pyinstaller requirements
-ENV LIBGIT2_SRC_URL=https://github.com/libgit2/libgit2/archive/v0.26.3.tar.gz
+ENV LIBGIT2_SRC_URL=https://github.com/libgit2/libgit2/archive/v0.26.5.tar.gz
 #it turns out github provided release files can change. so even though the code hopefully hasn't changed, the hash has.
-ENV LIBGIT2_SRC_SHA256=0da4e211dfb63c22e5f43f2a4a5373e86a140afa88a25ca6ba3cc2cae58263d2
-ENV LIBGIT2_SRC_VERSION=0.26.3
+ENV LIBGIT2_SRC_SHA256=52e28a5166564bc4365a2e4112f5e5c6e334708dbf13596241b2fd34efc1b0a9
+ENV LIBGIT2_SRC_VERSION=0.26.5
 ENV LIBGIT2TEMP=/tmp/libgit2temp
 RUN mkdir -p "$LIBGIT2TEMP" \
  && cd "$LIBGIT2TEMP" \
@@ -143,7 +143,7 @@ RUN apt-get install -y ruby ruby-dev rubygems gcc make \
 #use the following variables to choose the version of hubble
 ARG HUBBLE_CHECKOUT=develop
 ARG HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
-ENV HUBBLE_VERSION=2.3.4
+ENV HUBBLE_VERSION=2.3.4_develop
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_SRC_PATH=/hubble_src
 ENV _HOOK_DIR="./pkg/"

--- a/pkg/dev/debian9/pyinstaller-requirements.txt
+++ b/pkg/dev/debian9/pyinstaller-requirements.txt
@@ -1,4 +1,4 @@
-pyinstaller==3.2 # currently 3.2.1 version is not supported because of botocore exception
+pyinstaller==3.3.1
 Crypto
 pyopenssl>=16.2.0
 argparse


### PR DESCRIPTION
The dep version bumps are mostly minor version releases that only address git cve's released earlier this year.
See also pyinstaller requirements change for Debian 7 due to its old age.