### PR TITLE
FDG splunk returner

### DIFF
--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -437,10 +437,10 @@ def run_function():
             __returners__[returner](returner_ret)
 
     # TODO instantiate the salt outputter system?
-    if(__opts__['json_print']):
+    if __opts__['json_print']:
         print(json.dumps(ret))
     else:
-        if(__opts__['no_pprint']):
+        if not __opts__['no_pprint']:
             pprint.pprint(ret)
         else:
             print(ret)

--- a/hubblestack/extmods/modules/fdg.py
+++ b/hubblestack/extmods/modules/fdg.py
@@ -232,6 +232,7 @@ def _fdg_execute(block_id, block_data, chained=None):
     Recursive function which executes a block and any blocks chained by that
     block (by calling itself).
     '''
+    log.debug('Executing fdg block with id {0} and chained value {1}'.format(block_id, chained))
     block = block_data.get(block_id)
 
     _check_block(block, block_id)
@@ -247,18 +248,25 @@ def _fdg_execute(block_id, block_data, chained=None):
         returner = None
 
     if 'xpipe_on_true' in block and status:
+        log.debug('Piping via chaining keyword xpipe_on_true.')
         return _xpipe(ret, block_data, block['xpipe_on_true'], returner)
     elif 'xpipe_on_false' in block and not status:
+        log.debug('Piping via chaining keyword xpipe_on_false.')
         return _xpipe(ret, block_data, block['xpipe_on_false'], returner)
     elif 'pipe_on_true' in block and status:
+        log.debug('Piping via chaining keyword pipe_on_true.')
         return _pipe(ret, block_data, block['pipe_on_true'], returner)
     elif 'pipe_on_false' in block and not status:
+        log.debug('Piping via chaining keyword pipe_on_false.')
         return _pipe(ret, block_data, block['pipe_on_false'], returner)
     elif 'xpipe' in block:
+        log.debug('Piping via chaining keyword xpipe.')
         return _xpipe(ret, block_data, block['xpipe'], returner)
     elif 'pipe' in block:
+        log.debug('Piping via chaining keyword pipe.')
         return _pipe(ret, block_data, block['pipe'], returner)
     else:
+        log.debug('No valid chaining keyword matched. Returning.')
         if returner:
             _return(ret, returner)
         return ret

--- a/hubblestack/extmods/modules/fdg.py
+++ b/hubblestack/extmods/modules/fdg.py
@@ -134,6 +134,12 @@ def fdg(fdg_file, starting_chained=None):
     path to a file on the system), execute that fdg file, starting with the
     ``main`` block
 
+    Returns a tuple, with the first item in that tuple being a two-item tuple
+    with the fdg_file and the starting_chained value (dumped to a json string),
+    and the second item being the results::
+
+        ((fdg_file, starting_chained), results
+
     starting_chained
         Allows you to pass in a starting argument, which will be treated as
         the ``chained`` argument for the ``main`` block. Optional.
@@ -167,7 +173,7 @@ def fdg(fdg_file, starting_chained=None):
 
     # Recursive execution of the blocks
     ret = _fdg_execute('main', block_data, chained=starting_chained)
-    return ret
+    return (fdg_file, json.dumps(starting_chained)), ret
 
 
 def top(fdg_topfile='salt://fdg/top.fdg'):
@@ -195,8 +201,8 @@ def top(fdg_topfile='salt://fdg/top.fdg'):
 
     Returns will be compiled into a dictionary. The keys are two-item tuples,
     the first of which is the fdg file, and the second of which is the
-    (optional) ``starting_chained`` value. The values in the dictionary are
-    the associated returns from the fdg runs.
+    (optional) ``starting_chained`` value dumped to a json string. The values
+    in the dictionary are the associated returns from the fdg runs.
     '''
     fdg_routines = _get_top_data(fdg_topfile)
 
@@ -204,10 +210,11 @@ def top(fdg_topfile='salt://fdg/top.fdg'):
     for fdg_file in fdg_routines:
         if isinstance(fdg_file, dict):
             for key, val in fdg_file.iteritems():
-                ret[(key, val)] = fdg(_fdg_saltify(key), val)
+                retkey, retval = fdg(_fdg_saltify(key), val)
+                ret[retkey] = retval
         else:
-            ret[(fdg_file, None)] = fdg(_fdg_saltify(fdg_file))
-
+            retkey, retval = fdg(_fdg_saltify(fdg_file))
+            ret[retkey] = retval
     return ret
 
 

