### PR TITLE
Fix some copy pasta

### DIFF
--- a/hubblestack/extmods/modules/nebula_osquery.py
+++ b/hubblestack/extmods/modules/nebula_osquery.py
@@ -346,7 +346,7 @@ def _dict_update(dest, upd, recursive_update=True, merge_lists=False):
                 dest_subkey = None
             if isinstance(dest_subkey, collections.Mapping) \
                     and isinstance(val, collections.Mapping):
-                ret = update(dest_subkey, val, merge_lists=merge_lists)
+                ret = _dict_update(dest_subkey, val, merge_lists=merge_lists)
                 dest[key] = ret
             elif isinstance(dest_subkey, list) \
                     and isinstance(val, list):

--- a/hubblestack/extmods/modules/win_pulsar_winaudit.py
+++ b/hubblestack/extmods/modules/win_pulsar_winaudit.py
@@ -549,7 +549,7 @@ def _dict_update(dest, upd, recursive_update=True, merge_lists=False):
                 dest_subkey = None
             if isinstance(dest_subkey, collections.Mapping) \
                     and isinstance(val, collections.Mapping):
-                ret = update(dest_subkey, val, merge_lists=merge_lists)
+                ret = _dict_update(dest_subkey, val, merge_lists=merge_lists)
                 dest[key] = ret
             elif isinstance(dest_subkey, list) \
                      and isinstance(val, list):


### PR DESCRIPTION
When I first added this function from salt, I apparently caught this
recursive reference in two files, missed it in two others. Anyway,
our new nebula data format hits it when merging files via the topfile.