### PR TITLE
Queue improvements

### DIFF
--- a/hubblestack/extmods/returners/splunk_nebula_return.py
+++ b/hubblestack/extmods/returners/splunk_nebula_return.py
@@ -45,7 +45,7 @@ import requests
 import json
 import time
 from datetime import datetime
-from hubblestack.hec import http_event_collector, get_splunk_options
+from hubblestack.hec import http_event_collector, get_splunk_options, make_hec_args
 
 import logging
 
@@ -63,14 +63,7 @@ def returner(ret):
 
         for opts in opts_list:
             logging.debug('Options: %s' % json.dumps(opts))
-            http_event_collector_key = opts['token']
-            http_event_collector_host = opts['indexer']
-            http_event_collector_port = opts['port']
-            hec_ssl = opts['http_event_server_ssl']
-            proxy = opts['proxy']
-            timeout = opts['timeout']
             custom_fields = opts['custom_fields']
-            http_event_collector_ssl_verify = opts['http_event_collector_ssl_verify']
 
             # Set up the fields to be extracted at index time. The field values must be strings.
             # Note that these fields will also still be available in the event data
@@ -81,10 +74,8 @@ def returner(ret):
                 pass
 
             # Set up the collector
-            hec = http_event_collector(http_event_collector_key, http_event_collector_host,
-                                       http_event_port=http_event_collector_port, http_event_server_ssl=hec_ssl,
-                                       http_event_collector_ssl_verify=http_event_collector_ssl_verify,
-                                       proxy=proxy, timeout=timeout)
+            args, kwargs = make_hec_args(opts)
+            hec = http_event_collector(*args, **kwargs)
 
             # st = 'salt:hubble:nova'
             data = ret['return']

--- a/hubblestack/extmods/returners/splunk_nova_return.py
+++ b/hubblestack/extmods/returners/splunk_nova_return.py
@@ -46,7 +46,7 @@ import json
 import time
 import logging
 
-from hubblestack.hec import http_event_collector, get_splunk_options
+from hubblestack.hec import http_event_collector, get_splunk_options, make_hec_args
 
 RETRY = False
 
@@ -60,14 +60,7 @@ def returner(ret):
 
         for opts in opts_list:
             log.debug('Options: %s' % json.dumps(opts))
-            http_event_collector_key = opts['token']
-            http_event_collector_host = opts['indexer']
-            http_event_collector_port = opts['port']
-            hec_ssl = opts['http_event_server_ssl']
-            proxy = opts['proxy']
-            timeout = opts['timeout']
             custom_fields = opts['custom_fields']
-            http_event_collector_ssl_verify = opts['http_event_collector_ssl_verify']
 
             # Set up the fields to be extracted at index time. The field values must be strings.
             # Note that these fields will also still be available in the event data
@@ -78,10 +71,9 @@ def returner(ret):
                 pass
 
             # Set up the collector
-            hec = http_event_collector(http_event_collector_key, http_event_collector_host,
-                                       http_event_port=http_event_collector_port, http_event_server_ssl=hec_ssl,
-                                       http_event_collector_ssl_verify=http_event_collector_ssl_verify,
-                                       proxy=proxy, timeout=timeout)
+            args, kwargs = make_hec_args(opts)
+            hec = http_event_collector(*args, **kwargs)
+
             # st = 'salt:hubble:nova'
             data = ret['return']
             minion_id = ret['id']

--- a/hubblestack/extmods/returners/splunk_pulsar_return.py
+++ b/hubblestack/extmods/returners/splunk_pulsar_return.py
@@ -46,7 +46,7 @@ import json
 import os
 import time
 from collections import defaultdict
-from hubblestack.hec import http_event_collector, get_splunk_options
+from hubblestack.hec import http_event_collector, get_splunk_options, make_hec_args
 
 import logging
 
@@ -66,14 +66,7 @@ def returner(ret):
 
         for opts in opts_list:
             logging.debug('Options: %s' % json.dumps(opts))
-            http_event_collector_key = opts['token']
-            http_event_collector_host = opts['indexer']
-            http_event_collector_port = opts['port']
-            hec_ssl = opts['http_event_server_ssl']
-            proxy = opts['proxy']
-            timeout = opts['timeout']
             custom_fields = opts['custom_fields']
-            http_event_collector_ssl_verify = opts['http_event_collector_ssl_verify']
 
             # Set up the fields to be extracted at index time. The field values must be strings.
             # Note that these fields will also still be available in the event data
@@ -84,10 +77,9 @@ def returner(ret):
                 pass
 
             # Set up the collector
-            hec = http_event_collector(http_event_collector_key, http_event_collector_host,
-                                       http_event_port=http_event_collector_port, http_event_server_ssl=hec_ssl,
-                                       http_event_collector_ssl_verify=http_event_collector_ssl_verify,
-                                       proxy=proxy, timeout=timeout)
+            args, kwargs = make_hec_args(opts)
+            hec = http_event_collector(*args, **kwargs)
+
             # Check whether or not data is batched:
             if isinstance(ret, dict):  # Batching is disabled
                 data = [ret]

--- a/hubblestack/hec/__init__.py
+++ b/hubblestack/hec/__init__.py
@@ -1,4 +1,4 @@
 # -*- encoding: utf-8 -*-
 
 from . obj import Payload, HEC, http_event_collector
-from . opt import get_splunk_options
+from . opt import get_splunk_options, make_hec_args

--- a/hubblestack/hec/dq.py
+++ b/hubblestack/hec/dq.py
@@ -102,9 +102,10 @@ class MemQueue(OKTypesMixin):
 class DiskQueue(OKTypesMixin):
     sep = b' '
 
-    def __init__(self, directory, size=DEFAULT_DISK_SIZE, ok_types=OK_TYPES, fresh=False):
+    def __init__(self, directory, size=DEFAULT_DISK_SIZE, ok_types=OK_TYPES, fresh=False, compression=0):
         self.init_types(ok_types)
         self.init_dq(directory, size)
+        self.compression = compression
         if fresh:
             self.clear()
         self._count()

--- a/hubblestack/hec/dq.py
+++ b/hubblestack/hec/dq.py
@@ -36,6 +36,16 @@ class OKTypesMixin:
         if not isinstance(item, self.ok_types):
             raise QueueTypeError('type({0}) is not ({1})'.format(type(item), self.ok_types))
 
