### PR TITLE
Fix the hubblestack/cent7dev for caching

### DIFF
--- a/utils/hubblestack-cent7dev.dockerfile
+++ b/utils/hubblestack-cent7dev.dockerfile
@@ -6,13 +6,7 @@ RUN yum install wget git vim python-setuptools net-tools unzip osquery gcc pytho
 WORKDIR /root
 RUN easy_install pip \
     && pip install -U setuptools
-RUN git clone --bare https://github.com/hubblestack/hubble repo
 ADD https://github.com/hubblestack/hubble/archive/develop.zip /tmp
-RUN unzip /tmp/develop.zip \
-    && mv hubble-develop hubble \
-    && mv repo hubble/.git
+RUN git clone https://github.com/hubblestack/hubble /root/hubble
 WORKDIR /root/hubble
-RUN git init \
-    && git pull \
-    && git reset HEAD
 RUN python setup.py install --force


### PR DESCRIPTION
Originally I was just going to turn off caching for the build altogether
and just do a full clone every time. But that seems a little silly. So
I added back in the ADD command even though we don't use the result. I
figure it's better to download the develop archive than to have to
install osquery and the other deps every time.

I think with these changes I can re-enable caching on the docker hub
build which will save time and resources overall even though we have the
wasted ADD command.

@mew1033 Any thoughts?