### PR TITLE
Python 3 syntax error: '\Users:' --> r'\Users:'

### DIFF
--- a/hubblestack/extmods/modules/win_pulsar.py
+++ b/hubblestack/extmods/modules/win_pulsar.py
@@ -40,7 +40,7 @@ def __virtual__():
 
 def process(configfile='salt://hubblestack_pulsar/hubblestack_pulsar_win_config.yaml',
             verbose=False):
-    '''
+    r'''
     Watch the configured files
 
     Example yaml config on fileserver (targeted by configfile option)

--- a/hubblestack/extmods/modules/win_pulsar_winaudit.py
+++ b/hubblestack/extmods/modules/win_pulsar_winaudit.py
@@ -40,7 +40,7 @@ def __virtual__():
 
 def process(configfile='salt://hubblestack_pulsar/hubblestack_pulsar_win_config.yaml',
             verbose=False):
-    '''
+    r'''
     Watch the configured files
 
     Example yaml config on fileserver (targeted by configfile option)


### PR DESCRIPTION
Python 3 will treat __\U__ in a string as a Unicode escape and will raise a syntax error so let's use an r'string' instead of a normal 'string'.
* $ __python3 -c "print('\U')__   # SyntaxError: (unicode error)
* $ __python3 -c "print(r'\U')__  # __\U__