### PR TITLE
Write the pidfile once per minute

### DIFF
--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -139,6 +139,9 @@ def main():
     last_grains_refresh = time.time() - __opts__['grains_refresh_frequency']
 
     log.info('Starting main loop')
+    pidfile_count = 0
+    # pidfile_refresh in seconds, our scheduler deals in half-seconds
+    pidfile_refresh = int(__opts__.get('pidfile_refresh', 60)) * 2
     while True:
         # Check if fileserver needs update
         if time.time() - last_fc_update >= __opts__['fileserver_update_frequency']:
@@ -151,6 +154,11 @@ def main():
                 log.exception('Exception thrown trying to update fileclient. '
                               'Trying again in {0} seconds.'
                               .format(retry))
+
+        pidfile_count += 1
+        if pidfile_count > pidfile_refresh:
+            pidfile_count = 0
+            create_pidfile()
 
         if time.time() - last_grains_refresh >= __opts__['grains_refresh_frequency']:
             log.info('Refreshing grains')


### PR DESCRIPTION
This will hopefully help with issues we've seen around hubble not restarting properly.

I can think of only two reasons that the restart wouldn't happen properly:

1. Hubble is hung. Not only is this uncommon, but assuming the pidfile is still in place, hubble will try to kill the previous process before starting, and will then refuse to start, so assuming the pidfile is in place, there will still only be one running hubble process.

2. The pidfile is gone or has been moved

This PR should alleviate the second issue.