--- a/hubblestack/extmods/modules/fdg.py
+++ b/hubblestack/extmods/modules/fdg.py
@@ -115,6 +115,7 @@ will end and any ``return`` keywords will be evaluated as we move back up the
 call chain.
 '''
 from __future__ import absolute_import
+import json
 import logging
 import os
 import salt.loader

--- a/hubblestack/extmods/modules/fdg.py
+++ b/hubblestack/extmods/modules/fdg.py
@@ -240,7 +240,7 @@ def _fdg_execute(block_id, block_data, chained=None):
     # Status is used for the conditional chaining keywords
     status, ret = __fdg__[block['module']](*block.get('args', []), chained=chained, **block.get('kwargs', {}))
 
-    log.debug('fdg execution {0} returned {1}'.format(block_id, (status, ret)))
+    log.debug('fdg execution "{0}" returned {1}'.format(block_id, (status, ret)))
 
     if 'return' in block:
         returner = block['return']

--- a/hubblestack/extmods/modules/fdg.py
+++ b/hubblestack/extmods/modules/fdg.py
@@ -115,7 +115,6 @@ will end and any ``return`` keywords will be evaluated as we move back up the
 call chain.
 '''
 from __future__ import absolute_import
-import json
 import logging
 import os
 import salt.loader
@@ -136,7 +135,7 @@ def fdg(fdg_file, starting_chained=None):
     ``main`` block
 
     Returns a tuple, with the first item in that tuple being a two-item tuple