+class NoQueue(object):
+    cn = 0
+    def put(self, *a, **kw):
+        log.debug('no-queue.put() dumping event')
+        pass
+    def getz(self, *a, **kw):
+        log.debug('no-queue.put() nothing to dequeue')
+        pass
+    def __bool__(self):
+        return False
 
 class MemQueue(OKTypesMixin):
     sep = b' '
@@ -43,6 +53,9 @@ class MemQueue(OKTypesMixin):
     def __init__(self, size=DEFAULT_MEMORY_SIZE, ok_types=OK_TYPES):
         self.init_types(ok_types)
         self.init_mq(size)
+
+    def __bool__(self):
+        return True
 
     def init_mq(self, size):
         self.size = size
@@ -111,6 +124,9 @@ class DiskQueue(OKTypesMixin):
         if fresh:
             self.clear()
         self._count()
+
+    def __bool__(self):
+        return True
 
     def compress(self, dat):
         if not self.compression:
@@ -236,6 +252,9 @@ class DiskBackedQueue:
 
         self.dq = DiskQueue(directory, size=disk_size, ok_types=ok_types, fresh=fresh)
         self.mq = MemQueue(size=mem_size, ok_types=ok_types)
+
+    def __bool__(self):
+        return True
 
     def put(self, item):
         try:

--- a/hubblestack/hec/dq.py
+++ b/hubblestack/hec/dq.py
@@ -1,129 +1,273 @@
 # -*- encoding: utf-8 -*-
 
-import time
-from diskcache import Deque
-from sqlite3 import DatabaseError as SQLiteDBError
-import shutil, os
-import glob
-
+import os
 import logging
+import time
+import shutil
+from collections import deque
+
+__all__ = [
+    'QueueTypeError', 'QueueCapacityError', 'MemQueue', 'DiskQueue',
+    'DiskBackedQueue', 'DEFAULT_MEMORY_SIZE', 'DEFAULT_DISK_SIZE',
+]
+
 log = logging.getLogger(__name__)
 
-class DataFormatError(ValueError):
+OK_TYPES = (str,)
+SPLUNK_MAX_MSG = 100000 # 100k
+DEFAULT_MEMORY_SIZE = SPLUNK_MAX_MSG * 5 # 500k
+DEFAULT_DISK_SIZE = DEFAULT_MEMORY_SIZE * 1000 # 0.5GB
+
+class QueueTypeError(Exception):
     pass
 
-class DiskQueue(object):
-    last_put = last_get = 0
+class QueueCapacityError(Exception):
+    pass
 
-    def __init__(self, directory, max_items=None, max_size=None, restrict_to=None):
-        self.directory = directory
-        self.max_items = max_items
-        self.max_size  = max_size
-        self.restrict_to = restrict_to
+class OKTypesMixin:
+    def __init__(self, ok_types=OK_TYPES):
+        self.init_types(ok_types)
+
+    def init_types(self, ok_types):
+        self.ok_types = ok_types
+
+    def check_type(self, item):
+        if not isinstance(item, self.ok_types):
+            raise QueueTypeError('type({0}) is not ({1})'.format(type(item), self.ok_types))
+
+
+class MemQueue(OKTypesMixin):
+    sep = b' '
+
+    def __init__(self, size=DEFAULT_MEMORY_SIZE, ok_types=OK_TYPES):
+        self.init_types(ok_types)
+        self.init_mq(size)
+
+    def init_mq(self, size):
+        self.size = size
+        # compose rather than inherit to limit operations to append()/popleft() and
+        # ignore the rest of the deque() functionality
+        self.mq = deque()
+
+    def accept(self, item):
+        if len(item) + self.sz > self.size:
+            return False
+        return True
+
+    def put(self, item):
+        self.check_type(item)
+        if not self.accept(item):
+            raise QueueCapacityError('refusing to accept item due to size')
+        self.mq.append(item)
+
+    def unget(self, item):
+        self.check_type(item)
+        self.mq.appendleft(item)
+
+    def get(self):
+        if len(self.mq) > 0:
+            return self.mq.popleft()
+
+    def getz(self, sz=SPLUNK_MAX_MSG):
+        r = b''
+        while len(self.mq) > 0 and len(r) + len(self.sep) + len(self.peek()) < sz:
+            if r:
+                r += self.sep
+            r += self.mq.popleft()
+        return r
+
+    def peek(self):
+        if len(self.mq) > 0:
+            return self.mq[0]
 
     @property
-    def q(self):
-        ''' Open the cache and return the Deque object.  It's desirable for
-        this instance to go out of scope frequently to keep the journal size
-        nominal.
-
-        If the SQLite3 file that backs the deck gets corrupted or if there's
-        SQLite3 version mismatches (etc) this property should nuke the deck and
-        quietly start from scratch.
-        '''
-
-        try:
-            return Deque(directory=self.directory)
-        except SQLiteDBError as e:
-            # The notion is: if we can't open the database because it's
-            # corrupted or the wrong sqlite version or whatever; just give up
-            # and consider those msgs lost.
-            log.error("problem opening the diskqueue at %s: %s", self.directory, e)
-            log.error("deleting the diskqueue")
-            cache_file = os.path.join(self.directory, 'cache.db')
-            if os.path.isfile(cache_file):
-                for f in glob.glob(cache_file + '*'):
-                    os.unlink(f)
-            # Retry the write. If it still doesn't work, we'll raise an
-            # exception here. Hopefully the outer daemon loop catches the
-            # error. Also, hopefully, this doesn't interrupt logging for very
-            # long. Is this a full /var/ scenario?
-            return Deque(directory=self.directory)
-
-    @property
-    def stats(self):
-        return {'items': self.eventcount, 'size': self.disksize}
-
-    @property
-    def eventcount(self):
-        return len(self.q)
-
-    @property
-    def disksize(self):
-        ''' Try to guess the size of the cache.  It will never be 100%
-        accurate because the cache is backed by SQLite3, which has a wal
-        journal.  The size of the journal is unpredictable at best.
-        '''
-        if not os.path.isdir(self.directory):
-            return 0
+    def sz(self):
         s = 0
