### PR TITLE
Travis CI: Run tests in parallel on Python 3 in allow_failures mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ env:
 
 python:
   - "2.7"
+  - "3.6"
+
+matrix:
+  allow_failures:
+    - python: "3.6"
 
 install:
   - pip install -r test-requirements.txt


### PR DESCRIPTION
Repo switch must be turned on at https://travis-ci.org/hubblestack