### PR TITLE
Add optional retries to splunk returners

### DIFF
--- a/conf/hubble
+++ b/conf/hubble
@@ -45,6 +45,7 @@ fileserver_backend:
 #    kwargs:
 #      verbose: True
 #    returner: splunk_nova_return
+#    returner_retry: True # only works on splunk returners for now
 #    run_on_start: False
 #  nebula_fifteen_min:
 #    function: nebula.queries
@@ -69,6 +70,7 @@ fileserver_backend:
 #    args:
 #      - day
 #    returner: splunk_nebula_return
+#    returner_retry: True # only works on splunk returners for now
 #    run_on_start: False
 #  pulsar:
 #    function: pulsar.process

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -308,6 +308,7 @@ def schedule():
         returners = jobdata.get('returner', [])
         if not isinstance(returners, list):
             returners = [returners]
+        returner_retry = jobdata.get('returner_retry', False)
 
         # Actually process the job
         run = False
@@ -356,7 +357,8 @@ def schedule():
                                 'jid': salt.utils.jid.gen_jid(__opts__),
                                 'fun': func,
                                 'fun_args': args + ([kwargs] if kwargs else []),
-                                'return': ret}
+                                'return': ret,
+                                'retry': returner_retry}
                 __returners__[returner](returner_ret)
 
 

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -396,7 +396,10 @@ def run_function():
                             'jid': salt.utils.jid.gen_jid(__opts__),
                             'fun': __opts__['function'],
                             'fun_args': args + ([kwargs] if kwargs else []),
-                            'return': ret}
+                            'return': ret,
+                            'retry': False}
+            if __opts__.get('returner_retry', False):
+                returner_ret['retry'] = True
             __returners__[returner](returner_ret)
 
     # TODO instantiate the salt outputter system?
@@ -698,6 +701,9 @@ def parse_args():
     parser.add_argument('--ignore_running',
                         action='store_true',
                         help='Ignore any running hubble processes. This disables the pidfile.')
+    parser.add_argument('--returner_retry',
+                        action='store_true',
+                        help='Enable retry on the returner for one-off jobs')
     return vars(parser.parse_args())
 
 def check_pidfile(kill_other=False):

--- a/hubblestack/extmods/returners/splunk_nebula_return.py
+++ b/hubblestack/extmods/returners/splunk_nebula_return.py
@@ -56,6 +56,7 @@ import logging
 
 _max_content_bytes = 100000
 http_event_collector_debug = False
+RETRY = False
 
 log = logging.getLogger(__name__)
 
@@ -93,6 +94,8 @@ def returner(ret):
             data = ret['return']
             minion_id = ret['id']
             jid = ret['jid']
+            global RETRY
+            RETRY = ret['retry']
             master = __grains__['master']
             fqdn = __grains__['fqdn']
             # Sometimes fqdn is blank. If it is, replace it with minion_id
@@ -366,23 +369,37 @@ class http_event_collector:
         if len(self.batchEvents) > 0:
             headers = {'Authorization': 'Splunk ' + self.token}
             self.server_uri = [x for x in self.server_uri if x[1] is not False]
+            success = False
             for server in self.server_uri:
-                try:
-                    r = requests.post(server[0], data=' '.join(self.batchEvents), headers=headers,
-                                      verify=self.http_event_collector_ssl_verify, proxies=self.proxy, timeout=self.timeout)
-                    r.raise_for_status()
-                    server[1] = True
+                retries = -1
+                max_retries = 0
+                retry_sleep = 15
+                if RETRY:
+                    max_retries = __salt__['config.get']('returner_retry_max', 3)
+                    retry_sleep = __salt__['config.get']('returner_retry_sleep', 15)
+                while retries < max_retries:
+                    retries += 1
+                    if retries != 0:
+                        time.sleep(retry_sleep)
+                    try:
+                        r = requests.post(server[0], data=' '.join(self.batchEvents), headers=headers,
+                                          verify=self.http_event_collector_ssl_verify, proxies=self.proxy, timeout=self.timeout)
+                        r.raise_for_status()
+                        server[1] = True
+                        success = True
+                        break
+                    except requests.exceptions.Timeout as timeout_err:
+                        log.info('Connection timed out to splunk server {0}: {1}'.format(unicode(server[0]), unicode(timeout_err)))
+                    except requests.exceptions.ConnectionError as connect_err:
+                        log.info('Error establishing connection to splunk server {0}: {1}'.format(unicode(server[0]), unicode(connect_err)))
+                    except requests.exceptions.HTTPError as http_err:
+                        log.info('HTTP Error received while connecting to splunk server {0}: {1}'.format(unicode(server[0]), unicode(http_err)))
+                    except requests.exceptions.RequestException as gen_err:
+                        log.info('Request to splunk server {0} failed: {1}'.format(unicode(server[0]), unicode(gen_err)))
+                        server[1] = False
+                    except Exception as e:
+                        log.error('Request to splunk threw an error: {0}'.format(e))
+                if success:
                     break