-        for dp, dn, fn in os.walk(self.directory):
-            for pn in [ os.path.join(dp, f) for f in fn ]:
-                s += os.stat(pn).st_size
-        log.debug('q.size = %d', s)
+        for i in self.mq:
+            s += len(i)
         return s
 
-    def _drop_for_items(self):
-        if self.max_items and self.max_items > 0:
-            log.debug('_drop_for_size .max_items %d', self.max_items)
-            while self.eventcount > self.max_items:
-                self.pop()
+    @property
+    def cn(self):
+        return len(self.mq)
 
-    def _drop_for_size(self):
-        if self.max_size and self.max_size >= 1000:
-            log.debug('_drop_for_size .max_size %d', self.max_size)
-            while self.disksize > self.max_size and self.eventcount > 0:
-                self.pop()
+    @property
+    def msz(self):
+        return self.sz + max(0, len(self.sep) * (self.cn -1))
 
-    def push(self, item):
-        log.debug('pushing item to diskqueue')
-        if self.restrict_to and not isinstance(item, self.restrict_to):
-            raise DataFormatError("items in this queue must be of type {0}".format(self.restrict_to))
-        q = self.q
-        q.append(item)
-        self._drop_for_items()
-        self._drop_for_size()
-        self.last_put = time.time()
-    put = push
+    def __len__(self):
+        return self.msz
 
-    def peek(self, idx=0):
-        try:
-            return self.q[idx]
-        except IndexError:
-            pass
 
-    def pull(self):
-        if self.eventcount < 1:
-            log.debug('pull: empty')
-            return
-        try:
-            r = self.q.popleft()
-            self.last_get = time.time()
-            log.debug('pull: popped item: %s', r)
-            return r
-        except IndexError:
-            log.debug('pull: failed to pop item')
-    pop = pull
+class DiskQueue(OKTypesMixin):
+    sep = b' '
 
-    # copy *some* of the operator overloading up from the q
-    def __iter__(self):
-        return self.q.__iter__()
+    def __init__(self, directory, size=DEFAULT_DISK_SIZE, ok_types=OK_TYPES, fresh=False):
+        self.init_types(ok_types)
+        self.init_dq(directory, size)
+        if fresh:
+            self.clear()
+        self._count()
 
-    def __getitem__(self, idx):
-        return self.q[idx]
+    def init_dq(self, directory, size):
+        self.directory = directory
+        self.size = size
 
-    def __contains__(self, thing):
-        return thing in self.q
+    def _mkdir(self, partial=None):
+        d = self.directory
+        if partial is not None:
+            d = os.path.join(d, partial)
+        if not os.path.isdir(d):
+            try: os.makedirs(d)
+            except OSError as e:
+                if e.errno == errno.EEXIST and os.path.isdir(d): pass
+                else: raise
+        return d
 
     def clear(self):
-        self.q.clear()
+        if os.path.isdir(self.directory):
+            shutil.rmtree(self.directory)
+
+    def _fanout(self, name):
+        return (name[0:4], name[4:])
+
+    def accept(self, item):
+        if len(item) + self.sz > self.size:
+            return False
+        return True
+
+    def put(self, item):
+        self.check_type(item)
+        if not self.accept(item):
+            raise QueueCapacityError('refusing to accept item due to size')
+        fanout,remainder = self._fanout('{0}.{1}'.format(int(time.time()), self.cn))
+        d = self._mkdir(fanout)
+        f = os.path.join(d, remainder)
+        with open(f, 'wb') as fh:
+            log.debug('writing item to disk cache')
+            fh.write(item)
+        self._count()
+
+    def peek(self):
+        for fname in self.files:
+            with open(fname, 'rb') as fh:
+                return fh.read()
+
+    def get(self):
+        for fname in self.files:
+            with open(fname, 'rb') as fh:
+                ret = fh.read()
+            os.unlink(fname)
+            self._count()
+            return ret
+
+    def getz(self, sz=SPLUNK_MAX_MSG):
+        # Is it "dangerous" to unlink files during the os.walk (via generator)?
+        # .oO( probably doesn't matter )
+        r = b''
+        for fname in self.files:
+            with open(fname, 'rb') as fh:
+                p = fh.read()
+            if len(r) + len(self.sep) + len(p) > sz:
+                break
+            if r:
+                r += self.sep
+            r += p
+            os.unlink(fname)
+        self._count()
+        return r
+
+    def pop(self):
+        for fname in self.files:
+            os.unlink(fname)
+            break
+        self._count()
+
+    @property
+    def files(self):
+        def _k(x):
+            try:
+                return [ int(i) for i in x.split('.') ]
+            except:
+                pass
+            return x
+        for path, dirs, files in sorted(os.walk(self.directory)):
+            for fname in [ os.path.join(path, f) for f in sorted(files, key=_k) ]:
+                yield fname
+
+    def _count(self):
+        self.cn = 0
+        self.sz = 0
+        for fname in self.files:
+            self.sz += os.stat(fname).st_size
+            self.cn += 1
+        log.debug('disk cache sizes: cn=%d sz=%d', self.cn, self.sz)
+
+    @property
+    def msz(self):
+        return self.sz + max(0, self.cn-1)
+
+    def __len__(self):
+        return self.msz
+
+class DiskBackedQueue:
+    def __init__(self, directory, mem_size=DEFAULT_MEMORY_SIZE,
+        disk_size=DEFAULT_DISK_SIZE, ok_types=OK_TYPES, fresh=False):
+
+        self.dq = DiskQueue(directory, size=disk_size, ok_types=ok_types, fresh=fresh)
+        self.mq = MemQueue(size=mem_size, ok_types=ok_types)
+
+    def put(self, item):
+        try:
+            self.mq.put(item)
+        except QueueCapacityError:
+            self.dq.put(item)
+
+    def peek(self):
+        r = self.mq.peek()
+        if r is None:
+            r = self.dq.peek()
+        return r
+
+    def unget(self, msg):
+        self.mq.unget(msg)
+
+    def _disk_to_mem(self):
+        while self.dq.cn > 0:
+            # NOTE: dq.peek() read()s the file but doesn't unlink()
+            # dq.get() read()s the file and unlink()s it
+            # dq.pop() just unlink()s the file
+            # we attempt here to read each file exactly once — until the
+            # stopping condition
+            p = self.dq.peek()
+            if self.mq.accept(p):
+                self.mq.put(p)
+                self.dq.pop()
+            else:
+                break
+
+    def get(self):
+        r = self.mq.get()
+        if r is None:
+            r = self.dq.get()
+        self._disk_to_mem()
+        return r
+
+    def getz(self, sz=SPLUNK_MAX_MSG):
+        r = self.mq.getz(sz)
+        if r is None:
+            r = self.dq.getz(sz)
+        elif len(r) < sz-1:
+            r2 = self.dq.getz(sz-(len(r)+1))
+            if r2:
+                r += b' ' + r2
+        self._disk_to_mem()
+        return r
+
+    @property
+    def cn(self):
+        return self.mq.cn + self.dq.cn
+
+    @property
+    def sz(self):
+        return self.mq.sz + self.dq.sz

