### PR TITLE
Remove bad cachedir and log_file definitions from windows config

### DIFF
--- a/pkg/windows/hubble.conf
+++ b/pkg/windows/hubble.conf
@@ -14,17 +14,6 @@ fileserver_backend:
   - roots
 
 #################################
-## CacheDir and Log_File Locatoin
-#################################
-##
-## Hubble will auto create a DIR in C:\salt, since it uses a lot of salt 
-## dependancies.  This will change it so it places the chache and log in with the
-## Hubble directory where everything else is stored.
-
-cachedir:
-log_file:
-  
-#################################
 ## Scheduler Config
 #################################
 ##


### PR DESCRIPTION
I don't know how this got here. We handle the defaults in daemon.py.

Submitting against 3.0 branch since this is a bugfix.

Fixes #513 