### PR TITLE
fix various bad error handlings in the hec.obj

### DIFF
--- a/hubblestack/hec/obj.py
+++ b/hubblestack/hec/obj.py
@@ -291,19 +291,20 @@ class HEC(object):
                 r = self.pool_manager.request('POST', server.uri, body=data, headers=self.headers)
                 server.fails = 0
             except urllib3.exceptions.LocationParseError as e:
-                if self.log_other_exceptions:
-                    log.error('server uri parse error "{0}": {1}'.format(server.uri, e))
+                log.error('server uri parse error "{0}": {1}'.format(server.uri, e))
                 server.bad = True
                 continue
             except Exception as e:
+                log.error('misc exception: %s', e)
                 server.fails += 1
                 continue
             if r.status < 400:
                 return r
-
-        log.error('failed to send payload, queueing for later delivery')
-        self._requeue(payload)
-
+            elif r.status == 400 and r.reason.lower() == 'bad request':
+                log.error('message not accepted (%d %s), dropping payload: %s', r.status, r.reason, r.data)
+            else:
+                log.error('message not accepted (%d %s), requeueing: %s', r.status, r.reason, r.data)
+                self._requeue(payload)
 
     def _finish_send(self, r):
         if r is not None and hasattr(r, 'text'):


### PR DESCRIPTION
* the misc exception catch fails to log anything (but almost never comes up anyway)
* if the status is >= 400, the message was requeued regardless of the reply; fixed to discard if the message is malformatted (and log the fact), or to requeue on other errors unknown --- and in either case, we log as much of the reply as possible for later analysis
* the check for `if self.log_other_exceptions` is flawed (no such settting exists)