### PR TITLE
Osquery daemon integration in Hubble

### DIFF
--- a/conf/hubble
+++ b/conf/hubble
@@ -133,6 +133,7 @@ fileserver_backend:
 #        add_query_to_sourcetype: True  # Separate nebula sourcetype per query
 #        sourcetype_nova: hubble_audit
 #        sourcetype_nebula: hubble_osquery
+#        sourcetype_osqueryd: hubble_osqd
 #        sourcetype_pulsar: hubble_fim
 #        sourcetype_log: hubble_log
 #splunklogging: True

--- a/conf/hubble
+++ b/conf/hubble
@@ -75,6 +75,32 @@ fileserver_backend:
 #    returner: splunk_nebula_return
 #    returner_retry: True # only works on splunk returners for now
 #    run_on_start: False
+#  nebula_osqueryd_monitor:
+#    function: nebula.osqueryd_monitor
+#    seconds: 60
+#    splay: 10
+#    kwargs:
+#      configfile: /path/to/confbase/osquery/osquery.conf
+#      flagfile: /path/to/confbase/osquery/osquery.flags
+#      logdir: /var/log/hubble_osquery
+#      databasepath: /var/cache/hubble/osquery
+#      pidfile: /var/run/hubble_osquery/osquery.pidfile
+#      hashfile: /var/cache/hubble/osquery/hash_of_flagfile.txt
+#    run_on_start: True
+#  nebula_osquery:
+#    function: nebula.osqueryd_log_parser
+#    seconds: 60
+#    splay: 10
+#    kwargs:
+#      osqueryd_logdir: /var/log/hubble_osquery
+#      backuplogdir: /var/log/hubble_osquery/backuplogs
+#      maxlogfilesizethreshold: 1000000
+#      logfilethresholdinbytes: 100000
+#      enablediskstatslogging: True
+#      backuplogfilescount: 5
+#      mask_passwords: True
+#    returner: splunk_osqueryd_return
+#    run_on_start: True
 #  pulsar:
 #    function: pulsar.process
 #    seconds: 1

--- a/hubblestack/extmods/modules/nebula_osquery.py
+++ b/hubblestack/extmods/modules/nebula_osquery.py
@@ -24,6 +24,7 @@ nebula_osquery:
 from __future__ import absolute_import
 
 import copy
+import glob
 import json
 import logging
 import os
@@ -33,14 +34,19 @@ import yaml
 import collections
 
 import salt.utils
+import salt.utils.files
 import salt.utils.platform
+
+from hashlib import md5
 from salt.exceptions import CommandExecutionError
+from os import path
 from hubblestack import __version__
 import hubblestack.splunklogging
 
 log = logging.getLogger(__name__)
 
 __virtualname__ = 'nebula'
+__RESULT_LOG_OFFSET__ = {}
 
 
 def __virtual__():