--- a/hubblestack/hec/dq.py
+++ b/hubblestack/hec/dq.py
@@ -66,25 +66,39 @@ class MemQueue(OKTypesMixin):
         self.mq = deque()
 
     def accept(self, item):
+        ''' test to see whether the given item would fit in the queue under the queue's size restraints '''
         if len(item) + self.sz > self.size:
             return False
         return True
 
     def put(self, item):
+        ''' Put an item in the queue at the end (FIFO order) '''
         self.check_type(item)
         if not self.accept(item):
             raise QueueCapacityError('refusing to accept item due to size')
         self.mq.append(item)
 
     def unget(self, item):
+        ''' Put an item (back) in the queue at the front (LIFO order)
+
+            This is meant to reverse a previous .get() that later turns out to
+            be un-needed.
+        '''
         self.check_type(item)
         self.mq.appendleft(item)
 
     def get(self):
+        ''' get the next item from the queue '''
         if len(self.mq) > 0:
             return self.mq.popleft()
 
     def getz(self, sz=SPLUNK_MAX_MSG):
+        ''' get items from the queue and concatenate them together using the
+        spacer ' ' until the size reaches (but does not exceed) the kwarg sz.
+
+            kwargs:
+                sz : the maxsize of the queue fetch (default: SPLUNK_MAX_MSG=100k)
+        '''
         r = b''
         while len(self.mq) > 0 and len(r) + len(self.sep) + len(self.peek()) < sz:
             if r:
@@ -93,11 +107,13 @@ class MemQueue(OKTypesMixin):
         return r
 
     def peek(self):
+        ''' look at the next item in the queue, but don't actually remove it from the queue '''
         if len(self.mq) > 0:
             return self.mq[0]
 
     @property
     def sz(self):
+        ''' the size of the queue in bytes (not counting any needed spacers) '''
         s = 0
         for i in self.mq:
             s += len(i)
@@ -105,10 +121,12 @@ class MemQueue(OKTypesMixin):
 
     @property
     def cn(self):
+        ''' the size of the queue in items (the count) '''
         return len(self.mq)
 
     @property
     def msz(self):
+        ''' The size of the queue as it would be returned from getz() iff getz had no size limit '''
         return self.sz + max(0, len(self.sep) * (self.cn -1))
 
     def __len__(self):
@@ -161,6 +179,7 @@ class DiskQueue(OKTypesMixin):
         return d
 
     def clear(self):
+        ''' clear the queue '''
         if os.path.isdir(self.directory):
             shutil.rmtree(self.directory)
 
@@ -168,11 +187,13 @@ class DiskQueue(OKTypesMixin):
         return (name[0:4], name[4:])
 
     def accept(self, item):
+        ''' test to see whether the given item would fit in the queue under the queue's size restraints '''
         if len(item) + self.sz > self.size:
             return False
         return True
 
     def put(self, item):
+        ''' Put an item in the queue at the end (FIFO order) '''
         self.check_type(item)
         if not self.accept(item):
             raise QueueCapacityError('refusing to accept item due to size')
@@ -185,11 +206,13 @@ class DiskQueue(OKTypesMixin):
         self._count()
 
     def peek(self):
+        ''' look at the next item in the queue, but don't actually remove it from the queue '''
         for fname in self.files:
             with open(fname, 'rb') as fh:
                 return self.decompress(fh.read())
 
     def get(self):
+        ''' get the next item from the queue '''
         for fname in self.files:
             with open(fname, 'rb') as fh:
                 ret = self.decompress(fh.read())
@@ -221,6 +244,7 @@ class DiskQueue(OKTypesMixin):
         return r
 
     def pop(self):
+        ''' remove the next item from the queue (do not return it); useful with .peek() '''
         for fname in self.files:
             os.unlink(fname)
             break
@@ -228,6 +252,7 @@ class DiskQueue(OKTypesMixin):
 
     @property
     def files(self):
+        ''' generate all filenames in the diskqueue (returns iterable) '''
         def _k(x):
             try:
                 return [ int(i) for i in x.split('.') ]
@@ -248,7 +273,8 @@ class DiskQueue(OKTypesMixin):
 
     @property
     def msz(self):
-        return self.sz + max(0, self.cn-1)
+        ''' The size of the queue as it would be returned from getz() iff getz had no size limit '''
+        return self.sz + max(0, len(self.sep) * (self.cn -1))
 
     def __len__(self):
         return self.msz
@@ -265,18 +291,25 @@ class DiskBackedQueue:
     __nonzero__ = __bool__ # stupid python2
 
     def put(self, item):
+        ''' Put an item in the queue at the end (FIFO order) '''
         try:
             self.mq.put(item)
         except QueueCapacityError:
             self.dq.put(item)
 
     def peek(self):
+        ''' look at the next item in the queue, but don't actually remove it from the queue '''
         r = self.mq.peek()
         if r is None:
             r = self.dq.peek()
         return r
 
     def unget(self, msg):
+        ''' Put an item (back) in the queue at the front (LIFO order)
+
+            This is meant to reverse a previous .get() that later turns out to
+            be un-needed.
+        '''
         self.mq.unget(msg)
 
     def _disk_to_mem(self):
@@ -294,6 +327,7 @@ class DiskBackedQueue:
                 break
 
     def get(self):
+        ''' get the next item from the queue '''
         r = self.mq.get()
         if r is None:
             r = self.dq.get()
@@ -301,6 +335,13 @@ class DiskBackedQueue:
         return r
 
     def getz(self, sz=SPLUNK_MAX_MSG):
