### PR TITLE
Python 3 syntax error: 0755 --> 0o755

### DIFF
--- a/hubblestack/extmods/returners/sqlite.py
+++ b/hubblestack/extmods/returners/sqlite.py
@@ -63,7 +63,7 @@ def _get_conn():
         _d = os.path.dirname(_p)
         if _d and not os.path.isdir(_d):
             log.debug('creating directory {0}'.format(_d))
-            os.makedirs(_d, 0755)
+            os.makedirs(_d, 0o755)
         log.debug('connecting to database in {0}'.format(_p))
         _conn = sqlite3.connect( _options.get('dumpster', 'hubble-returns.db') )
         log.debug('creating ret table')


### PR DESCRIPTION
$ __python3 -c "0755"__  # --> SyntaxError: invalid token
$ __python2 -c "print(0755 == 0o755)"__ # --> True
