### PR TITLE
Mask nebula passwords

### DIFF
--- a/hubblestack/extmods/modules/nebula_osquery.py
+++ b/hubblestack/extmods/modules/nebula_osquery.py
@@ -339,7 +339,6 @@ def mask_passwords(unmasked_object):
                                     key == blacklisted_string['column']:
                                         for pattern in blacklisted_string['blacklisted_patterns']:
                                             value = re.sub(pattern + "()",r"\1" + mask_by + r"\3", value)
-                                        #print("string  masking : {0} : {1}".format(result[key],value))
                                         result[key] = value
                             else:
                                 # handle like [json]
@@ -365,7 +364,6 @@ def _recursively_mask_objects(object_to_mask, blacklisted_object, mask_by):
         for key in blacklisted_object['attributes_to_mask']:
             if key in object_to_mask:
                 object_to_mask[key] = mask_by
-                print(" masking : {0}".format(object_to_mask[key]))
 
 
 def _dict_update(dest, upd, recursive_update=True, merge_lists=False):

--- a/hubblestack/extmods/modules/nebula_osquery.py
+++ b/hubblestack/extmods/modules/nebula_osquery.py
@@ -324,7 +324,7 @@ def mask_passwords(unmasked_object):
     masked_object = copy.deepcopy(unmasked_object)
 
     try:
-        mask = yaml.load(open('mask.yaml'))
+        mask = yaml.load(open('salt://mask.yaml'))
         mask_by = mask.get('mask_by','******')
         for r in masked_object:
             for query_name, query_ret in r.iteritems():