+        ''' fetch items from the queue and concatenate them together using the
+            spacer ' ' until the size reaches (but does not exceed) the size
+            kwargs (sz).
+
+            kwargs:
+                sz : the maxsize of the queue fetch (default: SPLUNK_MAX_MSG=100k)
+        '''
         r = self.mq.getz(sz)
         if r is None:
             r = self.dq.getz(sz)
@@ -313,8 +354,23 @@ class DiskBackedQueue:
 
     @property
     def cn(self):
+        ''' the size of the queue in items (the count) '''
         return self.mq.cn + self.dq.cn
 
     @property
+    def msz(self):
+        ''' The size of the queue as it would be returned from getz() iff getz had no size limit '''
+        mq_msz = self.mq.msz
+        dq_msz = self.dq.msz
+        if mq_msz and dq_msz:
+            return 1 + mq_msz + dq_msz
+        if mq_msz:
+            return mq_msz
+        if dq_msz:
+            return dq_msz
+        return 0
+
+    @property
     def sz(self):
+        ''' the size of the queue in bytes (not counting any needed spacers) '''
         return self.mq.sz + self.dq.sz

--- a/hubblestack/hec/dq.py
+++ b/hubblestack/hec/dq.py
@@ -201,6 +201,13 @@ class DiskQueue(OKTypesMixin):
             return ret
 
     def getz(self, sz=SPLUNK_MAX_MSG):
+        ''' fetch items from the queue and concatenate them together using the
+            spacer ' ' until the size reaches (but does not exceed) the size
+            kwargs (sz).
+
+            kwargs:
+                sz : the maxsize of the queue fetch (default: SPLUNK_MAX_MSG=100k)
+        '''
         # Is it "dangerous" to unlink files during the os.walk (via generator)?
         # .oO( probably doesn't matter )
         r = b''

--- a/hubblestack/hec/dq.py
+++ b/hubblestack/hec/dq.py
@@ -46,6 +46,7 @@ class NoQueue(object):
         pass
     def __bool__(self):
         return False
+    __nonzero__ = __bool__ # stupid python2
 
 class MemQueue(OKTypesMixin):
     sep = b' '
@@ -56,6 +57,7 @@ class MemQueue(OKTypesMixin):
 
     def __bool__(self):
         return True
+    __nonzero__ = __bool__ # stupid python2
 
     def init_mq(self, size):
         self.size = size
@@ -127,6 +129,7 @@ class DiskQueue(OKTypesMixin):
 
     def __bool__(self):
         return True
+    __nonzero__ = __bool__ # stupid python2
 
     def compress(self, dat):
         if not self.compression:
@@ -255,6 +258,7 @@ class DiskBackedQueue:
 
     def __bool__(self):
         return True
+    __nonzero__ = __bool__ # stupid python2
 
     def put(self, item):
         try:

--- a/hubblestack/hec/dq.py
+++ b/hubblestack/hec/dq.py
@@ -157,10 +157,7 @@ class DiskQueue(OKTypesMixin):
         if partial is not None:
             d = os.path.join(d, partial)
         if not os.path.isdir(d):
-            try: os.makedirs(d)
-            except OSError as e:
-                if e.errno == errno.EEXIST and os.path.isdir(d): pass
-                else: raise
+            os.makedirs(d)
         return d
 
     def clear(self):

--- a/hubblestack/hec/dq.py
+++ b/hubblestack/hec/dq.py
@@ -107,6 +107,7 @@ class DiskQueue(OKTypesMixin):
         self.init_types(ok_types)
         self.init_dq(directory, size)
         self.compression = compression
+        log.debug('DiskQueue.__init__(%s, compression=%d)', directory, compression)
         if fresh:
             self.clear()
         self._count()

--- a/hubblestack/hec/dq.py
+++ b/hubblestack/hec/dq.py
@@ -281,7 +281,7 @@ class DiskQueue(OKTypesMixin):
 
 class DiskBackedQueue:
     def __init__(self, directory, mem_size=DEFAULT_MEMORY_SIZE,
-        disk_size=DEFAULT_DISK_SIZE, ok_types=OK_TYPES, fresh=False):
+                            disk_size=DEFAULT_DISK_SIZE, ok_types=OK_TYPES, fresh=False):
 
         self.dq = DiskQueue(directory, size=disk_size, ok_types=ok_types, fresh=fresh)
         self.mq = MemQueue(size=mem_size, ok_types=ok_types)

--- a/hubblestack/hec/dq.py
+++ b/hubblestack/hec/dq.py
@@ -176,7 +176,7 @@ class DiskQueue(OKTypesMixin):
         self.check_type(item)
         if not self.accept(item):
             raise QueueCapacityError('refusing to accept item due to size')
-        fanout,remainder = self._fanout('{0}.{1}'.format(int(time.time()), self.cn))
+        fanout, remainder = self._fanout('{0}.{1}'.format(int(time.time()), self.cn))
         d = self._mkdir(fanout)
         f = os.path.join(d, remainder)
         with open(f, 'wb') as fh:

--- a/hubblestack/hec/dq.py
+++ b/hubblestack/hec/dq.py
@@ -281,7 +281,7 @@ class DiskQueue(OKTypesMixin):
 
 class DiskBackedQueue:
     def __init__(self, directory, mem_size=DEFAULT_MEMORY_SIZE,
-                            disk_size=DEFAULT_DISK_SIZE, ok_types=OK_TYPES, fresh=False):
+            disk_size=DEFAULT_DISK_SIZE, ok_types=OK_TYPES, fresh=False):
 
         self.dq = DiskQueue(directory, size=disk_size, ok_types=ok_types, fresh=fresh)
         self.mq = MemQueue(size=mem_size, ok_types=ok_types)

--- a/hubblestack/hec/obj.py
+++ b/hubblestack/hec/obj.py
@@ -105,6 +105,7 @@ class Payload(object):
 
 class HEC(object):
     flushing_queue = False
+    last_flush = 0
 
     class Server(object):
         bad = False
@@ -228,9 +229,10 @@ class HEC(object):
         if self.queue.cn < 1:
             log.debug('nothing in queue')
             return
-        dt = time.time() - self.queue.last_get
+        dt = time.time() - self.last_flush
         if dt >= self.retry_diskqueue_interval and self.queue.cn:
             log.debug('flushing queue eventscount=%d', self.queue.cn)
