### PR TITLE
Log major signals to splunk

### DIFF
--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -527,7 +527,7 @@ def load_config():
 
     if __opts__['daemonize']:
         # before becoming a daemon, check for other procs and possibly send
-        # then a signal 15 (otherwise refuse to run)
+        # them a signal 15 (otherwise refuse to run)
         if not __opts__.get('ignore_running', False):
             check_pidfile(kill_other=True, scan_proc=scan_proc)
         salt.utils.daemonize()
@@ -829,7 +829,6 @@ def check_pidfile(kill_other=False, scan_proc=True):
         processes; otherwise exit with an error.
 
     '''
-
     pidfile = __opts__['pidfile']
     if os.path.isfile(pidfile):
         with open(pidfile, 'r') as f:
@@ -913,6 +912,9 @@ def kill_other_or_sys_exit(xpid, hname=r'hubble', ksig=signal.SIGTERM, kill_othe
             else:
                 log.error("refusing to run while another hubble instance is running")
                 sys.exit(1)
+    else:
+        # pidfile present, but nothing at that pid. Did we receive a sigterm?
+        log.warning('Pidfile found on startup, but no process at that pid. Did hubble receive a SIGTERM?')
     return False
 
 def scan_proc_for_hubbles(proc_path='/proc', hname=r'^/\S+python.*?/opt/.*?hubble', kill_other=True, ksig=signal.SIGTERM):

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -184,7 +184,7 @@ def main():
                                          'host']
                  grains_to_emit = []
                  grains_to_emit.extend(__opts__.get('emit_grains_to_syslog_list', default_grains_to_emit))
-                 emit_to_syslog(grains_to_emit) 
+                 emit_to_syslog(grains_to_emit)
 
         try:
             log.debug('Executing schedule')
@@ -289,7 +289,7 @@ def schedule():
 
     min_splay
         This parameters works in conjunction with <splay>. If a <min_splay> is provided, and random
-        between <min_splay> and <splay> is chosen. If <min_splay> is not provided, it 
+        between <min_splay> and <splay> is chosen. If <min_splay> is not provided, it
         defaults to zero. Optional.
 
     args
@@ -500,7 +500,7 @@ def load_config():
     salt.config.DEFAULT_MINION_OPTS['osquery_logfile_maxbytes'] = 50000000 # 50MB
     salt.config.DEFAULT_MINION_OPTS['osquery_logfile_maxbytes_toparse'] = 100000000 #100MB
     salt.config.DEFAULT_MINION_OPTS['osquery_backuplogs_count'] = 2
-    
+
 
     global __opts__
 

--- a/hubblestack/status.py
+++ b/hubblestack/status.py
@@ -425,17 +425,18 @@ class HubbleStatus(object):
             hubble:status:dumpster options (see above).
         '''
         try:
-            handler = hubblestack.splunklogging.SplunkHandler()
-            class MockRecord(object):
-                def __init__(self, message, levelname, asctime, name):
-                    self.message = message
-                    self.levelname = levelname
-                    self.asctime = asctime
-                    self.name = name
-            handler.emit(MockRecord('Signal {0} detected'.format(signal.SIGUSR1),
-                                    'INFO',
-                                    time.asctime(),
-                                    'hubblestack.signals'))
+            if __salt__['config.get']('splunklogging', False):
+                handler = hubblestack.splunklogging.SplunkHandler()
+                class MockRecord(object):
+                    def __init__(self, message, levelname, asctime, name):
+                        self.message = message
+                        self.levelname = levelname
+                        self.asctime = asctime
+                        self.name = name
+                handler.emit(MockRecord('Signal {0} detected'.format(signal.SIGUSR1),
+                                        'INFO',
+                                        time.asctime(),
+                                        'hubblestack.signals'))
         finally:
             dumpster = get_hubble_status_opt('dumpster') or 'status.json'
             if not dumpster.startswith('/'):

--- a/hubblestack/status.py
+++ b/hubblestack/status.py
@@ -38,6 +38,8 @@ import signal
 import logging
 import os
 
+import hubblestack.splunklogging
+
 log = logging.getLogger(__name__)
 
 DEFAULTS = {
@@ -422,17 +424,30 @@ class HubbleStatus(object):
             Location and filename can be adjusted with the cachedir and
             hubble:status:dumpster options (see above).
         '''
-        dumpster = get_hubble_status_opt('dumpster') or 'status.json'
-        if not dumpster.startswith('/'):
-            cachedir = get_hubble_or_salt_opt('cachedir') or '/tmp'
-            dumpster = os.path.join(cachedir, dumpster)
         try:
-            with open(dumpster, 'w') as fh:
-                fh.write(cls.as_json())
-                fh.write('\n')
-            log.info("wrote HubbleStatus to %s", dumpster)
-        except:
-            log.exception("ignoring exception during dumpster fire")
+            handler = hubblestack.splunklogging.SplunkHandler()
+            class MockRecord(object):
+                def __init__(self, message, levelname, asctime, name):
+                    self.message = message
+                    self.levelname = levelname
+                    self.asctime = asctime
+                    self.name = name
+            handler.emit(MockRecord('Signal {0} detected'.format(signal.SIGUSR1),
+                                    'INFO',
+                                    time.asctime(),
+                                    'hubblestack.signals'))
+        finally:
+            dumpster = get_hubble_status_opt('dumpster') or 'status.json'
+            if not dumpster.startswith('/'):
+                cachedir = get_hubble_or_salt_opt('cachedir') or '/tmp'
+                dumpster = os.path.join(cachedir, dumpster)
+            try:
+                with open(dumpster, 'w') as fh:
+                    fh.write(cls.as_json())
+                    fh.write('\n')
+                log.info("wrote HubbleStatus to %s", dumpster)
+            except:
+                log.exception("ignoring exception during dumpster fire")
 
     @classmethod
     def start_sigusr1_signal_handler(cls):


### PR DESCRIPTION
As requested in https://jira.corp.adobe.com/browse/CSTTEAM-44470, this logs major signals to splunk when received.

Note that it doesn't log SIGALRM since we use that internally for setting interrupt timers on things that might hang (such as grains refreshes).

Future editions of this functionality could use a library like 
https://github.com/larsks/python-signalfd to get more information about where the signal came from, and could also do some HASATTR magic to catch all the signals supported by a given system. (I only included the most common)

Talking to @fossam he thinks we should just hold off until we can include that additional information, but since I was already mostly done with the code I figured I'd submit this PR for discussion. Thoughts?