--- a/hubblestack/extmods/modules/nebula_osquery.py
+++ b/hubblestack/extmods/modules/nebula_osquery.py
@@ -227,7 +227,9 @@ def queries(query_group,
                         if value and isinstance(value, basestring) and value.startswith('__JSONIFY__'):
                             result[key] = json.loads(value[len('__JSONIFY__'):])
 
-    return mask_passwords(ret) if mask_passwords else ret
+    if mask_passwords:
+        mask_passwords_inplace(ret)
+    return ret
 
 
 def fields(*args):
@@ -322,7 +324,7 @@ def get_top_data(topfile):
     return ret
 
 
-def mask_passwords(object_to_be_masked):
+def mask_passwords_inplace(object_to_be_masked):
 
     try:
         mask_file  = __salt__['cp.cache_file']('salt://hubblestack_nebula_v2/mask.yaml')

--- a/hubblestack/extmods/modules/nebula_osquery.py
+++ b/hubblestack/extmods/modules/nebula_osquery.py
@@ -361,7 +361,7 @@ def _recursively_mask_objects(object_to_mask, blacklisted_object, mask_by):
         for child in object_to_mask:
             _recursively_mask_objects(child, blacklisted_object, mask_by)
     elif blacklisted_object['attribute_to_check'] in object_to_mask and \
-         object_to_mask[blacklisted_object['attribute_to_check']] in blacklisted_object['balcklisted_patterns']:
+         object_to_mask[blacklisted_object['attribute_to_check']] in blacklisted_object['blacklisted_patterns']:
         for key in blacklisted_object['attributes_to_mask']:
             if key in object_to_mask:
                 object_to_mask[key] = mask_by

--- a/hubblestack/extmods/modules/nebula_osquery.py
+++ b/hubblestack/extmods/modules/nebula_osquery.py
@@ -71,6 +71,10 @@ def queries(query_group,
         Defaults to False. If set to True, more information (such as the query
         which was run) will be included in the result.
 
+    mask_passwords
+        Defaults to False. If set to True, passwords mentioned in the 
+        return object are masked.
+        
     CLI Examples:
 
     .. code_block:: bash
@@ -325,7 +329,11 @@ def get_top_data(topfile):
 
 
 def mask_passwords_inplace(object_to_be_masked):
-
+    '''
+    It masks the passwords present in 'object_to_be_masked'. Uses "mask.yaml" as
+    a reference to find out the list of blacklisted strings or objects.
+    Note that this method alters "object_to_be_masked".
+    '''
     try:
         mask_file  = __salt__['cp.cache_file']('salt://hubblestack_nebula_v2/mask.yaml')
         if not mask_file:
@@ -359,7 +367,24 @@ def mask_passwords_inplace(object_to_be_masked):
 
 
 def _recursively_mask_objects(object_to_mask, blacklisted_object, mask_by):
-
+    '''
+    This function is used by "mask_passwords_inplace" to mask passwords contained in
+    json objects or json arrays. If the "object_to_mask" is a json array, then this 
+    function is called recursively on the individual members of the array.
+ 
+     object_to_mask
+        Json object/array whose elements are to masked recursively
+        
+     blacklisted_object
+        This parameters contains info about which queries are to be masked, which 
+        attributes are to be masked, based upon the value of which attribute.
+        See hubblestack_nebula_v2/mask.yaml for exact format.
+        
+    mask_by
+        If a password string is detected, it is replaced by the value of "mask_by" 
+        parameter.
+        
+    '''
     if isinstance(object_to_mask, list):
         for child in object_to_mask:
             _recursively_mask_objects(child, blacklisted_object, mask_by)

--- a/hubblestack/extmods/modules/nebula_osquery.py
+++ b/hubblestack/extmods/modules/nebula_osquery.py
@@ -324,7 +324,8 @@ def mask_passwords(unmasked_object):
     masked_object = copy.deepcopy(unmasked_object)
 
     try:
-        mask = yaml.load(open('salt://mask.yaml'))
+        mask_file  = __salt__['cp.cache_file']('salt://mask.yaml')
+        mask = yaml.safe_load(open(mask_file))
         mask_by = mask.get('mask_by','******')
         for r in masked_object:
             for query_name, query_ret in r.iteritems():

--- a/hubblestack/extmods/modules/nebula_osquery.py
+++ b/hubblestack/extmods/modules/nebula_osquery.py
@@ -327,7 +327,6 @@ def get_top_data(topfile):
 
     return ret
 
-
 def mask_passwords_inplace(object_to_be_masked):
     '''
     It masks the passwords present in 'object_to_be_masked'. Uses "mask.yaml" as
@@ -360,21 +359,19 @@ def mask_passwords_inplace(object_to_be_masked):
                                                     .format(f_data))
                     mask = _dict_update(mask, f_data, recursive_update=True, merge_lists=True)
 
-
-        mask_by = mask.get('mask_by','******')
-
+        log.debug("Using the mask: {}".format(mask))
+        mask_by = mask.get('mask_by', '******')
 
         for blacklisted_string in mask.get("blacklisted_strings", []):
             query_name = blacklisted_string['query_name']
             column = blacklisted_string['column']
             if query_name != '*':
                 for r in object_to_be_masked:
-                    for query_result in r.get(query_name,{'data':[]})['data']:
+                    for query_result in r.get(query_name, {'data':[]})['data']:
                         if column not in query_result or not isinstance(query_result[column], basestring):
                             # if the column in not present in one data-object, it will 
                             # not be present in others as well. Break in that case.
                             # This will happen only if mask.yaml is malformed
-                            print("string", query_name, query_result, column)
                             break
                         value = query_result[column]
                         for pattern in blacklisted_string['blacklisted_patterns']:
@@ -385,7 +382,6 @@ def mask_passwords_inplace(object_to_be_masked):
                     for query_name, query_ret in r.iteritems():
                         for query_result in query_ret['data']:
                             if column not in query_result or not isinstance(query_result[column], basestring):
-                                print("string", query_name, query_result, column)
                                 break
                             value = query_result[column]
                             for pattern in blacklisted_string['blacklisted_patterns']:
@@ -398,10 +394,9 @@ def mask_passwords_inplace(object_to_be_masked):
             column = blacklisted_object['column']
             if query_name != '*':
                 for r in object_to_be_masked:
-                    for query_result in r.get(query_name,{'data':[]})['data']:
+                    for query_result in r.get(query_name, {'data':[]})['data']:
                         if column not in query_result or \
-                        ( isinstance(query_result[column], basestring) and query_result[column].strip() != '' ):
-                            print("object", query_name, query_result, column)
+                        (isinstance(query_result[column], basestring) and query_result[column].strip() != '' ):
                             break
                         _recursively_mask_objects(query_result[column], blacklisted_object, mask_by)
             else:
@@ -409,17 +404,14 @@ def mask_passwords_inplace(object_to_be_masked):
                     for query_name, query_ret in r.iteritems():
                         for query_result in query_ret['data']:
                             if column not in query_result or \
-                            ( isinstance(query_result[column], basestring) and query_result[column].strip() != '' ):
-                                print("object", query_name, query_result, column)
+                            (isinstance(query_result[column], basestring) and query_result[column].strip() != '' ):
                                 break
                             _recursively_mask_objects(query_result[column], blacklisted_object, mask_by)
-
                                             
             # successfully masked the object. No need to return anything
         
     except Exception as e:
         log.exception("An error occured while masking the passwords: {}".format(e))
-
 
 def _recursively_mask_objects(object_to_mask, blacklisted_object, mask_by):
     '''

--- a/hubblestack/extmods/modules/nebula_osquery.py
+++ b/hubblestack/extmods/modules/nebula_osquery.py
@@ -56,6 +56,7 @@ def queries(query_group,
             query_file=None,
             verbose=False,
             report_version_with_day=True,
+            topfile_for_mask=None,
             mask_passwords=False):
     '''
     Run the set of queries represented by ``query_group`` from the
@@ -71,6 +72,10 @@ def queries(query_group,
         Defaults to False. If set to True, more information (such as the query
         which was run) will be included in the result.
 
+    topfile_for_mask
+        This is the location of the top file from which the masking information 
+        will be extracted.
+        
     mask_passwords
         Defaults to False. If set to True, passwords mentioned in the 
         return object are masked.
@@ -232,7 +237,7 @@ def queries(query_group,
                             result[key] = json.loads(value[len('__JSONIFY__'):])
 
     if mask_passwords:
-        mask_passwords_inplace(ret)
+        mask_passwords_inplace(ret, topfile_for_mask)
     return ret
 
 
@@ -280,6 +285,7 @@ def hubble_versions():
 
 def top(query_group,
         topfile='salt://hubblestack_nebula_v2/top.nebula',
+        topfile_for_mask=None,
         verbose=False,
         report_version_with_day=True,
         mask_passwords=False):
@@ -296,6 +302,7 @@ def top(query_group,
                    query_file=configs,
                    verbose=False,
                    report_version_with_day=True,
+                   topfile_for_mask=topfile_for_mask,
                    mask_passwords=mask_passwords)
 
 
@@ -327,16 +334,20 @@ def get_top_data(topfile):
 
     return ret
 
-def mask_passwords_inplace(object_to_be_masked):
+def mask_passwords_inplace(object_to_be_masked, topfile):
     '''
-    It masks the passwords present in 'object_to_be_masked'. Uses "mask.yaml" as
-    a reference to find out the list of blacklisted strings or objects.
+    It masks the passwords present in 'object_to_be_masked'. Uses mask configuration
+    file as a reference to find out the list of blacklisted strings or objects.
     Note that this method alters "object_to_be_masked".
+    
+    The path to the mask configuration file can be specified in the "topfile" 
+    argument.
     '''
     try:
 
         mask = {}
-        topfile = 'salt://hubblestack_nebula_v2/top.mask'
+        if topfile is None:
+            topfile = 'salt://hubblestack_nebula_v2/top.mask'
         mask_files = get_top_data(topfile)
         mask_files = ['salt://hubblestack_nebula_v2/' + mask_file.replace('.', '/') + '.yaml'
                    for mask_file in mask_files]

--- a/hubblestack/extmods/modules/nebula_osquery.py
+++ b/hubblestack/extmods/modules/nebula_osquery.py
@@ -226,7 +226,7 @@ def queries(query_group,
                         if value and isinstance(value, basestring) and value.startswith('__JSONIFY__'):
                             result[key] = json.loads(value[len('__JSONIFY__'):])
 
-    return ret
+    return mask_passwords(ret)
 
 
 def fields(*args):


### PR DESCRIPTION
Currently, some passwords are also getting logged by hubble osqueries. 
This PR aims to mask such passwords by using mask.yaml file. See PR in hubblestack_data for more details:
https://github.com/hubblestack/hubblestack_data/pull/119

There are two ways in which passwords are being printed:
1) Some passwords are being passed as command line arguemnts. For example "command_line" column of 'running_procs' contains some passwords in some cases.
2) Some passwords are injected as environment variable, and hence logged under 'environment' column of 'running_procs' for example.

Passwords of type 1 can be handled by "blacklisted_strings" part of mask.yaml.
Passwords of type 2 can be handled by "blacklisted_objects" part of mask.yaml.


DO NOT MERGE. 
( still need to test a few scenarios )
But reviews are welcome. 