+        self.last_flush = time.time()
         self.flushing_queue = True
         while self.flushing_queue:
             x = self.queue.getz()

--- a/hubblestack/hec/obj.py
+++ b/hubblestack/hec/obj.py
@@ -271,11 +271,11 @@ class HEC(object):
                 r = self.pool_manager.request('POST', server.uri, body=data, headers=self.headers)
                 server.fails = 0
             except urllib3.exceptions.LocationParseError as e:
-                log.error('server uri parse error "{0}": {1}'.format(server.uri, e))
+                log.error('server uri parse error "%s": %s', server.uri, e)
                 server.bad = True
                 continue
             except Exception as e:
-                log.error('misc exception: %s', e)
+                log.error('presumed minor error with "%s" (mark fail and continue): %s', server.uri, e)
                 server.fails += 1
                 continue
             if r.status < 400:

--- a/hubblestack/hec/obj.py
+++ b/hubblestack/hec/obj.py
@@ -298,9 +298,10 @@ class HEC(object):
                 return r
             elif r.status == 400 and r.reason.lower() == 'bad request':
                 log.error('message not accepted (%d %s), dropping payload: %s', r.status, r.reason, r.data)
-            else:
-                log.error('message not accepted (%d %s), requeueing: %s', r.status, r.reason, r.data)
-                self._requeue(payload)
+                return r
+
+        log.error('message not accepted (%d %s), requeueing: %s', r.status, r.reason, r.data)
+        self._requeue(payload)
 
     def _finish_send(self, r):
         if r is not None and hasattr(r, 'status') and hasattr(r, 'reason'):

--- a/hubblestack/hec/obj.py
+++ b/hubblestack/hec/obj.py
@@ -211,9 +211,10 @@ class HEC(object):
             class NoQueue(object):
                 cn = 0
                 def put(self, *a, **kw):
-                    # log.debug('no-queue.put() dumping event')
+                    log.debug('no-queue.put() dumping event')
                     pass
                 def getz(self, *a, **kw):
+                    log.debug('no-queue.put() nothing to dequeue')
                     pass
 
     def _queue_event(self, payload):

--- a/hubblestack/hec/obj.py
+++ b/hubblestack/hec/obj.py
@@ -293,8 +293,8 @@ class HEC(object):
                 self._requeue(payload)
 
     def _finish_send(self, r):
-        if r is not None and hasattr(r, 'text'):
-            log.debug(r.text)
+        if r is not None and hasattr(r, 'status') and hasattr(r, 'reason'):
+            log.debug('_send() result: %d %s', r.status, r.reason)
             self.flushQueue()
 
 

--- a/hubblestack/hec/obj.py
+++ b/hubblestack/hec/obj.py
@@ -23,7 +23,6 @@ http_event_collector_debug = False
 # the list of collector URLs given to the HEC object
 # are hashed into an md5 string that identifies the URL set
 # these maximums are per URL set, not for the entire disk cache
-max_diskqueue_items = 200
 max_diskqueue_size  = 10 * (1024 ** 2)
 
 class Payload(object):
@@ -128,10 +127,11 @@ class HEC(object):
     def __init__(self, token, http_event_server, host='', http_event_port='8088',
                  http_event_server_ssl=True, http_event_collector_ssl_verify=True,
                  max_bytes=_max_content_bytes, proxy=None, timeout=9.05,
-                 disk_queue='/var/cache/hubble/dq'):
+                 disk_queue='/var/cache/hubble/dq',
+                 disk_queue_size=max_diskqueue_size,
+                 disk_queue_compression=0):
 
         self.max_requeues =  5
-        self.queue_overflow_msg_delay = 10
         self.retry_diskqueue_interval = 60
 
         self.timeout = timeout
@@ -204,7 +204,7 @@ class HEC(object):
             md5.update(u)
         actual_disk_queue = os.path.join(disk_queue, md5.hexdigest())
         log.debug("disk_queue for %s: %s", uril, actual_disk_queue)
-        self.queue = DiskQueue(actual_disk_queue, size=max_diskqueue_size)
+        self.queue = DiskQueue(actual_disk_queue, size=disk_queue_size, compression=disk_queue_compression)
 
     def _queue_event(self, payload):
         try:

--- a/hubblestack/hec/obj.py
+++ b/hubblestack/hec/obj.py
@@ -246,6 +246,8 @@ class HEC(object):
 
 
     def _requeue(self, payloads):
+        if not self.queue:
+            return
         log.debug("_requeue")
         if self.flushing_queue:
             log.debug("aborting queue flush due to requeue")
@@ -325,7 +327,8 @@ class HEC(object):
     def _finish_send(self, r):
         if r is not None and hasattr(r, 'status') and hasattr(r, 'reason'):
             log.debug('_send() result: %d %s', r.status, r.reason)
-            self.flushQueue()
+            if self.queue:
+                self.flushQueue()
 
 
     def sendEvent(self, payload, eventtime='', no_queue=False):

--- a/hubblestack/hec/obj.py
+++ b/hubblestack/hec/obj.py
@@ -215,10 +215,10 @@ class HEC(object):
 
     def queueEvent(self, dat, eventtime=''):
         if not isinstance(dat, Payload):
-            payload = Payload(dat, eventtime, no_queue=no_queue)
-        if payload.no_queue: # here you silly hec, queue this no_queue payload...
+            dat = Payload(dat, eventtime, no_queue=no_queue)
+        if dat.no_queue: # here you silly hec, queue this no_queue payload...
             return
-        self._queue_event(payload)
+        self._queue_event(dat)
 
 
     def flushQueue(self):
@@ -253,7 +253,7 @@ class HEC(object):
             if pload.requeues < self.max_requeues:
                 log.debug("requeueing payload (requeues so far: %d)", pload.requeues)
                 pload.requeues += 1
-                self._queue_event(payload)
+                self._queue_event(pload)
 
 
     def _send(self, *payload):

--- a/hubblestack/hec/opt.py
+++ b/hubblestack/hec/opt.py
@@ -140,7 +140,7 @@ def make_hec_args(opts):
     return (a, kw)
 
 
-def __setup_for_testing():
+def _setup_for_testing():
     global __salt__, __opts__
     import hubblestack.daemon
     parsed_args = hubblestack.daemon.parse_args()