@@ -241,6 +247,213 @@ def queries(query_group,
     return ret
 
 
+def osqueryd_monitor(servicename='hubble_osqueryd',
+                     configfile=None,
+                     flagfile=None,
+                     logdir=None,
+                     databasepath=None,
+                     pidfile=None,
+                     hashfile=None,
+                     daemonize=True):
+    '''
+    This function will monitor whether osqueryd is running on the system or not. 
+    Whenever it detects that osqueryd is not running, it will start the osqueryd. 
+    Also, it checks for conditions that would require osqueryd to restart(such as changes in flag file content) 
+    On such conditions, osqueryd will get restarted, thereby loading new files.
+
+    servicename
+        service name to use in Windows. Default is 'hubble_osqueryd'
+
+    configfile
+        Path to osquery configuration file.
+
+    flagfile
+        Path to osquery flag file
+
+    logdir
+        Path to log directory where osquery daemon/service will write logs
+
+    pidfile
+        pidfile path where osquery daemon will write pid info
+
+    hashfile
+        path to hashfile where osquery flagfile's hash would be stored
+
+    daemonize
+        daemonize osquery daemon. Default is True. Applicable for posix system only
+
+    '''
+    saltenv = __salt__['config.get']('hubblestack:nova:saltenv', 'base')
+    osqueryd_path = 'salt://osqueryd'
+    cached = __salt__['cp.cache_dir'](osqueryd_path,saltenv=saltenv)
+    log.info('cached osqueryd files to cachedir')
+    cachedir = os.path.join(__opts__.get('cachedir'),'files',saltenv,'osqueryd')
+    base_path = cachedir
+    if salt.utils.platform.is_windows():
+        log.info("System is windows")
+        if not pidfile:
+            pidfile = os.path.join(base_path, "osqueryd.pidfile")
+        if not configfile:
+            configfile = os.path.join(base_path, "osquery.conf")
+        if not flagfile:
+            flagfile = os.path.join(base_path, "osquery.flags")
+        if not hashfile:
+            hashfile = os.path.join(base_path, "hash_of_flagfile.txt")
+        if not logdir:
+            logdir = "C:\Program Files(x86)\Hubble\var\log\hubble_osquery"
+        if not databasepath:
+            databasepath = "C:\Program Files(x86)\Hubble\var\hubble_osquery_db"
+        osqueryd_running = _osqueryd_running_status_windows(servicename)
+        if not osqueryd_running:
+            _start_osqueryd(pidfile, configfile, flagfile, logdir, databasepath, servicename)
+        osqueryd_restart = _osqueryd_restart_required(hashfile, flagfile)
+        if osqueryd_restart:
+            _restart_osqueryd(pidfile, configfile, flagfile, logdir, databasepath, hashfile, servicename)
+
+    else:
+        log.info("Not windows")
+        if not pidfile:
+            pidfile = os.path.join(base_path, "osqueryd.pidfile")
+        if not configfile:
+            configfile = os.path.join(base_path, "osquery.conf")
+        if not flagfile:
+            flagfile = os.path.join(base_path, "osquery.flags")
+        if not hashfile:
+            hashfile = os.path.join(base_path, "hash_of_flagfile.txt")
+        if not logdir:
+            logdir = "/var/log/hubble_osquery"
+        if not databasepath:
+            databasepath = "/var/cache/hubble/osquery"
+        osqueryd_running = _osqueryd_running_status(pidfile, servicename)
+        if not osqueryd_running:
+            _start_osqueryd(pidfile, configfile, flagfile, logdir, databasepath, servicename)
+        osqueryd_restart = _osqueryd_restart_required(hashfile, flagfile)
+        if osqueryd_restart:
+            _restart_osqueryd(pidfile, configfile, flagfile, logdir, databasepath, hashfile, servicename)
+
+
+def osqueryd_log_parser(osqueryd_logdir=None, 
+                        backuplogdir=None,
+                        maxlogfilesizethreshold=100000, 
+                        logfilethresholdinbytes=10000,
+                        backuplogfilescount=5,
+                        enablediskstatslogging=False,
+                        topfile_for_mask=None,
+                        mask_passwords=False):
+    '''
+    Parse osquery daemon logs and perform log rotation based on specified parameters
+
+    osqueryd_logdir
+        Directory path where osquery result and snapshot logs would be created
+
+    backuplogdir
+        Directory path where hubble should create log file backups post log rotation
+
+    maxlogfilesizethreshold
+        Log file size threshold in bytes. If osquery log file size is greter than this value,
+        then logs will only be roatated but not parsed
+
+    logfilethresholdinbytes
+        Log file size threshold in bytes. If osquery log file is greter than this value,
+        then log rotation will be done once logs have been processed
+
+    backuplogfilescount
+        Number of log file backups to keep
+
+    enablediskstatslogging
+        Enable logging of disk usage of /var/log partition. Default is False
+
+    topfile_for_mask
+        This is the location of the top file from which the masking information
+        will be extracted
+
+    mask_passwords
+        Defaults to False. If set to True, passwords mentioned in the
+        return object are masked
+
+    '''
+    ret = []
+    if osqueryd_logdir:
+        result_logfile =  os.path.normpath(os.path.join(osqueryd_logdir, 'osqueryd.results.log'))
+        snapshot_logfile = os.path.normpath(os.path.join(osqueryd_logdir, 'osqueryd.snapshots.log'))
+    else:
+        result_logfile = os.path.normpath(os.path.join(__grains__.get('osquerylogpath'), 
+                                                       'osqueryd.results.log'))
+        snapshot_logfile = os.path.normpath(os.path.join(__grains__.get('osquerylogpath'), 
+                                                         '/osqueryd.snapshots.log'))
+    if path.exists(result_logfile):
+        result_logfile_offset = _get_file_offset(result_logfile)
+        r_event_data = _parse_log(result_logfile, 
+                                  result_logfile_offset, 
+                                  backuplogdir, 
+                                  logfilethresholdinbytes,
+                                  maxlogfilesizethreshold, 
+                                  backuplogfilescount,
+                                  enablediskstatslogging)
+        if r_event_data:
+            ret = r_event_data
+    else:
+        log.error("Specified osquery result log file doesn't exist: {0}".format(result_logfile))
+    
+    if path.exists(snapshot_logfile):
+        snapshot_logfile_offset = _get_file_offset(snapshot_logfile)
+        s_event_data = _parse_log(snapshot_logfile, 
+                                  snapshot_logfile_offset,
+                                  backuplogdir,
+                                  logfilethresholdinbytes,
+                                  maxlogfilesizethreshold, 
+                                  backuplogfilescount,
+                                  enablediskstatslogging)
+        #log.info("Snapshot Event data: {0}".format(s_event_data))
+        if s_event_data:
+            ret = ret + s_event_data
+    else:
+        log.error("Specified osquery snapshot log file doesn't exist: {0}".format(snapshot_logfile))
+
+    if mask_passwords:
+        #TODO Need to verify if masking feature works with new data format
+        log.info("Perform masking")
+        #mask_passwords_inplace(ret, topfile_for_mask)
+    return ret
+
+
+def check_disk_usage(path=None):
+    '''
+    Check disk usage of specified path.
+    If no path is specified, path will default to '/var/log'
+
+    Can be scheduled via hubble conf as well
+
+    *** Linux Only method ***
+
+    '''
+    disk_stats = {}
+    if salt.utils.platform.is_windows():
+        log.info("Platform is windows, skipping disk usage stats")
+        disk_stats = {"Error": "Platform is windows"}
+    else:
+        if not path:
+            # We would be interested in var partition disk stats only, for other partitions specify 'path' param
+            path = "/var/log"
+        df_stat = os.statvfs(path)
+        total =  df_stat.f_frsize * df_stat.f_blocks
+        avail = df_stat.f_frsize * df_stat.f_bavail
+        used = total - avail
+        per_used = float(used)/total * 100
+        log.info("Stats for path: {0}, Total: {1}, Available: {2}, Used: {3}, Use%: {4}".format(path,
+                                                                                                total, 
+                                                                                                avail, 
+                                                                                                used, 
+                                                                                                per_used))
+        disk_stats = { 'Total' : total,
+                       'Available' : avail,
+                       'Used' : used,
+                       'Use_percent' : per_used
+        }
+
+    return disk_stats
+
+
 def fields(*args):
     '''
     Use config.get to retrieve custom data based on the keys in the `*args`
@@ -333,6 +546,7 @@ def _get_top_data(topfile):
                 ret.extend(data)
 
     return ret
+
 
 def _mask_object(object_to_be_masked, topfile):
     '''
@@ -507,6 +721,7 @@ def _mask_object(object_to_be_masked, topfile):
     # Object masked in place, so we don't need to return the object
     return True
 
+
 def _recursively_mask_objects(object_to_mask, blacklisted_object, mask_with):
     '''
     This function is used by ``_mask_object()`` to mask passwords contained in
@@ -580,3 +795,328 @@ def _dict_update(dest, upd, recursive_update=True, merge_lists=False):
             for k in upd:
                 dest[k] = upd[k]
         return dest
+
+
+def _osqueryd_running_status(pidfile, servicename):
+    '''
+    This function will check whether osqueryd is running in *nix systems
+    '''
+    osqueryd_running = False
+    if os.path.isfile(pidfile):
+      try:
+        with open(pidfile, 'r') as f:
+          xpid = f.readline().strip()
+          try:
+            xpid = int(xpid)
+          except:
+            xpid = 0
+            log.warn('unable to parse pid="{pid}" in pidfile={file}'.format(pid=xpid,file=pidfile))
+          if xpid:
+            log.warn('pidfile={file} exists and contains pid={pid}'.format(file=pidfile, pid=xpid))
+            if os.path.isdir("/proc/{pid}".format(pid=xpid)):
+              with open("/proc/{pid}/cmdline".format(pid=xpid),'r') as f2:
+                cmdline = f2.readline().strip().strip('\x00').replace('\x00',' ')
+                if 'osqueryd' in cmdline:
+                  log.info("process folder present and process is osqueryd")
+                  osqueryd_running = True
+                else:
+                  log.error("process is not osqueryd, attempting to start osqueryd")
+            else:
+              log.error("process folder not present, attempting to start osqueryd")
+          else:
+            log.error("pid cannot be determined, attempting to start osqueryd")
+      except:
+        log.error("unable to open pidfile, attempting to start osqueryd")
+    else:
+      cmd = ['pkill', 'osqueryd']
+      __salt__['cmd.run'](cmd, timeout=10000)
+      log.error("pidfile not found, attempting to start osqueryd")
+    return osqueryd_running
+
+
+def _osqueryd_restart_required(hashfile, flagfile):
+    '''
+    This function will check whether osqueryd needs to be restarted
+    '''
+    open_file = open(flagfile, 'r')
+    file_content = open_file.read().lower().rstrip('\n\r ').strip('\n\r')
+    hash_md5 = md5()
+    hash_md5.update(file_content.encode('ISO-8859-1'))
+    new_hash = hash_md5.hexdigest()
+
+    if not os.path.isfile(hashfile):
+        f = open(hashfile, "w")
+        f.write(new_hash)
+        return False
+    else:
+        f = open(hashfile, "r")
+        old_hash = f.read()
+        if old_hash != new_hash:
+          log.info('old hash is {0} and new hash is {1}'.format(old_hash, new_hash))
+          log.info('changes detected in flag file')
+          return True
+        else:
+          log.info('no changes detected in flag file')
+    return False
+
+
+def _osqueryd_running_status_windows(servicename):
+    '''
+    This function will check whether osqueryd is running in windows systems
+    '''
+    osqueryd_running = False
+    cmd_status = "(Get-Service -Name " + servicename + ").Status"
+    osqueryd_status = __salt__['cmd.run'](cmd_status, shell='powershell')
+    if osqueryd_status == 'Running':
+        osqueryd_running = True
+        log.info('osqueryd already running')
+    else:
+        log.info('osqueryd not running')
+        osqueryd_running = False
+    
+    return osqueryd_running
+
+
+def _start_osqueryd(pidfile, 
+                    configfile, 
+                    flagfile, 
+                    logdir, 
+                    databasepath, 
+                    servicename):
+    '''
+    This function will start osqueryd
+    ''' 
+    log.info("osqueryd is not running, attempting to start osqueryd")
+    if salt.utils.platform.is_windows():
+        log.error("requesting service manager to start osqueryD")
+        cmd = ['net', 'start', servicename]
+    else:
+        cmd = ['/opt/osquery/osqueryd', '--pidfile={0}'.format(pidfile), '--logger_path={0}'.format(logdir),
+               '--config_path={0}'.format(configfile), '--flagfile={0}'.format(flagfile), 
+               '--database_path={0}'.format(databasepath), '--daemonize']
+    __salt__['cmd.run'](cmd, timeout=10000)
+    log.info("daemonized the osqueryd")
+
+
+def _restart_osqueryd(pidfile, 
+                      configfile, 
+                      flagfile, 
+                      logdir, 
+                      databasepath, 
+                      hashfile, 
+                      servicename):
+    '''
+    This function will restart osqueryd
+    ''' 
+    log.info("osqueryd needs to be restarted, restarting now")
+
+    open_file = open(flagfile, 'r')
+    file_content = open_file.read().lower().rstrip('\n\r ').strip('\n\r')
+    hash_md5 = md5()
+    hash_md5.update(file_content.encode('ISO-8859-1'))
+    new_hash = hash_md5.hexdigest()
+
+    f = open(hashfile, "w")
+    f.write(new_hash)
+    if salt.utils.platform.is_windows():
+        stop_cmd = ['net', 'stop', servicename]
+        __salt__['cmd.run'](stop_cmd, timeout=10000)
+        start_cmd = ['net', 'start', servicename]
+        __salt__['cmd.run'](start_cmd, timeout=10000)
+    else:
+        stop_cmd = ['pkill', 'osqueryd']
+        __salt__['cmd.run'](stop_cmd, timeout=10000)
+        remove_pidfile_cmd = ['rm', '-rf', '{0}'.format(pidfile)]
+        __salt__['cmd.run'](remove_pidfile_cmd, timeout=10000)
+        start_cmd = ['/opt/osquery/osqueryd', '--pidfile={0}'.format(pidfile), '--logger_path={0}'.format(logdir),
+                     '--config_path={0}.format(configfile)', '--flagfile={0}'.format(flagfile), 
+                     '--database_path={0}'.format(databasepath), '--daemonize']
+        __salt__['cmd.run'](start_cmd, timeout=10000)
+    log.info("daemonized the osqueryd")
+
+
+def _parse_log(path_to_logfile, 
+               offset,
+               backuplogdir,
+               logfilethresholdinbytes,
+               maxlogfilesizethreshold,
+               backuplogfilescount,
+               enablediskstatslogging):
+    '''
+    Parse logs generated by osquery daemon.
+    Path to log file to be parsed should be specified
+    '''
+    event_data = []
+    file_offset = offset
+    rotateLog = False
+    if path.exists(path_to_logfile):
+        fileDes = open(path_to_logfile, "r+")
+        if fileDes:
+            if os.stat(path_to_logfile).st_size > maxlogfilesizethreshold:
+                # This is done to handle scenarios where hubble process was in stopped state and
+                # osquery daemon was generating logs for that time frame. When hubble is started and
+                # this function gets executed, it might be possible that the log file is now huge.
+                # In this scenario hubble might take too much time to process the logs which may not be required
+                # To handle this, log file size is validated against max threshold size.
+                log.info("Log file size is above max threshold size that can be parsed by Hubble.")
+                log.info("Log file size: {0}, max threshold: {1}".format(os.stat(path_to_logfile).st_size, 
+                                                                         maxlogfilesizethreshold))
+                log.info("Rotating log and skipping parsing for this iteration")
+                _perform_log_rotation(path_to_logfile, 
+                                      file_offset,
+                                      backuplogdir,
+                                      backuplogfilescount,
+                                      enablediskstatslogging,
+                                      False)
+                file_offset = 0 #Reset file offset to start of file in case original file is rotated
+            else:
+                if os.stat(path_to_logfile).st_size > logfilethresholdinbytes:
+                    rotateLog = True
+                fileDes.seek(offset)
+                for event in fileDes.readlines():
+                    event_data.append(event)
+                file_offset = fileDes.tell()
+                if rotateLog:
+                    log.info('Log file size above threshold, '
+                              'going to rotate log file: {0}'.format(path_to_logfile))
+                    residue_events = _perform_log_rotation(path_to_logfile, 
+                                                        file_offset, 
+                                                        backuplogdir, 
+                                                        backuplogfilescount,
+                                                        enablediskstatslogging,
+                                                        True)
+                    if residue_events:
+                        log.info("Found few residue logs, updating the data object")
+                        event_data.append(residue_events)
+                    file_offset = 0 #Reset file offset to start of file in case original file is rotated
+            _set_cache_offset(path_to_logfile, file_offset)
+            fileDes.close()
+        else:
+            log.error('Unable to open log file for reading: {0}'.format(path_to_logfile))
+    else:
+        log.error("Log file doesn't exists: {0}".format(path_to_logfile))
+
+    return event_data
+
+
+def _set_cache_offset(path_to_logfile, offset):
+    '''
+    Cache file offset in memory
+    '''
+    cachefilekey = os.path.basename(path_to_logfile)
+    __RESULT_LOG_OFFSET__[cachefilekey] = offset
+
+
+def _get_file_offset(path_to_logfile):
+    '''
+    Fetch file offset for specified file
+    '''
+    cachefilekey = os.path.basename(path_to_logfile)
+    offset = __RESULT_LOG_OFFSET__.get(cachefilekey, 0)
+    return offset
+
+
+def _perform_log_rotation(path_to_logfile, 
+                          offset,
+                          backuplogdir,
+                          backuplogfilescount,
+                          enablediskstatslogging,
+                          readResidueEvents):
+    '''
+    Perform log rotation on specified file and create backup of file under specified backup directory.
+    '''
+    residue_events = []
+    if path.exists(path_to_logfile):
+        if salt.utils.platform.is_windows():
+            residue_events = _rotate_log_windows(path_to_logfile, 
+                                                 offset, 
+                                                 backuplogdir, 
+                                                 backuplogfilescount, 
+                                                 readResidueEvents)
+        else:
+            if enablediskstatslogging:
+                # Not forwarding disk_stats to splunk as of now, only filesystem logging will be done
+                disk_stats = check_disk_usage()
+            residue_events = _rotate_log_posix(path_to_logfile, 
+                                               offset, 
+                                               backuplogdir, 
+                                               backuplogfilescount,
+                                               readResidueEvents)
+    return residue_events
+
+
+def _rotate_log_posix(path_to_logfile, 
+                      offset,
+                      backuplogdir,
+                      backuplogfilescount,
+                      readResidueEvents=True):
+    '''
+    Function to perform log rotation on linux systems
+    '''
+    residue_events = []
+    logfilename = os.path.basename(path_to_logfile)
+    listofbackuplogfiles = glob.glob(os.path.normpath(os.path.join(backuplogdir, logfilename)) + "*")
+
+    if listofbackuplogfiles:
+        log.info("Backup log file count: {0} and backup count threshold: {1}".format(len(listofbackuplogfiles), 
+                                                                                     backuplogfilescount))
+        listofbackuplogfiles.sort()
+        log.info("Backup log file sorted list: {0}".format(listofbackuplogfiles))
+        if(len(listofbackuplogfiles) > backuplogfilescount):
+            listofbackuplogfiles = listofbackuplogfiles[:len(listofbackuplogfiles) - backuplogfilescount]
+            for dfile in listofbackuplogfiles:
+                salt.utils.files.remove(dfile)
+            log.info("Successfully deleted backup files")
+    
+    backupLogFile = os.path.normpath(os.path.join(backuplogdir, logfilename) + "-" + str(time.time()))
+    salt.utils.files.rename(path_to_logfile, backupLogFile)
+    if readResidueEvents:
+        residue_events = _read_residue_logs(backupLogFile, offset)
+    return residue_events
+
+
+def _rotate_log_windows(path_to_logfile,
+                        offset,
+                        backuplogdir,
+                        backuplogfilescount,
+                        readResidueEvents=True):
+    '''
+    Perform log rotation on windows
+    '''
+    residue_events = []
+    logfilename = os.path.basename(path_to_logfile)
+    listofbackuplogfiles = glob.glob(os.path.normpath(os.path.join(backuplogdir, logfilename)) + "*")
+
+    if listofbackuplogfiles:
+        log.info("Backup log file count: {0} and backup count threshold: {1}".format(len(listofbackuplogfiles), 
+                                                                                     backuplogfilescount))
+        listofbackuplogfiles.sort()
+        log.info("Backup log file sorted list: {0}".format(listofbackuplogfiles))
+        if(len(listofbackuplogfiles) > backuplogfilescount):
+            listofbackuplogfiles = listofbackuplogfiles[:len(listofbackuplogfiles) - backuplogfilescount]
+            for dfile in listofbackuplogfiles:
+                salt.utils.files.remove(dfile)
+            log.info("Successfully deleted backup files")
+    
+    backupLogFile = os.path.normpath(os.path.join(backuplogdir, logfilename) + "-" + str(time.time()))
+    #salt.utils.files.rename(path_to_logfile, backupLogFile) # Throws FileInUseException on windows platform
+
+    log.info("Need to implement log rotation in windows and handle file in use exception")
+    return residue_events
+
+
+def _read_residue_logs(path_to_logfile, offset):
+    '''
+    Read any logs that might have been written while creating backup log file
+    '''
+    event_data= []
+    if path.exists(path_to_logfile):
+       fileDes = open(path_to_logfile, "r+")
+       if fileDes:
+           log.info('Checking for any residue logs that might have been '
+                     'added while log rotation was being performed')
+           fileDes.seek(offset)
+           for event in fileDes.readlines():
+               event_data.append(event)
+           fileDes.close()
+    return event_data

--- a/hubblestack/extmods/returners/splunk_osqueryd_return.py
+++ b/hubblestack/extmods/returners/splunk_osqueryd_return.py
@@ -1,0 +1,438 @@
+# -*- encoding: utf-8 -*-
+'''
+HubbleStack Nebula-osqueryd-to-Splunk returner
+
+Deliver HubbleStack Nebula osqueryd query data into Splunk using the HTTP
+event collector. Required config/pillar settings:
+
+.. code-block:: yaml
+
+    hubblestack:
+      returner:
+        splunk:
+          - token: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+            indexer: splunk-indexer.domain.tld
+            index: hubble
+            sourcetype_osqueryd: hubble_osqueryd
+
+You can also add a `custom_fields` argument which is a list of keys to add to
+events with using the results of config.get(<custom_field>). These new keys
+will be prefixed with 'custom_' to prevent conflicts. The values of these keys
+should be strings or lists (will be sent as CSV string), do not choose grains
+or pillar values with complex values or they will be skipped.
+
+Additionally, you can define a fallback_indexer which will be used if a default
+gateway is not defined.
+
+.. code-block:: yaml
+
+    hubblestack:
+      returner:
+        splunk:
+          - token: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+            indexer: splunk-indexer.domain.tld
+            index: hubble
+            sourcetype_osqueryd: hubble_osqueryd
+            fallback_indexer: splunk-indexer.loc.domain.tld
+            custom_fields:
+              - site
+              - product_group
+'''
+import socket
+
+# Imports for http event forwarder
+import requests
+import json
+import time
+import copy
+from datetime import datetime
+import urllib3
+import json
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+import logging
+
+_max_content_bytes = 100000
+http_event_collector_debug = False
+RETRY = False
+
+log = logging.getLogger(__name__)
+
+
+def returner(ret):
+    try:
+        opts_list = _get_options()
+
+        for opts in opts_list:
+            logging.debug('Options: %s' % json.dumps(opts))
+            http_event_collector_key = opts['token']
+            http_event_collector_host = opts['indexer']
+            http_event_collector_port = opts['port']
+            hec_ssl = opts['http_event_server_ssl']
+            proxy = opts['proxy']
+            timeout = opts['timeout']
+            custom_fields = opts['custom_fields']
+            http_event_collector_ssl_verify = opts['http_event_collector_ssl_verify']
+
+            # Set up the fields to be extracted at index time. The field values must be strings.
+            # Note that these fields will also still be available in the event data
+            index_extracted_fields = []
+            try:
+                index_extracted_fields.extend(__opts__.get('splunk_index_extracted_fields', []))
+            except TypeError:
+                pass
+
+            # Set up the collector
+            hec = http_event_collector(http_event_collector_key, http_event_collector_host,
+                                       http_event_port=http_event_collector_port, http_event_server_ssl=hec_ssl,
+                                       http_event_collector_ssl_verify=http_event_collector_ssl_verify,
+                                       proxy=proxy, timeout=timeout)
+            
+            data = ret['return']
+            minion_id = ret['id']
+            jid = ret['jid']
+            global RETRY
+            RETRY = ret['retry']
+            master = __grains__['master']
+            fqdn = __grains__['fqdn']
+            # Sometimes fqdn is blank. If it is, replace it with minion_id
+            fqdn = fqdn if fqdn else minion_id
+            try:
+                fqdn_ip4 = __grains__.get('local_ip4')
+                if not fqdn_ip4:
+                    fqdn_ip4 = __grains__['fqdn_ip4'][0]
+            except IndexError:
+                try:
+                    fqdn_ip4 = __grains__['ipv4'][0]
+                except IndexError:
+                    raise Exception('No ipv4 grains found. Is net-tools installed?')
+            if fqdn_ip4.startswith('127.'):
+                for ip4_addr in __grains__['ipv4']:
+                    if ip4_addr and not ip4_addr.startswith('127.'):
+                        fqdn_ip4 = ip4_addr
+                        break
+            local_fqdn = __grains__.get('local_fqdn', __grains__['fqdn'])
+
+            # Sometimes fqdn reports a value of localhost. If that happens, try another method.
+            bad_fqdns = ['localhost', 'localhost.localdomain', 'localhost6.localdomain6']
+            if fqdn in bad_fqdns:
+                new_fqdn = socket.gethostname()
+                if '.' not in new_fqdn or new_fqdn in bad_fqdns:
+                    new_fqdn = fqdn_ip4
+                fqdn = new_fqdn
+
+            # Get cloud details
+            cloud_details = __grains__.get('cloud_details', {})
+
+            if not data:
+                return
+            else:
+                for query in data:
+                    query_results = json.loads(query)
+                    event = {}
+                    query_name = query_results['name']
+                    event.update({'query': query_name})
+                    event.update({'job_id': jid})
+                    event.update({'master': master})
+                    event.update({'minion_id': minion_id})
+                    event.update({'dest_host': fqdn})
+                    event.update({'dest_ip': fqdn_ip4})
+                    event.update({'dest_fqdn': local_fqdn})
+                    event.update({'system_uuid': __grains__.get('system_uuid')})
+                    event.update({'epoch': query_results['epoch']})
+                    event.update({'counter': query_results['counter']})
+                    event.update({'action': query_results['action']})
+
+                    event.update(cloud_details)
+                    sourcetype = opts['sourcetype']
+                    if opts['add_query_to_sourcetype']:
+                        sourcetype = opts['sourcetype'] + '_' + query_name
+
+                    # If the osquery query includes a field called 'time' it will be checked.
+                    # If it's within the last year, it will be used as the eventtime.
+                    event_time = query_results.get('time', '')
+                    if 'columns' in query_results: #This means we have result log event
+                        event.update(query_results['columns'])
+                        _generate_and_send_payload(hec, 
+                                                   opts['index'], 
+                                                   sourcetype, 
+                                                   fqdn, 
+                                                   custom_fields, 
+                                                   index_extracted_fields, 
+                                                   event, 
+                                                   event_time)
+                    elif 'snapshot' in query_results: #This means we have snapshot log event
+                        for q_result in query_results['snapshot']:
+                            n_event = copy.deepcopy(event)
+                            n_event.update(q_result)
+                            _generate_and_send_payload(hec, 
+                                                       opts['index'], 
+                                                       sourcetype, 
+                                                       fqdn, 
+                                                       custom_fields, 
+                                                       index_extracted_fields, 
+                                                       n_event, 
+                                                       event_time)
+                    else:
+                        log.error("Incompatible event data captured")
+
+            hec.flushBatch()
+    except Exception:
+        log.exception('Error ocurred in splunk_osqueryd_return')
+    return
+
+
+def _generate_and_send_payload(hec, 
+                               index, 
+                               sourcetype, 
+                               fqdn, 
+                               custom_fields, 
+                               index_extracted_fields, 
+                               event, 
+                               event_time):
+    payload = {}
+    for custom_field in custom_fields:
+        custom_field_name = 'custom_' + custom_field
+        custom_field_value = __salt__['config.get'](custom_field, '')
+        if isinstance(custom_field_value, (str, unicode)):
+            event.update({custom_field_name: custom_field_value})
+        elif isinstance(custom_field_value, list):
+            custom_field_value = ','.join(custom_field_value)
+            event.update({custom_field_name: custom_field_value})
+
+    payload.update({'host': fqdn})
+    payload.update({'index': index})
+    payload.update({'sourcetype': sourcetype})
+
+    # Remove any empty fields from the event payload
+    remove_keys = [k for k in event if event[k] == ""]
+    for k in remove_keys:
+        del event[k]
+
+    payload.update({'event': event})
+
+    # Potentially add metadata fields:
+    fields = {}
+    for item in index_extracted_fields:
+        if item in payload['event'] and not isinstance(payload['event'][item], (list, dict, tuple)):
+            fields[item] = str(payload['event'][item])
+    if fields:
+        payload.update({'fields': fields})
+
+    try:
+        if (datetime.fromtimestamp(time.time()) - datetime.fromtimestamp(float(event_time))).days > 365:
+            event_time = ''
+    except Exception:
+        event_time = ''
+    finally:
+        log.info("Sending logs to splunk: {0}".format(payload))
+        hec.batchEvent(payload, eventtime=event_time)
+
+
+def _get_options():
+    if __salt__['grains.get']('hubblestack:returner:splunk'):
+        splunk_opts = []
+        returner_opts = __salt__['grains.get']('hubblestack:returner:splunk')
+        if not isinstance(returner_opts, list):
+            returner_opts = [returner_opts]
+        for opt in returner_opts:
+            processed = {}
+            processed['token'] = opt.get('token')
+            processed['indexer'] = opt.get('indexer')
+            processed['port'] = str(opt.get('port', '8088'))
+            processed['index'] = opt.get('index')
+            processed['custom_fields'] = opt.get('custom_fields', [])
+            processed['sourcetype'] = opt.get('sourcetype_osqueryd', 'hubble_osqueryd')
+            processed['add_query_to_sourcetype'] = opt.get('add_query_to_sourcetype', True)
+            processed['http_event_server_ssl'] = opt.get('hec_ssl', True)
+            processed['proxy'] = opt.get('proxy', {})
+            processed['timeout'] = opt.get('timeout', 9.05)
+            processed['http_event_collector_ssl_verify'] = opt.get('http_event_collector_ssl_verify', True)
+
+            if 'fallback_indexer' in opt and __grains__.get('ip_gw', None) is False:
+                processed['indexer'] = opt['fallback_indexer']
+            splunk_opts.append(processed)
+        return splunk_opts
+    elif __salt__['config.get']('hubblestack:returner:splunk'):
+        splunk_opts = []
+        returner_opts = __salt__['config.get']('hubblestack:returner:splunk')
+        if not isinstance(returner_opts, list):
+            returner_opts = [returner_opts]
+        for opt in returner_opts:
+            processed = {}
+            processed['token'] = opt.get('token')
+            processed['indexer'] = opt.get('indexer')
+            processed['port'] = str(opt.get('port', '8088'))
+            processed['index'] = opt.get('index')
+            processed['custom_fields'] = opt.get('custom_fields', [])
+            processed['sourcetype'] = opt.get('sourcetype_osqueryd', 'hubble_osqueryd')
+            processed['add_query_to_sourcetype'] = opt.get('add_query_to_sourcetype', True)
+            processed['http_event_server_ssl'] = opt.get('hec_ssl', True)
+            processed['proxy'] = opt.get('proxy', {})
+            processed['timeout'] = opt.get('timeout', 9.05)
+            processed['http_event_collector_ssl_verify'] = opt.get('http_event_collector_ssl_verify', True)
+
+            if 'fallback_indexer' in opt and __grains__.get('ip_gw', None) is False:
+                processed['indexer'] = opt['fallback_indexer']
+            splunk_opts.append(processed)
+        return splunk_opts
+    else:
+        splunk_opts = {}
+        splunk_opts['token'] = __salt__['config.get']('hubblestack:nebula:returner:splunk:token').strip()
+        splunk_opts['indexer'] = __salt__['config.get']('hubblestack:nebula:returner:splunk:indexer')
+        splunk_opts['port'] = __salt__['config.get']('hubblestack:nebula:returner:splunk:port', '8088')
+        splunk_opts['index'] = __salt__['config.get']('hubblestack:nebula:returner:splunk:index')
+        splunk_opts['custom_fields'] = __salt__['config.get']('hubblestack:nebula:returner:splunk:custom_fields', [])
+        splunk_opts['sourcetype'] = __salt__['config.get']('hubblestack:nebula:returner:splunk:sourcetype')
+        splunk_opts['http_event_server_ssl'] = __salt__['config.get']('hubblestack:nebula:returner:splunk:hec_ssl', True)
+        splunk_opts['proxy'] = __salt__['config.get']('hubblestack:nebula:returner:splunk:proxy', {})
+        splunk_opts['timeout'] = __salt__['config.get']('hubblestack:nebula:returner:splunk:timeout', 9.05)
+        splunk_opts['add_query_to_sourcetype'] = \
+            __salt__['config.get']('hubblestack:nebula:returner:splunk:add_query_to_sourcetype', True)
+        splunk_opts['http_event_collector_ssl_verify'] = \
+            __salt__['config.get']('hubblestack:pulsar:returner:splunk:http_event_collector_ssl_verify', True)
+
+        return [splunk_opts]
+
+
+# Thanks to George Starcher for the http_event_collector class (https://github.com/georgestarcher/)
+# Default batch max size to match splunk's default limits for max byte
+# See http_input stanza in limits.conf; note in testing I had to limit to 100,000 to avoid http event collector breaking connection
+# Auto flush will occur if next event payload will exceed limit
+
+class http_event_collector:
+
+    def __init__(self, token, http_event_server, host='', http_event_port='8088',
+                 http_event_server_ssl=True, http_event_collector_ssl_verify=True,
+                 max_bytes=_max_content_bytes, proxy=None, timeout=9.05):
+        self.timeout = timeout
+        self.token = token
+        self.batchEvents = []
+        self.maxByteLength = max_bytes
+        self.currentByteLength = 0
+        self.server_uri = []
+        self.http_event_collector_ssl_verify = http_event_collector_ssl_verify
+        if proxy and http_event_server_ssl:
+            self.proxy = {'https': 'https://{0}'.format(proxy)}
+        elif proxy:
+            self.proxy = {'http': 'http://{0}'.format(proxy)}
+        else:
+            self.proxy = {}
+
+        # Set host to specified value or default to localhostname if no value provided
+        if host:
+            self.host = host
+        else:
+            self.host = socket.gethostname()
+
+        # Build and set server_uri for http event collector
+        # Defaults to SSL if flag not passed
+        # Defaults to port 8088 if port not passed
+
+        servers = http_event_server
+        if not isinstance(servers, list):
+            servers = [servers]
+        for server in servers:
+            if http_event_server_ssl:
+                self.server_uri.append(['https://%s:%s/services/collector/event' % (server, http_event_port), True])
+            else:
+                self.server_uri.append(['http://%s:%s/services/collector/event' % (server, http_event_port), True])
+
+        if http_event_collector_debug:
+            print self.token
+            print self.server_uri
+
+    def sendEvent(self, payload, eventtime=''):
+        # Method to immediately send an event to the http event collector
+
+        headers = {'Authorization': 'Splunk ' + self.token}
+
+        # If eventtime in epoch not passed as optional argument use current system time in epoch
+        if not eventtime:
+            eventtime = str(int(time.time()))
+
+        # Fill in local hostname if not manually populated
+        if 'host' not in payload:
+            payload.update({'host': self.host})
+
+        # Update time value on payload if need to use system time
+        data = {'time': eventtime}
+        data.update(payload)
+
+        # send event to http event collector
+        r = requests.post(self.server_uri, data=json.dumps(data), headers=headers,
+                          verify=self.http_event_collector_ssl_verify, proxies=self.proxy)
+
+        # Print debug info if flag set
+        if http_event_collector_debug:
+            logger.debug(r.text)
+            logger.debug(data)
+
+    def batchEvent(self, payload, eventtime=''):
+        # Method to store the event in a batch to flush later
+
+        # Fill in local hostname if not manually populated
+        if 'host' not in payload:
+            payload.update({'host': self.host})
+
+        payloadLength = len(json.dumps(payload))
+
+        if (self.currentByteLength + payloadLength) > self.maxByteLength:
+            self.flushBatch()
+            # Print debug info if flag set
+            if http_event_collector_debug:
+                print 'auto flushing'
+        else:
+            self.currentByteLength = self.currentByteLength + payloadLength
+
+        # If eventtime in epoch not passed as optional argument use current system time in epoch
+        if not eventtime:
+            eventtime = str(int(time.time()))
+
+        # Update time value on payload if need to use system time
+        data = {'time': eventtime}
+        data.update(payload)
+
+        self.batchEvents.append(json.dumps(data))
+
+    def flushBatch(self):
+        # Method to flush the batch list of events
+
+        if len(self.batchEvents) > 0:
+            headers = {'Authorization': 'Splunk ' + self.token}
+            self.server_uri = [x for x in self.server_uri if x[1] is not False]
+            success = False
+            for server in self.server_uri:
+                retries = -1
+                max_retries = 0
+                retry_sleep = 15
+                if RETRY:
+                    max_retries = __salt__['config.get']('returner_retry_max', 3)
+                    retry_sleep = __salt__['config.get']('returner_retry_sleep', 15)
+                while retries < max_retries:
+                    retries += 1
+                    if retries != 0:
+                        log.info('RETRYING in {0} seconds'.format(retry_sleep))
+                        time.sleep(retry_sleep)
+                    try:
+                        r = requests.post(server[0], data=' '.join(self.batchEvents), headers=headers,
+                                          verify=self.http_event_collector_ssl_verify, proxies=self.proxy, timeout=self.timeout)
+                        r.raise_for_status()
+                        server[1] = True
+                        success = True
+                        break
+                    except requests.exceptions.Timeout as timeout_err:
+                        log.info('Connection timed out to splunk server {0}: {1}'.format(unicode(server[0]), unicode(timeout_err)))
+                    except requests.exceptions.ConnectionError as connect_err:
+                        log.info('Error establishing connection to splunk server {0}: {1}'.format(unicode(server[0]), unicode(connect_err)))
+                    except requests.exceptions.HTTPError as http_err:
+                        log.info('HTTP Error received while connecting to splunk server {0}: {1}'.format(unicode(server[0]), unicode(http_err)))
+                    except requests.exceptions.RequestException as gen_err:
+                        log.info('Request to splunk server {0} failed: {1}'.format(unicode(server[0]), unicode(gen_err)))
+                        server[1] = False
+                    except Exception as e:
+                        log.error('Request to splunk threw an error: {0}'.format(e))
+                if success:
+                    break
+            self.batchEvents = []
+            self.currentByteLength = 0


### PR DESCRIPTION
Following are the requirements:
======================

1) Hubble should be able to update osqueryd configuration file and flag file.
2) Should be able to parse osqueryd log file(s) and send to splunk in efficient manner, probably cache file offset etc.
3) Should be able to rotate osqueryd's log file
4) Should have capabilities to start/stop/restart osquery daemon based on hubble profile flags.
5) osqueryd should be in running state, we can need to implement monitoring capability in hubble itself to take care of this.
6) There should be an option to enable/disbale events table in osqueryd. By enabling, I mean hubble should stop auditd in case it is already running and also make sure that it is kept in stopped state while hubble is in running state in order for osquery event tables to work. Although this can be handled using discovery queries in packs.
7) Hubble should have capabilities to insert custom fields in logs that are sent to splunk.
8) Design should be single process and should consume at-most 1 CPU core as SREs might not be ok otherwise. We may or may not chose make this multi-threaded depending on performance and python support etc.
9) Should support both osqueryi and osquery daemon mode.



Final High level design post discussion with team:
====================================

1) Conf and flag files in /var/cache/hubble directory
2) Hubble nebula module to have two separate functions scheduled at probably different frequency - osqueryd_monitor and osqueryd_log_parser
3) One function would be responsible for managing/monitoring osquery daemon like start/stop/restart. Should be responsible for keeping osquery daemon in running state.
4) Other function would be responsible for parsing osquery logs and sending to splunk
5) In case auditd is enabled, we can have following two approaches:
    a) Dynamically generate osquery flag file to disable events as they anyway won't work but continue to execute standalone queries like we have in osqueryi
    b) Create a separate pack for evented queries and execute them based on discovery query (conditional execution) which would check if auditd process is running or not. (As of now, opting for this approach)
6) Hubble would continue to support existing nebula functions to schedule queries through osqueryi. Depending on Hubble conf, users can make use of osqueryi or osqueryd to execute queries
7) There should be a way to distinguish sourcetype of osqueryi and osqueryd. Due to difference in logging format of osqueryi and osqueryd, new splunk returner is being created. This would allow users to specify custom sourcetype.
8) We'll keep at-least one backup log file of osquery (after logfile truncation). This number should be configurable and can be tweaked as per individual team's needs. Like if DME wants 5 log backups and DMA wants just 1 backup, it should be doable. Regarding caching offset on filesystem, we'll see if we can cover all corner cases without saving the offset to disk. If not, we'll probably make use of offset and save it to disk.
9) Since Hubble would be dealing with log file rotation, it would be good to have a feature where-in we can check disk usage. If disk/partition is full or is above a certain threshold then either do not make backups or alert users in some manner. We can discuss this further in more detail in subsequent meetings. Implemented a basic disk usage functionality, it's usage however is still to be finalized.