### PR TITLE
Minor logging issue

### DIFF
--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -51,7 +51,15 @@ def run():
     '''
     Set up program, daemonize if needed
     '''
-    # Don't put anything that needs config or logging above this line
+
+    # before running load_config -> salt.config.minion_config -> salt.config.load_config,
+    # salt populates logging handlers with a salt null-handler and a salt store logging handler
+    # if there are errors in the config, it then reports those errors to Null and invokes sys.exit
+    # ...
+    # clear out the salt null handlers and configure console logging for now
+    logging.root.handlers = []
+    logging.basicConfig(level=logging.INFO)
+
     try:
         load_config()
     except Exception as e:

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -856,7 +856,7 @@ def kill_other_or_sys_exit(xpid, hname=r'hubble', ksig=signal.SIGTERM, kill_othe
         # shebang; which the kernel picks up and uses to execute the real binary
         # with the "bin" file as an argument; so we'll have to live with cmdline
         pfile = '/proc/{pid}/cmdline'.format(pid=xpid)
-        log.error('searching %s for hubble procs matching %s', pfile, hname)
+        log.debug('searching %s for hubble procs matching %s', pfile, hname)
         with open(pfile,'r') as fh:
             # NOTE: cmdline is actually null separated, not space separated
             # that shouldn't matter much for most hname regular expressions,

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -485,7 +485,7 @@ def load_config():
         salt.config.DEFAULT_MINION_OPTS['log_file'] = '/var/log/hubble'
 
     salt.config.DEFAULT_MINION_OPTS['file_roots'] = {'base': []}
-    salt.config.DEFAULT_MINION_OPTS['log_level'] = None
+    salt.config.DEFAULT_MINION_OPTS['log_level'] = 'error'
     salt.config.DEFAULT_MINION_OPTS['file_client'] = 'local'
     salt.config.DEFAULT_MINION_OPTS['fileserver_update_frequency'] = 43200  # 12 hours
     salt.config.DEFAULT_MINION_OPTS['grains_refresh_frequency'] = 3600  # 1 hour

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -57,6 +57,8 @@ def run():
     # if there are errors in the config, it then reports those errors to Null and invokes sys.exit
     # ...
     # clear out the salt null handlers and configure console logging for now
+    global orig_logging_handlers
+    orig_logging_handlers = logging.root.handlers
     logging.root.handlers = []
     logging.basicConfig(level=logging.INFO)
 
@@ -608,6 +610,7 @@ def load_config():
     }
 
     # Setup logging
+    logging.root.handlers = orig_logging_handlers
     salt.log.setup.setup_console_logger(**console_logging_opts)
     salt.log.setup.setup_logfile_logger(__opts__['log_file'],
                                         __opts__['log_level'],

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -46,7 +46,6 @@ __opts__ = {}
 # This should work fine until we go to multiprocessing
 SESSION_UUID = str(uuid.uuid4())
 
-
 def run():
     '''
     Set up program, daemonize if needed
@@ -56,11 +55,12 @@ def run():
     # salt populates logging handlers with a salt null-handler and a salt store logging handler
     # if there are errors in the config, it then reports those errors to Null and invokes sys.exit
     # ...
-    # clear out the salt null handlers and configure console logging for now
-    global orig_logging_handlers
-    orig_logging_handlers = logging.root.handlers
-    logging.root.handlers = []
-    logging.basicConfig(level=logging.INFO)
+    # add a stream logger for now
+    formatter = logging.Formatter('%(asctime)s %(levelname)s %(name)s: %(message)s')
+    handler   = logging.StreamHandler()
+    handler.setLevel(logging.INFO)
+    handler.setFormatter(formatter)
+    logging.root.handlers.insert(0, handler)
 
     try:
         load_config()
@@ -610,7 +610,6 @@ def load_config():
     }
 
     # Setup logging
-    logging.root.handlers = orig_logging_handlers
     salt.log.setup.setup_console_logger(**console_logging_opts)
     salt.log.setup.setup_logfile_logger(__opts__['log_file'],
                                         __opts__['log_level'],


### PR DESCRIPTION
With this patch, if you insert yaml syntax errors in your config, hubble (actually Salt) will inform you of the errors before sys.exit.

Previous to this patch, Salt would log to the salt Null logger and sys.exit without comment.

(possibly should submit something to Salt too)