--- a/hubblestack/hec/opt.py
+++ b/hubblestack/hec/opt.py
@@ -125,6 +125,8 @@ def get_splunk_options(*spaces, **kw):
     return []
 
 def make_hec_args(opts):
+    if isinstance(opts, (tuple,list)):
+        return [ make_hec_args(i) for i in opts ]
     a  = (opts['token'], opts['indexer'])
     kw = {
         'http_event_port': opts['port'],

--- a/hubblestack/hec/opt.py
+++ b/hubblestack/hec/opt.py
@@ -42,6 +42,9 @@ def _get_splunk_options(space, modality, **kw):
         'index_extracted_fields': [],
         'http_event_collector_ssl_verify': True,
         'add_query_to_sourcetype': True,
+        'disk_queue': '/var/cache/hubble/dq',
+        'disk_queue_size': 10 * (1024 ** 2),
+        'disk_queue_compression': 0,
     }
 
     nicknames = kw.pop('_nick', {'sourcetype_log': 'sourcetype'})
@@ -119,6 +122,22 @@ def get_splunk_options(*spaces, **kw):
                 return ret
 
     return []
+
+def make_hec_args(opts):
+    a  = (opts['token'], opts['indexer'])
+    kw = {
+        'http_event_port': opts['port'],
+        'http_event_server_ssl': opts['http_event_server_ssl'],
+        'http_event_collector_ssl_verify': opts['http_event_collector_ssl_verify'],
+        'proxy': opts['proxy'],
+        'timeout': opts['timeout'],
+        'disk_queue': opts['disk_queue'],
+        'disk_queue_size': opts['disk_queue_size'],
+        'disk_queue_compression': opts['disk_queue_compression'],
+    }
+
+    return (a, kw)
+
 
 def __setup_for_testing():
     global __salt__, __opts__

--- a/hubblestack/hec/opt.py
+++ b/hubblestack/hec/opt.py
@@ -43,8 +43,9 @@ def _get_splunk_options(space, modality, **kw):
         'http_event_collector_ssl_verify': True,
         'add_query_to_sourcetype': True,
         'disk_queue': '/var/cache/hubble/dq',
+        'disk_queue': False, # '/var/cache/hubble/dq',
         'disk_queue_size': 10 * (1024 ** 2),
-        'disk_queue_compression': 0,
+        'disk_queue_compression': 5,
     }
 
     nicknames = kw.pop('_nick', {'sourcetype_log': 'sourcetype'})

--- a/hubblestack/splunklogging.py
+++ b/hubblestack/splunklogging.py
@@ -41,7 +41,7 @@ import requests
 import json
 import time
 import copy
-from hubblestack.hec import http_event_collector, get_splunk_options
+from hubblestack.hec import http_event_collector, get_splunk_options, make_hec_args
 
 import logging
 
@@ -59,14 +59,7 @@ class SplunkHandler(logging.Handler):
         cloud_details = __grains__.get('cloud_details', {})
 
         for opts in self.opts_list:
-            http_event_collector_key = opts['token']
-            http_event_collector_host = opts['indexer']
-            http_event_collector_port = opts['port']
-            hec_ssl = opts['http_event_server_ssl']
-            proxy = opts['proxy']
-            timeout = opts['timeout']
             custom_fields = opts['custom_fields']
-            http_event_collector_ssl_verify = opts['http_event_collector_ssl_verify']
 
             # Set up the fields to be extracted at index time. The field values must be strings.
             # Note that these fields will also still be available in the event data
@@ -77,10 +70,8 @@ class SplunkHandler(logging.Handler):
                 pass
 
             # Set up the collector
-            hec = http_event_collector(http_event_collector_key, http_event_collector_host,
-                                       http_event_port=http_event_collector_port, http_event_server_ssl=hec_ssl,
-                                       http_event_collector_ssl_verify=http_event_collector_ssl_verify,
-                                       proxy=proxy, timeout=timeout)
+            args, kwargs = make_hec_args(opts)
+            hec = http_event_collector(*args, **kwargs)
 
             minion_id = __grains__['id']
             master = __grains__['master']

--- a/hubblestack/splunklogging.py
+++ b/hubblestack/splunklogging.py
@@ -158,7 +158,7 @@ class SplunkHandler(logging.Handler):
         # to work right.
 
         rpn = getattr(record, 'pathname', '')
-        filtered = ('hubblestack/splunklogging', 'hubblestack/hec/')
+        filtered = ('hubblestack/splunklogging', 'hubblestack/hec/', 'urllib3/connectionpool')
         for i in filtered:
             if i in rpn:
                 return

--- a/pkg/amazonlinux2016.09/pyinstaller-requirements.txt
+++ b/pkg/amazonlinux2016.09/pyinstaller-requirements.txt
@@ -17,4 +17,3 @@ azure-storage-common
 azure-storage-blob
 croniter
 vulners
-diskcache

--- a/pkg/centos6/pyinstaller-requirements.txt
+++ b/pkg/centos6/pyinstaller-requirements.txt
@@ -17,4 +17,3 @@ azure-storage-common
 azure-storage-blob
 croniter
 vulners
-diskcache

--- a/pkg/centos7/pyinstaller-requirements.txt
+++ b/pkg/centos7/pyinstaller-requirements.txt
@@ -17,4 +17,3 @@ azure-storage-common
 azure-storage-blob
 croniter
 vulners
-diskcache

--- a/pkg/coreos/pyinstaller-requirements.txt
+++ b/pkg/coreos/pyinstaller-requirements.txt
@@ -17,4 +17,3 @@ azure-storage-common
 azure-storage-blob
 croniter
 vulners
-diskcache

--- a/pkg/debian7/pyinstaller-requirements.txt
+++ b/pkg/debian7/pyinstaller-requirements.txt
@@ -18,4 +18,3 @@ azure-storage-common
 azure-storage-blob
 croniter
 vulners
-diskcache

--- a/pkg/debian8/pyinstaller-requirements.txt
+++ b/pkg/debian8/pyinstaller-requirements.txt
@@ -17,4 +17,3 @@ azure-storage-common
 azure-storage-blob
 croniter
 vulners
-diskcache

