### PR TITLE
Fallback to hubble_uuid if system_uuid isn't consistent

### DIFF
--- a/hubblestack/extmods/grains/systemuuid.py
+++ b/hubblestack/extmods/grains/systemuuid.py
@@ -2,7 +2,6 @@
 '''
 Gather the system uuid via osquery
 '''
-import os
 import salt.utils.path
 import salt.modules.cmdmod
 

--- a/hubblestack/extmods/grains/systemuuid.py
+++ b/hubblestack/extmods/grains/systemuuid.py
@@ -2,6 +2,7 @@
 '''
 Gather the system uuid via osquery
 '''
+import os
 import salt.utils.path
 import salt.modules.cmdmod
 
@@ -11,6 +12,9 @@ __salt__ = {'cmd.run': salt.modules.cmdmod._run_quiet}
 def get_system_uuid():
     '''
     Gather the system uuid via osquery
+
+    If osquery can't get a hardware-based value, it'll just randomly generate a new uuid every time.
+    If that happens, fall back to the hubble_uuid.
     '''
     # Provides:
     #   system_uuid
@@ -22,9 +26,17 @@ def get_system_uuid():
     grains = {}
     for path in osqueryipaths:
         if salt.utils.path.which(path):
-            out = __salt__['cmd.run']('{0} {1}'.format(path, options))
-            out = str(out).upper()
-            if len(out) == 36:
-                grains = {"system_uuid": out}
+            first_run = __salt__['cmd.run']('{0} {1}'.format(path, options))
+            first_run = str(first_run).upper()
+
+            second_run = __salt__['cmd.run']('{0} {1}'.format(path, options))
+            second_run = str(second_run).upper()
+
+            if len(first_run) == 36 and first_run == second_run:
+                grains = {"system_uuid": first_run}
+            else:
+                existing_uuid = __opts__.get('hubble_uuid', None)
+                if existing_uuid:
+                    {"system_uuid": existing_uuid}
             break
     return grains


### PR DESCRIPTION
On some hosts, system_uuid isn't generated, and osquery creates a random value every time. If that's happening, we should fallback to the cached hubble_uuid value.