-    with the fdg_file and the starting_chained value (dumped to a json string),
+    with the fdg_file and the starting_chained value (dumped to a string),
     and the second item being the results::
 
         ((fdg_file, starting_chained), results
@@ -174,7 +173,7 @@ def fdg(fdg_file, starting_chained=None):
 
     # Recursive execution of the blocks
     ret = _fdg_execute('main', block_data, chained=starting_chained)
-    return (fdg_file, json.dumps(starting_chained)), ret
+    return (fdg_file, str(starting_chained)), ret
 
 
 def top(fdg_topfile='salt://fdg/top.fdg'):
@@ -202,7 +201,7 @@ def top(fdg_topfile='salt://fdg/top.fdg'):
 
     Returns will be compiled into a dictionary. The keys are two-item tuples,
     the first of which is the fdg file, and the second of which is the
-    (optional) ``starting_chained`` value dumped to a json string. The values
+    (optional) ``starting_chained`` value dumped to a string. The values
     in the dictionary are the associated returns from the fdg runs.
     '''
     fdg_routines = _get_top_data(fdg_topfile)

--- a/hubblestack/extmods/returners/splunk_fdg_return.py
+++ b/hubblestack/extmods/returners/splunk_fdg_return.py
@@ -138,6 +138,7 @@ def returner(ret):
                     data = {data[0]: data[1]}
                 for fdg_info, fdg_results in data.iteritems():
                     fdg_file, starting_chained = fdg_info
+                    fdg_file = fdg_file.lower().replace(' ', '_')
                     if not isinstance(fdg_results, list):
                         fdg_results = [fdg_results]
                     for fdg_result in fdg_results:
@@ -168,7 +169,7 @@ def returner(ret):
                         payload.update({'host': fqdn})
                         payload.update({'index': opts['index']})
                         if opts['add_query_to_sourcetype']:
-                            payload.update({'sourcetype': "%s_%s" % (opts['sourcetype'], query_name)})
+                            payload.update({'sourcetype': "%s_%s" % (opts['sourcetype'], fdg_file)})
                         else:
                             payload.update({'sourcetype': opts['sourcetype']})
 

--- a/hubblestack/extmods/returners/splunk_fdg_return.py
+++ b/hubblestack/extmods/returners/splunk_fdg_return.py
@@ -173,7 +173,7 @@ def returner(ret):
                             payload.update({'sourcetype': opts['sourcetype']})
 
                         # Remove any empty fields from the event payload
-                        remove_keys = [k for k in event if event[k] == ""]
+                        remove_keys = [k for k in event if event[k] == "" and not k.startswith('fdg_')]
                         for k in remove_keys:
                             del event[k]
 

--- a/hubblestack/extmods/returners/splunk_fdg_return.py
+++ b/hubblestack/extmods/returners/splunk_fdg_return.py
@@ -1,0 +1,195 @@
+# -*- encoding: utf-8 -*-
+'''
+HubbleStack FDG-to-Splunk returner
+
+Deliver HubbleStack FDG query data into Splunk using the HTTP
+event collector. Required config/pillar settings:
+
+.. code-block:: yaml
+
+    hubblestack:
+      returner:
+        splunk:
+          - token: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+            indexer: splunk-indexer.domain.tld
+            index: hubble
+            sourcetype_fdg: hubble_fdg
+
+Returns formed as a list will be sent as separate events, with the same fdg
+filename identifier. Returns from ``fdg.top`` will be separated and treated as
+separate FDG runs by this returner.
+
+You can also add a `custom_fields` argument which is a list of keys to add to
+events with using the results of config.get(<custom_field>). These new keys
+will be prefixed with 'custom_' to prevent conflicts. The values of these keys
+should be strings or lists (will be sent as CSV string), do not choose grains
+or pillar values with complex values or they will be skipped.
+
+Additionally, you can define a fallback_indexer which will be used if a default
+gateway is not defined.
+
+.. code-block:: yaml
+
+    hubblestack:
+      returner:
+        splunk:
+          - token: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+            indexer: splunk-indexer.domain.tld
+            index: hubble
+            sourcetype_fdg: hubble_fdg
+            fallback_indexer: splunk-indexer.loc.domain.tld
+            custom_fields:
+              - site
+              - product_group
+'''
+import socket
+
+# Imports for http event forwarder
+import requests
+import json
+import time
+from datetime import datetime
+from hubblestack.hec import http_event_collector, get_splunk_options
+
+import logging
+
+_max_content_bytes = 100000
+http_event_collector_debug = False
+RETRY = False
+
+log = logging.getLogger(__name__)
+
+
+def returner(ret):
+    try:
+        opts_list = get_splunk_options( sourcetype_fdg='hubble_fdg',
+            add_query_to_sourcetype=True, _nick={'sourcetype_fdg': 'sourcetype'})
+
+        for opts in opts_list:
+            logging.debug('Options: %s' % json.dumps(opts))
+            http_event_collector_key = opts['token']
+            http_event_collector_host = opts['indexer']
+            http_event_collector_port = opts['port']
+            hec_ssl = opts['http_event_server_ssl']
+            proxy = opts['proxy']
+            timeout = opts['timeout']
+            custom_fields = opts['custom_fields']
+            http_event_collector_ssl_verify = opts['http_event_collector_ssl_verify']
+
+            # Set up the fields to be extracted at index time. The field values must be strings.
+            # Note that these fields will also still be available in the event data
+            index_extracted_fields = []
+            try:
+                index_extracted_fields.extend(__opts__.get('splunk_index_extracted_fields', []))
+            except TypeError:
+                pass
+
+            # Set up the collector
+            hec = http_event_collector(http_event_collector_key, http_event_collector_host,
+                                       http_event_port=http_event_collector_port, http_event_server_ssl=hec_ssl,
+                                       http_event_collector_ssl_verify=http_event_collector_ssl_verify,
+                                       proxy=proxy, timeout=timeout)
+
+            # st = 'salt:hubble:nova'
+            data = ret['return']
+            minion_id = ret['id']
+            jid = ret['jid']
+            fun = ret['fun']
+            global RETRY
+            RETRY = ret['retry']
+            master = __grains__['master']
+            fqdn = __grains__['fqdn']
+            # Sometimes fqdn is blank. If it is, replace it with minion_id
+            fqdn = fqdn if fqdn else minion_id
+            try:
+                fqdn_ip4 = __grains__.get('local_ip4')
+                if not fqdn_ip4:
+                    fqdn_ip4 = __grains__['fqdn_ip4'][0]
+            except IndexError:
+                try:
+                    fqdn_ip4 = __grains__['ipv4'][0]
+                except IndexError:
+                    raise Exception('No ipv4 grains found. Is net-tools installed?')
+            if fqdn_ip4.startswith('127.'):
+                for ip4_addr in __grains__['ipv4']:
+                    if ip4_addr and not ip4_addr.startswith('127.'):
+                        fqdn_ip4 = ip4_addr
+                        break
+            local_fqdn = __grains__.get('local_fqdn', __grains__['fqdn'])
+
+            # Sometimes fqdn reports a value of localhost. If that happens, try another method.
+            bad_fqdns = ['localhost', 'localhost.localdomain', 'localhost6.localdomain6']
+            if fqdn in bad_fqdns:
+                new_fqdn = socket.gethostname()
+                if '.' not in new_fqdn or new_fqdn in bad_fqdns:
+                    new_fqdn = fqdn_ip4
+                fqdn = new_fqdn
+
+            # Get cloud details
+            cloud_details = __grains__.get('cloud_details', {})
+
+            if not data:
+                return
+            else:
+                if fun != 'fdg.top':
+                    if len(data) < 2:
+                        log.error('Non-fdg data found in splunk_fdg_return: {0}'.format(data))
+                        return
+                    data = {data[0]: data[1]}
+                for fdg_info, fdg_results in data.iteritems():
+                    fdg_file, starting_chained = fdg_info
+                    if not isinstance(fdg_results, list):
+                        fdg_results = [fdg_results]
+                    for fdg_result in fdg_results:
+                        event = {}
+                        payload = {}
+                        event.update({'fdg_result': fdg_result})
+                        event.update({'fdg_file': fdg_file})
+                        event.update({'fdg_starting_chained': starting_chained})
+                        event.update({'job_id': jid})
+                        event.update({'master': master})
+                        event.update({'minion_id': minion_id})
+                        event.update({'dest_host': fqdn})
+                        event.update({'dest_ip': fqdn_ip4})
+                        event.update({'dest_fqdn': local_fqdn})
+                        event.update({'system_uuid': __grains__.get('system_uuid')})
+
+                        event.update(cloud_details)
+
+                        for custom_field in custom_fields:
+                            custom_field_name = 'custom_' + custom_field
+                            custom_field_value = __salt__['config.get'](custom_field, '')
+                            if isinstance(custom_field_value, (str, unicode)):
+                                event.update({custom_field_name: custom_field_value})
+                            elif isinstance(custom_field_value, list):
+                                custom_field_value = ','.join(custom_field_value)
+                                event.update({custom_field_name: custom_field_value})
+
+                        payload.update({'host': fqdn})
+                        payload.update({'index': opts['index']})
+                        if opts['add_query_to_sourcetype']:
+                            payload.update({'sourcetype': "%s_%s" % (opts['sourcetype'], query_name)})
+                        else:
+                            payload.update({'sourcetype': opts['sourcetype']})
+
+                        # Remove any empty fields from the event payload
+                        remove_keys = [k for k in event if event[k] == ""]
+                        for k in remove_keys:
+                            del event[k]
+
+                        payload.update({'event': event})
+
+                        # Potentially add metadata fields:
+                        fields = {}
+                        for item in index_extracted_fields:
+                            if item in payload['event'] and not isinstance(payload['event'][item], (list, dict, tuple)):
+                                fields[item] = str(payload['event'][item])
+                        if fields:
+                            payload.update({'fields': fields})
+
+                        hec.batchEvent(payload)
+
+            hec.flushBatch()
+    except Exception:
+        log.exception('Error ocurred in splunk_fdg_return')
+    return

--- a/hubblestack/extmods/returners/splunk_fdg_return.py
+++ b/hubblestack/extmods/returners/splunk_fdg_return.py
@@ -90,7 +90,6 @@ def returner(ret):
                                        http_event_collector_ssl_verify=http_event_collector_ssl_verify,
                                        proxy=proxy, timeout=timeout)
 
-            # st = 'salt:hubble:nova'
             data = ret['return']
             minion_id = ret['id']
             jid = ret['jid']

--- a/hubblestack/hec/obj.py
+++ b/hubblestack/hec/obj.py
@@ -75,7 +75,6 @@ class Payload(object):
         elif 'time' not in dat:
             dat['time'] = str(int(time.time()))
 
-        self.strip_empty_dict_entries(dat)
         self.rename_event_fields_in_payload(dat)
         self.dat = json.dumps(dat)
 
@@ -98,25 +97,6 @@ class Payload(object):
                 if v is not None:
                     e[k + '_meta'] = v
 
-
-    @classmethod
-    def strip_empty_dict_entries(cls, dat):
-        todo = [dat]
-        while todo:
-            dat = todo.pop(0)
-            if isinstance(dat, dict):
-                remove_keys = [k for k in dat if not dat[k] and dat[k] not in (0,False) ]
-                for k in remove_keys:
-                    del dat[k]
-                for v in dat.values():
-                    if isinstance(v, (list,tuple,dict)):
-                        if v not in todo:
-                            todo.append(v)
-            else:
-                for item in dat:
-                    if isinstance(item, (list,tuple,dict)):
-                        if item not in todo:
-                            todo.append(item)
 
 # Thanks to George Starcher for the http_event_collector class (https://github.com/georgestarcher/)
 # Default batch max size to match splunk's default limits for max byte

--- a/hubblestack/hec/opt.py
+++ b/hubblestack/hec/opt.py
@@ -41,6 +41,7 @@ def _get_splunk_options(space, modality, **kw):
         'timeout': 9.05,
         'index_extracted_fields': [],
         'http_event_collector_ssl_verify': True,
+        'add_query_to_sourcetype': True,
     }
 
     nicknames = kw.pop('_nick', {'sourcetype_log': 'sourcetype'})


### PR DESCRIPTION
The returner for FDG has to be much more flexible than other returners because we don't know in advance in what format the data will be.

Here are the design requirements:

* Data formed as a list should be put in multiple events
* All events should have an identifier, which is a normalized fdg file name
* fdg.top results should be handled as if fdg.fdg were called on the individual files. The splunk events will look the same either way

In the process I had to tweak the return structures for the fdg system, but I think it's better for it.

I also removed the empty field stripping from the `hubblestack.hec.obj.Payload` class -- it was stripping in such a way that there were side effects, and really we only want to strip at the top-level of the event anyway in most cases -- something which is already done in the individual returners that consume this shared code. We don't want to strip all empty fields at all levels of the data in every case, so instead we'll leave that as an exercise for the individual returners, as they can tailor the stripping to the individual use cases. @jettero FYI, since this is your code.