--- a/pkg/debian9/pyinstaller-requirements.txt
+++ b/pkg/debian9/pyinstaller-requirements.txt
@@ -17,4 +17,3 @@ azure-storage-common
 azure-storage-blob
 croniter
 vulners
-diskcache

--- a/pkg/dev/amazonlinux2016.09/pyinstaller-requirements.txt
+++ b/pkg/dev/amazonlinux2016.09/pyinstaller-requirements.txt
@@ -17,4 +17,3 @@ azure-storage-common
 azure-storage-blob
 croniter
 vulners
-diskcache

--- a/pkg/dev/centos6/pyinstaller-requirements.txt
+++ b/pkg/dev/centos6/pyinstaller-requirements.txt
@@ -17,4 +17,3 @@ azure-storage-common
 azure-storage-blob
 croniter
 vulners
-diskcache

--- a/pkg/dev/centos7/pyinstaller-requirements.txt
+++ b/pkg/dev/centos7/pyinstaller-requirements.txt
@@ -17,4 +17,3 @@ azure-storage-common
 azure-storage-blob
 croniter
 vulners
-diskcache

--- a/pkg/dev/coreos/pyinstaller-requirements.txt
+++ b/pkg/dev/coreos/pyinstaller-requirements.txt
@@ -17,4 +17,3 @@ azure-storage-common
 azure-storage-blob
 croniter
 vulners
-diskcache

--- a/pkg/dev/debian7/pyinstaller-requirements.txt
+++ b/pkg/dev/debian7/pyinstaller-requirements.txt
@@ -18,4 +18,3 @@ azure-storage-common
 azure-storage-blob
 croniter
 vulners
-diskcache

--- a/pkg/dev/debian8/pyinstaller-requirements.txt
+++ b/pkg/dev/debian8/pyinstaller-requirements.txt
@@ -17,4 +17,3 @@ azure-storage-common
 azure-storage-blob
 croniter
 vulners
-diskcache

--- a/pkg/dev/debian9/pyinstaller-requirements.txt
+++ b/pkg/dev/debian9/pyinstaller-requirements.txt
@@ -17,4 +17,3 @@ azure-storage-common
 azure-storage-blob
 croniter
 vulners
-diskcache

--- a/pkg/windows/pyinstaller-requirements.txt
+++ b/pkg/windows/pyinstaller-requirements.txt
@@ -15,4 +15,3 @@ azure-storage-common
 azure-storage-blob
 croniter
 vulners
-diskcache

--- a/pyinstaller-requirements.txt
+++ b/pyinstaller-requirements.txt
@@ -17,4 +17,3 @@ azure-storage-common
 azure-storage-blob
 croniter
 vulners
-diskcache

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 salt-ssh
 vulners
-diskcache

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ setup(
         'gitpython',
         'pyinotify',
         'vulners == 1.3.0',
-        'diskcache',
     ],
     data_files=data_files,
     options={

--- a/tests/unittests/test_hec_dq.py
+++ b/tests/unittests/test_hec_dq.py
@@ -12,10 +12,20 @@ def summon_dq(request):
         if os.path.isdir(DQ_LOCATION):
             shutil.rmtree('/tmp/test-dq')
     fin() # make sure we don't have anything before we get started
-    request.addfinalizer(fin) # but also, make sure we clean up when we're done
+    #request.addfinalizer(fin) # but also, make sure we clean up when we're done
     def _go(**kw):
         return DiskQueue('/tmp/test-dq', **kw)
     return _go
+
+def test_getz_files(summon_dq):
+    dq = summon_dq()
+    dq.put('one')
+    dq.put('two')
+    assert len(list(dq.files)) == 0
+    assert dq.get() == 'one'
+    assert dq.get() == 'two'
+    assert len(list(dq.files)) == 0
+
 
 def test_dq_compression0(summon_dq):
     dq = summon_dq(compression=0)
@@ -28,9 +38,11 @@ def test_dq_compression0(summon_dq):
 
     dq.put('one')
     dq.put('two')
+    assert len(list(dq.files)) == 2
     assert dq.peek() == 'one'
     assert dq.get() == 'one'
     assert dq.get() == 'two'
+    assert len(list(dq.files)) == 0
 
 def test_dq_compression5(summon_dq):
     dq = summon_dq(compression=5)
@@ -44,9 +56,11 @@ def test_dq_compression5(summon_dq):
 
     dq.put('one')
     dq.put('two')
+    assert len(list(dq.files)) == 2
     assert dq.peek() == 'one'
     assert dq.get() == 'one'
     assert dq.get() == 'two'
+    assert len(list(dq.files)) == 0
 
 def test_dq_max_items(summon_dq):
     dq = summon_dq(size=100*10)

--- a/tests/unittests/test_hec_dq.py
+++ b/tests/unittests/test_hec_dq.py
@@ -17,6 +17,37 @@ def summon_dq(request):
         return DiskQueue('/tmp/test-dq', **kw)
     return _go
 
+def test_dq_compression0(summon_dq):
+    dq = summon_dq(compression=0)
+
+    source_data = ', '.join(['mah data'] * 10000)
+
+    x = dq.compress(source_data)
+    assert x == source_data
+    assert dq.decompress(x) == source_data
+
+    dq.put('one')
+    dq.put('two')
+    assert dq.peek() == 'one'
+    assert dq.get() == 'one'
+    assert dq.get() == 'two'
+
+def test_dq_compression5(summon_dq):
+    dq = summon_dq(compression=5)
+
+    source_data = ', '.join(['mah data'] * 10000)
+
+    x = dq.compress(source_data)
+    assert x != source_data
+    assert x.startswith("BZ")
+    assert dq.decompress(x) == source_data
+
+    dq.put('one')
+    dq.put('two')
+    assert dq.peek() == 'one'
+    assert dq.get() == 'one'
+    assert dq.get() == 'two'
+
 def test_dq_max_items(summon_dq):
     dq = summon_dq(size=100*10)
 


### PR DESCRIPTION
* removed diskcache, which uses sqlite3 (I feel like that's asking for trouble)
* refactored the http_event_collector options processing (more DRY is good)
* added some options @fossam wanted (compression, location, size of the diskqueue)
* fixed a missing log.error() when send fails without being an urllib3 exception
* found a major bug that prevented flushing the diskqueue; which without flushing is just a catalog of failure that never clears