-                except requests.exceptions.Timeout as timeout_err:
-                    log.info('Connection timed out to splunk server {0}: {1}'.format(unicode(server[0]), unicode(timeout_err)))
-                except requests.exceptions.ConnectionError as connect_err:
-                    log.info('Error establishing connection to splunk server {0}: {1}'.format(unicode(server[0]), unicode(connect_err)))
-                except requests.exceptions.HTTPError as http_err:
-                    log.info('HTTP Error received while connecting to splunk server {0}: {1}'.format(unicode(server[0]), unicode(http_err)))
-                except requests.exceptions.RequestException as gen_err:
-                    log.info('Request to splunk server {0} failed: {1}'.format(unicode(server[0]), unicode(gen_err)))
-                    server[1] = False
-                except Exception as e:
-                    log.error('Request to splunk threw an error: {0}'.format(e))
             self.batchEvents = []
             self.currentByteLength = 0

--- a/hubblestack/extmods/returners/splunk_nebula_return.py
+++ b/hubblestack/extmods/returners/splunk_nebula_return.py
@@ -380,6 +380,7 @@ class http_event_collector:
                 while retries < max_retries:
                     retries += 1
                     if retries != 0:
+                        log.info('RETRYING in {0} seconds'.format(retry_sleep))
                         time.sleep(retry_sleep)
                     try:
                         r = requests.post(server[0], data=' '.join(self.batchEvents), headers=headers,

--- a/hubblestack/extmods/returners/splunk_nova_return.py
+++ b/hubblestack/extmods/returners/splunk_nova_return.py
@@ -475,6 +475,7 @@ class http_event_collector:
                 while retries < max_retries:
                     retries += 1
                     if retries != 0:
+                        log.info('RETRYING in {0} seconds'.format(retry_sleep))
                         time.sleep(retry_sleep)
                     try:
                         r = requests.post(server[0], data=' '.join(self.batchEvents), headers=headers,

--- a/hubblestack/extmods/returners/splunk_nova_return.py
+++ b/hubblestack/extmods/returners/splunk_nova_return.py
@@ -55,6 +55,7 @@ import logging
 
 _max_content_bytes = 100000
 http_event_collector_debug = False
+RETRY = False
 
 log = logging.getLogger(__name__)
 
@@ -91,6 +92,8 @@ def returner(ret):
             data = ret['return']
             minion_id = ret['id']
             jid = ret['jid']
+            global RETRY
+            RETRY = ret['retry']
             fqdn = __grains__['fqdn']
             # Sometimes fqdn is blank. If it is, replace it with minion_id
             fqdn = fqdn if fqdn else minion_id
@@ -461,18 +464,37 @@ class http_event_collector:
         if len(self.batchEvents) > 0:
             headers = {'Authorization': 'Splunk ' + self.token}
             self.server_uri = [x for x in self.server_uri if x[1] is not False]
+            success = False
             for server in self.server_uri:
-                try:
-                    r = requests.post(server[0], data=' '.join(self.batchEvents), headers=headers,
-                                      verify=self.http_event_collector_ssl_verify,
-                                      proxies=self.proxy, timeout=self.timeout)
-                    r.raise_for_status()
-                    server[1] = True
+                retries = -1
+                max_retries = 0
+                retry_sleep = 15
+                if RETRY:
+                    max_retries = __salt__['config.get']('returner_retry_max', 3)
+                    retry_sleep = __salt__['config.get']('returner_retry_sleep', 15)
+                while retries < max_retries:
+                    retries += 1
+                    if retries != 0:
+                        time.sleep(retry_sleep)
+                    try:
+                        r = requests.post(server[0], data=' '.join(self.batchEvents), headers=headers,
+                                          verify=self.http_event_collector_ssl_verify, proxies=self.proxy, timeout=self.timeout)
+                        r.raise_for_status()
+                        server[1] = True
+                        success = True
+                        break
+                    except requests.exceptions.Timeout as timeout_err:
+                        log.info('Connection timed out to splunk server {0}: {1}'.format(unicode(server[0]), unicode(timeout_err)))
+                    except requests.exceptions.ConnectionError as connect_err:
+                        log.info('Error establishing connection to splunk server {0}: {1}'.format(unicode(server[0]), unicode(connect_err)))
+                    except requests.exceptions.HTTPError as http_err:
+                        log.info('HTTP Error received while connecting to splunk server {0}: {1}'.format(unicode(server[0]), unicode(http_err)))
+                    except requests.exceptions.RequestException as gen_err:
+                        log.info('Request to splunk server {0} failed: {1}'.format(unicode(server[0]), unicode(gen_err)))
+                        server[1] = False
+                    except Exception as e:
+                        log.error('Request to splunk threw an error: {0}'.format(e))
+                if success:
                     break
-                except requests.exceptions.RequestException:
-                    log.info('Request to splunk server "%s" failed. Marking as bad.' % server[0])
-                    server[1] = False
-                except Exception as e:
-                    log.error('Request to splunk threw an error: {0}'.format(e))
             self.batchEvents = []
             self.currentByteLength = 0

--- a/hubblestack/extmods/returners/splunk_pulsar_return.py
+++ b/hubblestack/extmods/returners/splunk_pulsar_return.py
@@ -495,6 +495,7 @@ class http_event_collector:
                 while retries < max_retries:
                     retries += 1
                     if retries != 0:
+                        log.info('RETRYING in {0} seconds'.format(retry_sleep))
                         time.sleep(retry_sleep)
                     try:
                         r = requests.post(server[0], data=' '.join(self.batchEvents), headers=headers,

--- a/hubblestack/extmods/returners/splunk_pulsar_return.py
+++ b/hubblestack/extmods/returners/splunk_pulsar_return.py
@@ -57,6 +57,7 @@ import logging
 
 _max_content_bytes = 100000
 http_event_collector_debug = False
+RETRY = False
 
 log = logging.getLogger(__name__)
 
@@ -101,6 +102,9 @@ def returner(ret):
             # Sometimes there are duplicate events in the list. Dedup them:
             data = _dedupList(data)
             minion_id = __opts__['id']
+            jid = ret['jid']
+            global RETRY
+            RETRY = ret['retry']
             fqdn = __grains__['fqdn']
             # Sometimes fqdn is blank. If it is, replace it with minion_id
             fqdn = fqdn if fqdn else minion_id
@@ -480,17 +484,37 @@ class http_event_collector:
         if len(self.batchEvents) > 0:
             headers = {'Authorization': 'Splunk ' + self.token}
             self.server_uri = [x for x in self.server_uri if x[1] is not False]
+            success = False
             for server in self.server_uri:
-                try:
-                    r = requests.post(server[0], data=' '.join(self.batchEvents), headers=headers,
-                                      verify=self.http_event_collector_ssl_verify, proxies=self.proxy, timeout=self.timeout)
-                    r.raise_for_status()
-                    server[1] = True
+                retries = -1
+                max_retries = 0
+                retry_sleep = 15
+                if RETRY:
+                    max_retries = __salt__['config.get']('returner_retry_max', 3)
+                    retry_sleep = __salt__['config.get']('returner_retry_sleep', 15)
+                while retries < max_retries:
+                    retries += 1
+                    if retries != 0:
+                        time.sleep(retry_sleep)
+                    try:
+                        r = requests.post(server[0], data=' '.join(self.batchEvents), headers=headers,
+                                          verify=self.http_event_collector_ssl_verify, proxies=self.proxy, timeout=self.timeout)
+                        r.raise_for_status()
+                        server[1] = True
+                        success = True
+                        break
+                    except requests.exceptions.Timeout as timeout_err:
+                        log.info('Connection timed out to splunk server {0}: {1}'.format(unicode(server[0]), unicode(timeout_err)))
+                    except requests.exceptions.ConnectionError as connect_err:
+                        log.info('Error establishing connection to splunk server {0}: {1}'.format(unicode(server[0]), unicode(connect_err)))
+                    except requests.exceptions.HTTPError as http_err:
+                        log.info('HTTP Error received while connecting to splunk server {0}: {1}'.format(unicode(server[0]), unicode(http_err)))
+                    except requests.exceptions.RequestException as gen_err:
+                        log.info('Request to splunk server {0} failed: {1}'.format(unicode(server[0]), unicode(gen_err)))
+                        server[1] = False
+                    except Exception as e:
+                        log.error('Request to splunk threw an error: {0}'.format(e))
+                if success:
                     break
-                except requests.exceptions.RequestException:
-                    log.info('Request to splunk server "%s" failed. Marking as bad.' % server[0])
-                    server[1] = False
-                except Exception as e:
-                    log.error('Request to splunk threw an error: {0}'.format(e))
             self.batchEvents = []
             self.currentByteLength = 0


### PR DESCRIPTION
Also brings all the returners in line for requests error handling

Defaults for the retries are 3 times with 15 seconds between. Retries
are on a per-batch basis.