### PR TITLE
Don't reassign aws account id after attempting to cast as int

### DIFF
--- a/hubblestack/extmods/grains/cloud_details.py
+++ b/hubblestack/extmods/grains/cloud_details.py
@@ -35,7 +35,7 @@ def _get_aws_details():
         # AWS account id is always an integer number
         # So if it's an aws machine it must be a valid integer number
         # Else it will throw an Exception
-        aws['cloud_account_id'] = int(aws['cloud_account_id'])
+        int(aws['cloud_account_id'])
 
         aws['cloud_instance_id'] = requests.get('http://169.254.169.254/latest/meta-data/instance-id',
                                                 timeout=3).text


### PR DESCRIPTION
There are some AWS accounts with leading 0's, which this method breaks. Leave it as a string, but still do the type casting to check for errors.

Thanks @tbennett0