### PR TITLE
message submission accounting

### DIFF
--- a/hubblestack/extmods/modules/hstatus.py
+++ b/hubblestack/extmods/modules/hstatus.py
@@ -8,7 +8,7 @@ log = logging.getLogger(__name__)
 
 __virtualname__ = 'hstatus'
 
-SOURCETYPE = 'hubble_audit_summary'
+SOURCETYPE = 'hubble_hec_summary'
 MSG_COUNTS_PAT = r'hubblestack.hec.obj.input:(?P<stype>[^:]+)'
 
 def __virtual__():

--- a/hubblestack/extmods/modules/hstatus.py
+++ b/hubblestack/extmods/modules/hstatus.py
@@ -38,10 +38,11 @@ def msg_counts(pat=MSG_COUNTS_PAT, reset=True, emit_self=False, sourcetype=SOURC
             # a couple counts before we report/reset.
             if v['last_t'] <= v['first_t'] + 1:
                 continue
-            if v['event_count'] < 1:
+            if v['count'] <= 1:
                 continue
         except KeyError:
             continue
+
         m = pat.match(k)
         if m:
             try:

--- a/hubblestack/extmods/modules/hstatus.py
+++ b/hubblestack/extmods/modules/hstatus.py
@@ -25,13 +25,11 @@ def msg_counts(pat=r'hubblestack.hec.obj.input:(?P<stype>[^:]+)', reset=True):
             pat - the key matching algorithm is a simple regular expression
     '''
 
-    if reset:
-        log.error("TODO: reset timers")
-
     km = re.compile(pat)
     r = list()
     s = get()
     fudge_me = None
+    rst = set()
     for k,v in s.iteritems():
         try:
             if v['first_t'] == 0 or v['last_t'] == 0:
@@ -46,7 +44,11 @@ def msg_counts(pat=r'hubblestack.hec.obj.input:(?P<stype>[^:]+)', reset=True):
             r.append(d)
             if d['stype'] == 'hubble_hec_counters':
                 fudge_me = d
+        rst.add(k)
+
     if r:
+       #for k in rst:
+       #    hubblestack.status.HubbleStatus.reset(k)
         min_time = min([ x['start'] for x in r ])
         if fudge_me:
             # this is a fudge factor for the recursion where we report on own

--- a/hubblestack/extmods/modules/hstatus.py
+++ b/hubblestack/extmods/modules/hstatus.py
@@ -1,5 +1,9 @@
 
+import re
+import logging
 import hubblestack.status
+
+log = logging.getLogger(__name__)
 
 __virtualname__ = 'hstatus'
 
@@ -11,7 +15,39 @@ def get():
 
         (probably only useful from other excution modules)
     '''
-    return hubblestack.status.HubbleStatus.as_json()
+    return hubblestack.status.HubbleStatus.stats()
+
+def msg_counts(pat=r'hubblestack.hec.obj.input:(?P<stype>[^:]+)', reset=True):
+    ''' returns counter data formatted for the splunk_generic_return returner
+
+        params:
+            pat - the key matching algorithm is a simple regular expression
+    '''
+
+    if reset:
+        log.error("TODO: reset timers")
+
+    km = re.compile(pat)
+    r = list()
+    s = get()
+    for k,v in s.iteritems():
+        try:
+            if v['first_t'] == 0 or v['last_t'] == 0:
+                continue
+        except KeyError:
+            continue
+        m = km.match(k)
+        if m:
+            d = m.groupdict()
+            d.update({ 'count': v['count'], 'start': v['first_t'], 'end': v['last_t'] })
+            r.append(d)
+    if r:
+        min_time = min([ x['start'] for x in r ])
+        return {
+            'sourcetype': 'hubble_hec_counters',
+            'time': str(int(min_time)),
+            'events': r
+        }
 
 def dump():
     ''' trigger a dump to the status.json file as described in hubblestack.status
@@ -19,4 +55,4 @@ def dump():
         This is intended to be invoked from a daemon schedule and is probably
         not useful outside that context.
     '''
-    return hubblestack.status.HubbleStatus.dumpster_fire()
+    hubblestack.status.HubbleStatus.dumpster_fire()

--- a/hubblestack/extmods/modules/hstatus.py
+++ b/hubblestack/extmods/modules/hstatus.py
@@ -51,8 +51,11 @@ def msg_counts(pat=r'hubblestack.hec.obj.input:(?P<stype>[^:]+)', reset=True):
         to_reset.add(k)
 
     if ret:
-       #for k in to_reset:
-       #    hubblestack.status.HubbleStatus.reset(k)
+        # XXX: I'm not convinced we really want to reset this on every fetch
+        # it's going to make the fudge_me work out poorly sometimes (or most of the time)
+        # so the hubble_hec_counters will essentially always be wrong... is that bad??
+      # for k in to_reset:
+      #     hubblestack.status.HubbleStatus.reset(k)
         min_time = min([ x['start'] for x in ret ])
         if fudge_me:
             # this is a fudge factor for the recursion where we report on own

--- a/hubblestack/extmods/modules/hstatus.py
+++ b/hubblestack/extmods/modules/hstatus.py
@@ -24,7 +24,8 @@ def msg_counts(pat=r'hubblestack.hec.obj.input:(?P<stype>[^:]+)', reset=True):
     ''' returns counter data formatted for the splunk_generic_return returner
 
         params:
-            pat - the key matching algorithm is a simple regular expression
+            pat   - the key matching algorithm is a simple regular expression
+            reset - whether or not to reset the counters returned
     '''
 
     pat = re.compile(pat)
@@ -53,13 +54,9 @@ def msg_counts(pat=r'hubblestack.hec.obj.input:(?P<stype>[^:]+)', reset=True):
         to_reset.add(k)
 
     if ret:
-        # XXX: I'm not convinced we really want to reset this on every fetch
-        # it's going to make the fudge_me work out poorly sometimes (or most of the time)
-        # so the SOURCETYPE will essentially always be wrong... is that bad??
-      # for k in to_reset:
-      #     hubblestack.status.HubbleStatus.reset(k)
-        # See also: should I be fudging it at all? perhaps it should itself be
-        # excluded from any reports and counted completely differently.
+        if reset:
+            for k in to_reset:
+                hubblestack.status.HubbleStatus.reset(k)
         min_time = min([ x['send_session_start'] for x in ret ])
         if fudge_me:
             # this is a fudge factor for the recursion where we report on own

--- a/hubblestack/extmods/modules/hstatus.py
+++ b/hubblestack/extmods/modules/hstatus.py
@@ -9,31 +9,26 @@ log = logging.getLogger(__name__)
 __virtualname__ = 'hstatus'
 
 SOURCETYPE = 'hubble_audit_summary'
+MSG_COUNTS_PAT = r'hubblestack.hec.obj.input:(?P<stype>[^:]+)'
 
 def __virtual__():
     return True
 
-def get():
-    ''' return the counters and timing status tracked by hubblestack.status
-
-        (probably only useful from other excution modules)
-    '''
-    return hubblestack.status.HubbleStatus.stats()
-
-def msg_counts(pat=r'hubblestack.hec.obj.input:(?P<stype>[^:]+)', reset=True):
+def msg_counts(pat=MSG_COUNTS_PAT, reset=True, emit_self=False, sourcetype=SOURCETYPE):
     ''' returns counter data formatted for the splunk_generic_return returner
 
         params:
-            pat   - the key matching algorithm is a simple regular expression
-            reset - whether or not to reset the counters returned
+            pat        - the key matching algorithm is a simple regular expression
+                         (default: hstatus.MSG_COUNTS_PAT)
+            reset      - whether or not to reset the counters returned (default: True)
+            emit_self  - whether to emit sourcetype counters (default: False)
+            sourcetype - the sourcetype for the accounting messages (default: hstatus.SOURCETYPE)
     '''
 
     pat = re.compile(pat)
     ret = list() # events to return
-    got_stats = get()
-    fudge_me = None
     to_reset = set()
-    for k,v in got_stats.iteritems():
+    for k,v in hubblestack.status.HubbleStatus.stats().iteritems():
         try:
             if v['first_t'] == 0 or v['last_t'] == 0:
                 continue
@@ -41,28 +36,22 @@ def msg_counts(pat=r'hubblestack.hec.obj.input:(?P<stype>[^:]+)', reset=True):
             continue
         m = pat.match(k)
         if m:
-            # first, populate d with {'stype': 'sourcetypehere'}
-            d = m.groupdict()
-            # then add the stats
-            d.update({ 'event_count': v['count'], 'send_session_start': int(v['first_t']),
-                'send_session_end': int(math.ceil(v['last_t'])) })
-            ret.append(d)
-            # keep a pointer to the hec_counters
-            # they'll need to be fixed later
-            if d['stype'] == SOURCETYPE:
-                fudge_me = d
-        to_reset.add(k)
+            try:
+                stype = m.groupdict()['stype']
+            except KeyError:
+                continue
+            if emit_self or stype != sourcetype:
+                ret.append({ 'stype': stype,
+                    'event_count': v['count'],
+                    'send_session_start': int(v['first_t']),
+                    'send_session_end': int(math.ceil(v['last_t'])) })
+            to_reset.add(k)
 
     if ret:
         if reset:
             for k in to_reset:
                 hubblestack.status.HubbleStatus.reset(k)
-        min_time = min([ x['send_session_start'] for x in ret ])
-        if fudge_me:
-            # this is a fudge factor for the recursion where we report on own
-            # sourcetype missing the currently-being-submitted counts
-            fudge_me['event_count'] += len(ret)
-        return { 'sourcetype': SOURCETYPE, 'time': min_time, 'events': ret }
+        return { 'sourcetype': sourcetype, 'events': ret }
 
 def dump():
     ''' trigger a dump to the status.json file as described in hubblestack.status
@@ -70,4 +59,4 @@ def dump():
         This is intended to be invoked from a daemon schedule and is probably
         not useful outside that context.
     '''
-    hubblestack.status.HubbleStatus.dumpster_fire()
+    return hubblestack.status.HubbleStatus.dumpster_fire()

--- a/hubblestack/extmods/modules/hstatus.py
+++ b/hubblestack/extmods/modules/hstatus.py
@@ -30,7 +30,15 @@ def msg_counts(pat=MSG_COUNTS_PAT, reset=True, emit_self=False, sourcetype=SOURC
     to_reset = set()
     for k,v in hubblestack.status.HubbleStatus.stats().iteritems():
         try:
+            # if this counter hasn't fired at all, skip it
             if v['first_t'] == 0 or v['last_t'] == 0:
+                continue
+            # Sometimes the very first loop will give a trivial
+            # 1 second long count of exactly one event. Let's build up at least
+            # a couple counts before we report/reset.
+            if v['last_t'] <= v['first_t'] + 1:
+                continue
+            if v['event_count'] < 1:
                 continue
         except KeyError:
             continue

--- a/hubblestack/extmods/returners/splunk_generic_return.py
+++ b/hubblestack/extmods/returners/splunk_generic_return.py
@@ -17,10 +17,10 @@ event collector. Required config/pillar settings:
 '''
 
 import time
-import logging
+#import logging
 from hubblestack.hec import http_event_collector, get_splunk_options
 
-log = logging.getLogger(__name__)
+#log = logging.getLogger(__name__)
 
 def _get_key(dat, k, d=None):
     if isinstance(dat, dict):
@@ -61,7 +61,7 @@ def returner(ret):
             payload = {'host': __grains__.get('fqdn', __grains__.get('id')), 'event': event,
                 'sourcetype': _get_key(event, 'sourcetype', t_sourcetype),
                 'time': _get_key(event, 'time', t_time) }
-            log.debug("batching payload: %s", payload)
-            time.sleep(2)
+            #log.debug("batching payload: %s", payload)
+            #time.sleep(2)
             hec.batchEvent(payload)
         hec.flushBatch()

--- a/hubblestack/extmods/returners/splunk_generic_return.py
+++ b/hubblestack/extmods/returners/splunk_generic_return.py
@@ -1,0 +1,67 @@
+# -*- encoding: utf-8 -*-
+'''
+generic data to splunk returner
+
+Deliver generic HubbleStack event data into Splunk using the HTTP
+event collector. Required config/pillar settings:
+
+.. code-block:: yaml
+
+    hubblestack:
+      returner:
+        generic:
+          - token: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+            indexer: splunk-indexer.domain.tld
+            index: hubble
+            sourcetype_pulsar: generic
+'''
+
+import time
+import logging
+from hubblestack.hec import http_event_collector, get_splunk_options
+
+log = logging.getLogger(__name__)
+
+def _get_key(dat, k, d=None):
+    if isinstance(dat, dict):
+        return dat.pop(k, d)
+    return d
+
+def returner(ret):
+    try:
+        event = ret['return']
+    except KeyError:
+        return
+
+    opts_list = get_splunk_options()
+    for opts in opts_list:
+        http_event_collector_key = opts['token']
+        http_event_collector_host = opts['indexer']
+        http_event_collector_port = opts['port']
+        hec_ssl = opts['http_event_server_ssl']
+        proxy = opts['proxy']
+        timeout = opts['timeout']
+        http_event_collector_ssl_verify = opts['http_event_collector_ssl_verify']
+
+        hec = http_event_collector(http_event_collector_key, http_event_collector_host,
+                                   http_event_port=http_event_collector_port, http_event_server_ssl=hec_ssl,
+                                   http_event_collector_ssl_verify=http_event_collector_ssl_verify,
+                                   proxy=proxy, timeout=timeout)
+
+        now = str(int(time.time()))
+        t_sourcetype = _get_key(event, 'sourcetype', 'hubble_generic')
+        t_time       = _get_key(event, 'time', now)
+        event        = _get_key(event, 'event', event)
+        events       = _get_key(event, 'events', event)
+
+        if not isinstance(events, (list,tuple)):
+            events = [events]
+
+        for event in events:
+            payload = {'host': __grains__.get('fqdn', __grains__.get('id')), 'event': event,
+                'sourcetype': _get_key(event, 'sourcetype', t_sourcetype),
+                'time': _get_key(event, 'time', t_time) }
+            log.debug("batching payload: %s", payload)
+            time.sleep(2)
+            hec.batchEvent(payload)
+        hec.flushBatch()

--- a/hubblestack/hec/obj.py
+++ b/hubblestack/hec/obj.py
@@ -32,6 +32,9 @@ def count_input(payload):
     hs_key = ':'.join(['input', payload.sourcetype])
     hubble_status.add_resource(hs_key)
     hubble_status.mark(hs_key, t=payload.time)
+    # NOTE: t=payload.time is an undocumented mark() argument
+    # that ensures the first_t and last_t include the given timestamp
+    # (without this, the accounting likely wouldn't work)
 
 class Payload(object):
     ''' formatters for final payload stringification

--- a/hubblestack/hec/obj.py
+++ b/hubblestack/hec/obj.py
@@ -323,7 +323,7 @@ class HEC(object):
             if self.queue:
                 self._queue_event(data)
             else:
-                log.debug('NoQueue established')
+                log.debug('queue is NoQueue, not actually queueing anything')
 
     def _finish_send(self, r):
         if r is not None and hasattr(r, 'status') and hasattr(r, 'reason'):

--- a/hubblestack/hec/obj.py
+++ b/hubblestack/hec/obj.py
@@ -28,6 +28,11 @@ http_event_collector_debug = False
 # these maximums are per URL set, not for the entire disk cache
 max_diskqueue_size  = 10 * (1024 ** 2)
 
+def count_input(sourcetype):
+    hs_key = ':'.join(['input', sourcetype])
+    hubble_status.add_resource(hs_key)
+    hubble_status.mark(hs_key)
+
 class Payload(object):
     ''' formatters for final payload stringification
         and a convenient place to store retry counter information
@@ -226,6 +231,7 @@ class HEC(object):
             dat = Payload(dat, eventtime, no_queue=no_queue)
         if dat.no_queue: # here you silly hec, queue this no_queue payload...
             return
+        count_input(payload.sourcetype)
         self._queue_event(dat)
 
     def flushQueue(self):
@@ -322,6 +328,7 @@ class HEC(object):
 
     def sendEvent(self, payload, eventtime='', no_queue=False):
         payload = Payload.promote(payload, eventtime=eventtime, no_queue=no_queue)
+        count_input(payload.sourcetype)
 
         r = self._send(payload)
         self._finish_send(r)
@@ -329,6 +336,7 @@ class HEC(object):
 
     def batchEvent(self, dat, eventtime='', no_queue=False):
         payload = Payload.promote(dat, eventtime, no_queue=False)
+        count_input(payload.sourcetype)
 
         if (self.currentByteLength + len(payload)) > self.maxByteLength:
             self.flushBatch()

--- a/hubblestack/hec/obj.py
+++ b/hubblestack/hec/obj.py
@@ -237,7 +237,7 @@ class HEC(object):
             dat = Payload(dat, eventtime, no_queue=no_queue)
         if dat.no_queue: # here you silly hec, queue this no_queue payload...
             return
-        count_input(payload.sourcetype)
+        count_input(payload)
         self._queue_event(dat)
 
     def flushQueue(self):

--- a/hubblestack/status.py
+++ b/hubblestack/status.py
@@ -194,7 +194,7 @@ class HubbleStatus(object):
                 # NOTE: t should only be used for tracking time constrained counts
                 # (e.g., the sourcetype counts in hec.obj); we make sure the first_t
                 # and last_t include the given (e.g.) event time
-                if isinstance(t, str):
+                if isinstance(t, (str,unicode)):
                     t = int(t)
                 if t < self.first_t:
                     self.first_t = t

--- a/hubblestack/status.py
+++ b/hubblestack/status.py
@@ -184,12 +184,15 @@ class HubbleStatus(object):
                 r.update({'dur': self.dur, 'ema_dur': self.ema_dur})
             return r
 
-        def mark(self):
+        def mark(self, t=None):
             ''' mark a counter (ie, increment the count, mark the last_t =
                 time.time(), and update the ema_dt)
             '''
-            t = time.time()
-            if not self.first_t:
+            if t is None:
+                t = time.time()
+            elif isinstance(t, str):
+                t = int(t)
+            if not self.first_t or t < self.first_t:
                 self.first_t = t
             self.count += 1
             dt = self.dt
@@ -248,10 +251,10 @@ class HubbleStatus(object):
             raise HubbleStatusResourceNotFound('"{}" is not a resource of this HubbleStatus instance')
         return m
 
-    def mark(self, n):
+    def mark(self, n, t=None):
         ''' mark the named resource `n` — meaning increment the counters, update the last_t, etc '''
         n = self._checkmark(n)
-        self.dat[n].mark()
+        self.dat[n].mark(t=t)
 
     def fin(self, n):
         ''' mark the end of a duration measurement '''

--- a/hubblestack/status.py
+++ b/hubblestack/status.py
@@ -392,7 +392,7 @@ class HubbleStatus(object):
         return json.dumps(cls.stats(), indent=indent)
 
     @classmethod
-    def dumpster_fire(cls):
+    def dumpster_fire(cls, *a, **kw):
         ''' dump the status.json file to cachedir
 
             Location and filename can be adjusted with the cachedir and

--- a/hubblestack/status.py
+++ b/hubblestack/status.py
@@ -188,16 +188,23 @@ class HubbleStatus(object):
             ''' mark a counter (ie, increment the count, mark the last_t =
                 time.time(), and update the ema_dt)
             '''
-            if t is None:
-                t = time.time()
-            elif isinstance(t, str):
-                t = int(t)
-            if not self.first_t or t < self.first_t:
-                self.first_t = t
+            now = time.time()
+            if not self.first_t:
+                self.first_t = now
             self.count += 1
             dt = self.dt
-            self.last_t = t
-            self.ema_dt  = dt if self.ema_dt is None else 0.5*self.ema_dt + 0.5*dt
+            self.last_t = now
+            if t is not None:
+                # NOTE: t should only be used for tracking time constrained counts
+                # (e.g., the sourcetype counts in hec.obj); we make sure the first_t
+                # and last_t include the given (e.g.) event time
+                if isinstance(t, str):
+                    t = int(t)
+                if t < self.first_t:
+                    self.first_t = t
+                if t > self.last_t:
+                    self.last_t = t
+            self.ema_dt = dt if self.ema_dt is None else 0.5*self.ema_dt + 0.5*dt
 
         def fin(self):
             ''' mark a counter duration (ie, mark the time since the last mark, and update the ema_dur)

--- a/hubblestack/status.py
+++ b/hubblestack/status.py
@@ -164,11 +164,7 @@ class HubbleStatus(object):
         '''
 
         def __init__(self):
-            self.last_t = self.first_t = 0
-            self.count  = 0
-            self.ema_dt = None
-            self.dur = None
-            self.ema_dur = None
+            self.reset()
 
         @property
         def dt(self):
@@ -211,6 +207,13 @@ class HubbleStatus(object):
             '''
             self.dur = self.dt
             self.ema_dur  = self.dur if self.ema_dur is None else 0.5*self.ema_dur + 0.5*self.dur
+
+        def reset(self):
+            self.last_t = self.first_t = 0
+            self.count  = 0
+            self.ema_dt = None
+            self.dur = None
+            self.ema_dur = None
 
 
     def __init__(self, namespace, *resources):
@@ -306,6 +309,17 @@ class HubbleStatus(object):
         if invoke:
             return decorator(invoke)
         return decorator
+
+    @classmethod
+    def reset(cls, key=None):
+        # NOTE: this is janky... allowing resets on arbitrary keys on the
+        # class, not even tracked with _checkmark() ... but it's needed to make
+        # the sourcetype accounting beacon update meaningfully.
+        if key is None:
+            for key in cls.dat:
+                cls.dat[key].reset()
+        else:
+            cls.dat[key].reset()
 
     @classmethod
     def stats(cls):

--- a/hubblestack/status.py
+++ b/hubblestack/status.py
@@ -138,6 +138,7 @@ class HubbleStatus(object):
 
     _signaled = False
     dat = dict()
+    resources = list()
     class Stat(object):
         ''' Data sample container for a named mark.
             Stat objects have the following properties
@@ -204,8 +205,14 @@ class HubbleStatus(object):
         self.namespace = namespace
         if len(resources) == 1 and isinstance(resources[0], (list,tuple,dict)):
             resources = tuple(resources)
-        self.resources = [ self._namespaced(x) for x in resources ]
-        for r in self.resources:
+        for r in resources:
+            self.add_resource(r)
+
+    def add_resource(self, name):
+        r = self._namespaced(name)
+        if r not in self.resources:
+            self.resources.append(r)
+        if r not in self.dat:
             self.dat[r] = self.Stat()
 
     def _namespaced(self, n):


### PR DESCRIPTION
I'm not totally sure if we should call this a work in progress, or if @fossam will want changes to how the counters submit; but this is totally working for me with the below query.

(NOTE: do not actually do the below if your dataset is at all bigger than about a few thousand events... that O(N²) map search will kill your Splunk)
```
index=hubble sourcetype=hubble_hec_counters 
| table index stype count start end 
| dedup stype
| map search="tstats count as actual where index=$index$ sourcetype=$stype$ earliest=$start$ latest=$end$ | eval reported=$count$ | eval stype=\"$stype$\"" maxsearches=100
| fields stype actual reported 
| eval diff=abs(actual-reported)
| sort -diff
```