### PR TITLE
Enhancing nebula to generate osquery conf from yaml files

### DIFF
--- a/hubblestack/extmods/grains/hubbleversion.py
+++ b/hubblestack/extmods/grains/hubbleversion.py
@@ -14,3 +14,17 @@ def hubble_version():
     Add the hubble version to the grains
     '''
     return {'hubble_version': __version__}
+
+
+def hubble_build_metadata():
+    '''
+    Add hubble build metadata to grains
+    '''
+    build_metadata = {}
+    try:
+        from hubblestack import __buildinfo__
+    except ImportError:
+        __buildinfo__ = {'build_metadata': 'NOT SET'}
+    build_metadata.update(__buildinfo__)
+
+    return {'buildinfo': build_metadata}

--- a/hubblestack/extmods/modules/nebula_osquery.py
+++ b/hubblestack/extmods/modules/nebula_osquery.py
@@ -294,10 +294,10 @@ def osqueryd_monitor(configfile=None,
     '''
     log.info("Starting osqueryd monitor")
     saltenv = __salt__['config.get']('hubblestack:nova:saltenv', 'base')
-    osqueryd_path = 'salt://osquery'
+    osqueryd_path = 'salt://hubblestack_nebula_v2'
     cached = __salt__['cp.cache_dir'](osqueryd_path, saltenv=saltenv)
-    log.info('Cached osqueryd files to cachedir')
-    cachedir = os.path.join(__opts__.get('cachedir'), 'files', saltenv, 'osquery')
+    log.debug('Cached nebula files to cachedir')
+    cachedir = os.path.join(__opts__.get('cachedir'), 'files', saltenv, 'hubblestack_nebula_v2')
     base_path = cachedir
     servicename = "hubble_osqueryd"
     if not logdir:

--- a/hubblestack/extmods/modules/nebula_osquery.py
+++ b/hubblestack/extmods/modules/nebula_osquery.py
@@ -621,7 +621,7 @@ def _generate_osquery_conf_file(conftopfile):
     cachedir = os.path.join(__opts__.get('cachedir'), 'files', saltenv, 'hubblestack_nebula_v2')
     base_path = cachedir
 
-    osqd_configs = _get_osquery_top_data(conftopfile)
+    osqd_configs = _get_top_data(conftopfile)
     configfile = os.path.join(base_path, "osquery.conf")
     conf_data = {}
     osqd_configs = ['salt://hubblestack_nebula_v2/' + config.replace('.', '/') + '.yaml' for config in osqd_configs]
@@ -667,7 +667,7 @@ def _generate_osquery_flags_file(flagstopfile):
     cachedir = os.path.join(__opts__.get('cachedir'), 'files', saltenv, 'hubblestack_nebula_v2')
     base_path = cachedir
 
-    osqd_flags = _get_osquery_top_data(flagstopfile)
+    osqd_flags = _get_top_data(flagstopfile)
     flagfile = os.path.join(base_path, "osquery.flags")
     flags_data = {}
     osqd_flags = ['salt://hubblestack_nebula_v2/' + config.replace('.', '/') + '.yaml' for config in osqd_flags]
@@ -699,35 +699,6 @@ def _generate_osquery_flags_file(flagstopfile):
             log.error("Failed to generate osquery flags file using topfile {0}".format(e))
     
     return flagfile
-
-
-def _get_osquery_top_data(topfile):
-
-    topfile = __salt__['cp.cache_file'](topfile)
-
-    try:
-        with open(topfile) as handle:
-            topdata = yaml.safe_load(handle)
-    except Exception as e:
-        raise CommandExecutionError('Could not load topfile: {0}'.format(e))
-
-    if not isinstance(topdata, dict) or 'osquery' not in topdata or \
-            not isinstance(topdata['osquery'], list):
-        raise CommandExecutionError('Osquery topfile not formatted correctly. '
-                                    'Note that under the "osquery" key the data '
-                                    'should now be formatted as a list of '
-                                    'single-key dicts.')
-
-    topdata = topdata['osquery']
-
-    ret = []
-
-    for topmatch in topdata:
-        for match, data in topmatch.iteritems():
-            if __salt__['match.compound'](match):
-                ret.extend(data)
-
-    return ret
 
 
 def _mask_object(object_to_be_masked, topfile):

--- a/hubblestack/extmods/modules/nebula_osquery.py
+++ b/hubblestack/extmods/modules/nebula_osquery.py
@@ -301,9 +301,9 @@ def osqueryd_monitor(configfile=None,
     base_path = cachedir
     servicename = "hubble_osqueryd"
     if not logdir:
-            logdir = __opts__.get('osquerylogpath')
+        logdir = __opts__.get('osquerylogpath')
     if not databasepath:
-            databasepath = __opts__.get('osquery_dbpath')
+        databasepath = __opts__.get('osquery_dbpath')
     if salt.utils.platform.is_windows():
         if not pidfile:
             pidfile = os.path.join(base_path, "hubble_osqueryd.pidfile")
@@ -445,10 +445,10 @@ def osqueryd_log_parser(osqueryd_logdir=None,
         for r in ret:
             obj = json.loads(r)
             if 'action' in obj and obj['action'] == 'snapshot':
-                    for result in obj['snapshot']:
-                        for key, value in result.iteritems():
-                            if value and isinstance(value, basestring) and value.startswith('__JSONIFY__'):
-                                result[key] = json.loads(value[len('__JSONIFY__'):])
+                for result in obj['snapshot']:
+                    for key, value in result.iteritems():
+                        if value and isinstance(value, basestring) and value.startswith('__JSONIFY__'):
+                            result[key] = json.loads(value[len('__JSONIFY__'):])
             elif 'action' in obj:
                 for key, value in obj['columns'].iteritems():
                     if value and isinstance(value, basestring) and value.startswith('__JSONIFY__'):
@@ -610,7 +610,8 @@ def _get_top_data(topfile):
 def _generate_osquery_conf_file(conftopfile):
     '''
     Function to dynamically create osquery configuration file in JSON format.
-    This function would load osquery configuration in YAML format and make use of topfile to selectively load file(s) based on grains
+    This function would load osquery configuration in YAML format and 
+    make use of topfile to selectively load file(s) based on grains
     '''
 
     log.info("Generating osquery conf file using topfile: {0}".format(conftopfile))
@@ -624,7 +625,8 @@ def _generate_osquery_conf_file(conftopfile):
     osqd_configs = _get_top_data(conftopfile)
     configfile = os.path.join(base_path, "osquery.conf")
     conf_data = {}
-    osqd_configs = ['salt://hubblestack_nebula_v2/' + config.replace('.', '/') + '.yaml' for config in osqd_configs]
+    osqd_configs = ['salt://hubblestack_nebula_v2/' + config.replace('.', '/') + '.yaml'
+                    for config in osqd_configs]
     for fh in osqd_configs:
         if 'salt://' in fh:
             orig_fh = fh
@@ -639,9 +641,9 @@ def _generate_osquery_conf_file(conftopfile):
                     raise CommandExecutionError('File data is not formed as a dict {0}'
                                                 .format(f_data))
                 conf_data = _dict_update(conf_data,
-                                        f_data,
-                                        recursive_update=True,
-                                        merge_lists=True)
+                                         f_data,
+                                         recursive_update=True,
+                                         merge_lists=True)
     if conf_data:
         try:
             log.debug("Writing config to osquery.conf file")
@@ -649,14 +651,15 @@ def _generate_osquery_conf_file(conftopfile):
                 json.dump(conf_data, cf)
         except Exception as e:
             log.error("Failed to generate osquery conf file using topfile {0}".format(e))
-    
+
     return configfile
 
 
 def _generate_osquery_flags_file(flagstopfile):
     '''
     Function to dynamically create osquery flags file.
-    This function would load osquery flags in YAML format and make use of topfile to selectively load file(s) based on grains
+    This function would load osquery flags in YAML format and 
+    make use of topfile to selectively load file(s) based on grains
     '''
 
     log.info("Generating osquery flags file using topfile: {0}".format(flagstopfile))
@@ -670,7 +673,8 @@ def _generate_osquery_flags_file(flagstopfile):
     osqd_flags = _get_top_data(flagstopfile)
     flagfile = os.path.join(base_path, "osquery.flags")
     flags_data = {}
-    osqd_flags = ['salt://hubblestack_nebula_v2/' + config.replace('.', '/') + '.yaml' for config in osqd_flags]
+    osqd_flags = ['salt://hubblestack_nebula_v2/' + config.replace('.', '/') + '.yaml'
+                  for config in osqd_flags]
     for fh in osqd_flags:
         if 'salt://' in fh:
             orig_fh = fh
@@ -685,9 +689,9 @@ def _generate_osquery_flags_file(flagstopfile):
                     raise CommandExecutionError('File data is not formed as a dict {0}'
                                                 .format(f_data))
                 flags_data = _dict_update(flags_data,
-                                        f_data,
-                                        recursive_update=True,
-                                        merge_lists=True)
+                                          f_data,
+                                          recursive_update=True,
+                                          merge_lists=True)
     if flags_data:
         try:
             log.debug("Writing config to osquery.flags file")
@@ -697,7 +701,7 @@ def _generate_osquery_flags_file(flagstopfile):
                     cf.write(propdata)
         except Exception as e:
             log.error("Failed to generate osquery flags file using topfile {0}".format(e))
-    
+
     return flagfile
 
 

--- a/hubblestack/extmods/modules/nebula_osquery.py
+++ b/hubblestack/extmods/modules/nebula_osquery.py
@@ -253,6 +253,8 @@ def queries(query_group,
 
 @hubble_status.watch
 def osqueryd_monitor(configfile=None,
+                     conftopfile=None,
+                     flagstopfile=None,
                      flagfile=None,
                      logdir=None,
                      databasepath=None,
@@ -266,10 +268,16 @@ def osqueryd_monitor(configfile=None,
     On such conditions, osqueryd will get restarted, thereby loading new files.
 
     configfile
-        Path to osquery configuration file.
+        Path to osquery configuration file. If this is specified, conftopfile will be ignored
+
+    conftopfile
+        Path to topfile which will be used to dynamically generate osquery conf in JSON format
+
+    flagstopfile
+        Path to topfile which will be used to dynamically generate osquery flags
 
     flagfile
-        Path to osquery flag file
+        Path to osquery flag file. If this is specified, flagstopfile will be ignored
 
     logdir
         Path to log directory where osquery daemon/service will write logs
@@ -300,9 +308,13 @@ def osqueryd_monitor(configfile=None,
         if not pidfile:
             pidfile = os.path.join(base_path, "hubble_osqueryd.pidfile")
         if not configfile:
-            configfile = os.path.join(base_path, "osquery.conf")
+            if not conftopfile:
+                conftopfile = 'salt://hubblestack_nebula_v2/win_top.osqueryconf'
+            configfile = _generate_osquery_conf_file(conftopfile)
         if not flagfile:
-            flagfile = os.path.join(base_path, "osquery.flags")
+            if not flagstopfile:
+                flagstopfile = 'salt://hubblestack_nebula_v2/win_top.osqueryflags'
+            flagfile = _generate_osquery_flags_file(flagstopfile)
         if not hashfile:
             hashfile = os.path.join(base_path, "hash_of_flagfile.txt")
 
@@ -317,9 +329,13 @@ def osqueryd_monitor(configfile=None,
         if not pidfile:
             pidfile = os.path.join(base_path, "hubble_osqueryd.pidfile")
         if not configfile:
-            configfile = os.path.join(base_path, "osquery.conf")
+            if not conftopfile:
+                conftopfile = 'salt://hubblestack_nebula_v2/top.osqueryconf'
+            configfile = _generate_osquery_conf_file(conftopfile)
         if not flagfile:
-            flagfile = os.path.join(base_path, "osquery.flags")
+            if not flagstopfile:
+                flagstopfile = 'salt://hubblestack_nebula_v2/top.osqueryflags'
+            flagfile = _generate_osquery_flags_file(flagstopfile)
         if not hashfile:
             hashfile = os.path.join(base_path, "hash_of_flagfile.txt")
 
@@ -444,30 +460,6 @@ def osqueryd_log_parser(osqueryd_logdir=None,
         log.info("Perform masking")
         _mask_object(ret, topfile_for_mask)
     return ret
-
-
-def hubble_metadata():
-    '''
-    Log Hubble version and buildinfo. Buildinfo if set, will be logged.
-    Data logged by this function is union of hubble_versions() function and --buildinfo param.
-    '''
-    build_metadata = hubble_versions()
-    try:
-        from hubblestack import __buildinfo__
-    except ImportError:
-        __buildinfo__ = {'buildinfo': 'NOT SET'}
-    build_metadata.update(__buildinfo__)
-
-    log.info("Hubble build metadata: {0}".format(build_metadata))
-
-    if __salt__['config.get']('splunklogging', False):
-        log.debug('Logging hubble build metadata to splunk')
-        hubblestack.splunklogging.__grains__ = __grains__
-        hubblestack.splunklogging.__salt__ = __salt__
-        hubblestack.splunklogging.__opts__ = __opts__
-        handler = hubblestack.splunklogging.SplunkHandler()
-        metadata = {'build_metadata': build_metadata, 'schedule_time': time.time()}
-        handler.emit_data(metadata)
 
 
 def check_disk_usage(path=None):
@@ -604,6 +596,129 @@ def _get_top_data(topfile):
                                     'single-key dicts.')
 
     topdata = topdata['nebula']
+
+    ret = []
+
+    for topmatch in topdata:
+        for match, data in topmatch.iteritems():
+            if __salt__['match.compound'](match):
+                ret.extend(data)
+
+    return ret
+
+
+def _generate_osquery_conf_file(conftopfile):
+    '''
+    Function to dynamically create osquery configuration file in JSON format.
+    This function would load osquery configuration in YAML format and make use of topfile to selectively load file(s) based on grains
+    '''
+
+    log.info("Generating osquery conf file using topfile: {0}".format(conftopfile))
+    saltenv = __salt__['config.get']('hubblestack:nova:saltenv', 'base')
+    osqueryd_path = 'salt://hubblestack_nebula_v2'
+    cached = __salt__['cp.cache_dir'](osqueryd_path, saltenv=saltenv)
+    log.debug('Cached nebula files to cachedir')
+    cachedir = os.path.join(__opts__.get('cachedir'), 'files', saltenv, 'hubblestack_nebula_v2')
+    base_path = cachedir
+
+    osqd_configs = _get_osquery_top_data(conftopfile)
+    configfile = os.path.join(base_path, "osquery.conf")
+    conf_data = {}
+    osqd_configs = ['salt://hubblestack_nebula_v2/' + config.replace('.', '/') + '.yaml' for config in osqd_configs]
+    for fh in osqd_configs:
+        if 'salt://' in fh:
+            orig_fh = fh
+            fh = __salt__['cp.cache_file'](fh)
+        if fh is None:
+            log.error('Could not find file {0}.'.format(orig_fh))
+            return None
+        if os.path.isfile(fh):
+            with open(fh, 'r') as f:
+                f_data = yaml.safe_load(f)
+                if not isinstance(f_data, dict):
+                    raise CommandExecutionError('File data is not formed as a dict {0}'
+                                                .format(f_data))
+                conf_data = _dict_update(conf_data,
+                                        f_data,
+                                        recursive_update=True,
+                                        merge_lists=True)
+    if conf_data:
+        try:
+            log.debug("Writing config to osquery.conf file")
+            with open(configfile, "w") as cf:
+                json.dump(conf_data, cf)
+        except Exception as e:
+            log.error("Failed to generate osquery conf file using topfile {0}".format(e))
+    
+    return configfile
+
+
+def _generate_osquery_flags_file(flagstopfile):
+    '''
+    Function to dynamically create osquery flags file.
+    This function would load osquery flags in YAML format and make use of topfile to selectively load file(s) based on grains
+    '''
+
+    log.info("Generating osquery flags file using topfile: {0}".format(flagstopfile))
+    saltenv = __salt__['config.get']('hubblestack:nova:saltenv', 'base')
+    osqueryd_path = 'salt://hubblestack_nebula_v2'
+    cached = __salt__['cp.cache_dir'](osqueryd_path, saltenv=saltenv)
+    log.debug('Cached nebula files to cachedir')
+    cachedir = os.path.join(__opts__.get('cachedir'), 'files', saltenv, 'hubblestack_nebula_v2')
+    base_path = cachedir
+
+    osqd_flags = _get_osquery_top_data(flagstopfile)
+    flagfile = os.path.join(base_path, "osquery.flags")
+    flags_data = {}
+    osqd_flags = ['salt://hubblestack_nebula_v2/' + config.replace('.', '/') + '.yaml' for config in osqd_flags]
+    for fh in osqd_flags:
+        if 'salt://' in fh:
+            orig_fh = fh
+            fh = __salt__['cp.cache_file'](fh)
+        if fh is None:
+            log.error('Could not find file {0}.'.format(orig_fh))
+            return None
+        if os.path.isfile(fh):
+            with open(fh, 'r') as f:
+                f_data = yaml.safe_load(f)
+                if not isinstance(f_data, dict):
+                    raise CommandExecutionError('File data is not formed as a dict {0}'
+                                                .format(f_data))
+                flags_data = _dict_update(flags_data,
+                                        f_data,
+                                        recursive_update=True,
+                                        merge_lists=True)
+    if flags_data:
+        try:
+            log.debug("Writing config to osquery.flags file")
+            with open(flagfile, "w") as cf:
+                for key in flags_data:
+                    propdata = "--" + key + "=" + flags_data.get(key) + "\n"
+                    cf.write(propdata)
+        except Exception as e:
+            log.error("Failed to generate osquery flags file using topfile {0}".format(e))
+    
+    return flagfile
+
+
+def _get_osquery_top_data(topfile):
+
+    topfile = __salt__['cp.cache_file'](topfile)
+
+    try:
+        with open(topfile) as handle:
+            topdata = yaml.safe_load(handle)
+    except Exception as e:
+        raise CommandExecutionError('Could not load topfile: {0}'.format(e))
+
+    if not isinstance(topdata, dict) or 'osquery' not in topdata or \
+            not isinstance(topdata['osquery'], list):
+        raise CommandExecutionError('Osquery topfile not formatted correctly. '
+                                    'Note that under the "osquery" key the data '
+                                    'should now be formatted as a list of '
+                                    'single-key dicts.')
+
+    topdata = topdata['osquery']
 
     ret = []
 

--- a/pkg/windows/osqueryd_safe_permissions.ps1
+++ b/pkg/windows/osqueryd_safe_permissions.ps1
@@ -3,6 +3,8 @@
     $osqueryd_conffile_path = $hubble_path + "\var\cache\files\base\hubblestack_nebula_v2\osquery.conf"
     $osqueryd_flagfile_path = $hubble_path + "\var\cache\files\base\hubblestack_nebula_v2\osquery.flags"
     $osqueryd_logfile_path = $hubble_path + "\var\log\hubble_osquery"
+    $osqueryd_backuplog_path = $osqueryd_logfile_path + "\backuplogs"
+
     $acl = Get-Item $osqueryd_path |get-acl
     $acl.SetAccessRuleProtection($true,$true)
     $acl |Set-Acl
@@ -41,8 +43,8 @@
     $acl.RemoveAccessRuleAll($accessrule)
     set-acl -aclobject $acl $osqueryd_path
 
-    if(!(Test-Path -Path $osqueryd_logfile_path )){
-        New-Item -Path $osqueryd_logfile_path -ItemType Directory
+    if(!(Test-Path -Path $osqueryd_backuplog_path )){
+        New-Item -Path $osqueryd_backuplog_path -ItemType Directory
     }
 
     sc.exe create $osqueryd_service_name binpath=$binpath  displayname=$osqueryd_service_name

--- a/pkg/windows/osqueryd_safe_permissions.ps1
+++ b/pkg/windows/osqueryd_safe_permissions.ps1
@@ -1,7 +1,7 @@
     $hubble_path = $args[0]
     $osqueryd_path = $hubble_path + "\osqueryd\"
-    $osqueryd_conffile_path = $hubble_path + "\var\cache\files\base\osqueryd\osquery.conf"
-    $osqueryd_flagfile_path = $hubble_path + "\var\cache\files\base\osqueryd\osquery.flags"
+    $osqueryd_conffile_path = $hubble_path + "\var\cache\files\base\hubblestack_nebula_v2\osquery.conf"
+    $osqueryd_flagfile_path = $hubble_path + "\var\cache\files\base\hubblestack_nebula_v2\osquery.flags"
     $acl = Get-Item $osqueryd_path |get-acl
     $acl.SetAccessRuleProtection($true,$true)
     $acl |Set-Acl

--- a/pkg/windows/osqueryd_safe_permissions.ps1
+++ b/pkg/windows/osqueryd_safe_permissions.ps1
@@ -2,10 +2,11 @@
     $osqueryd_path = $hubble_path + "\osqueryd\"
     $osqueryd_conffile_path = $hubble_path + "\var\cache\files\base\hubblestack_nebula_v2\osquery.conf"
     $osqueryd_flagfile_path = $hubble_path + "\var\cache\files\base\hubblestack_nebula_v2\osquery.flags"
+    $osqueryd_logfile_path = $hubble_path + "\var\log\hubble_osquery"
     $acl = Get-Item $osqueryd_path |get-acl
     $acl.SetAccessRuleProtection($true,$true)
     $acl |Set-Acl
-    $binpath = "\" + '"' + $osqueryd_path + "osqueryd.exe" + "\" + '"' 	+ " --flagfile=\" + '"' + $osqueryd_flagfile_path + "\" + '"' + " --config_path=\" + '"' + $osqueryd_conffile_path + "\" + '"'
+    $binpath = "\" + '"' + $osqueryd_path + "osqueryd.exe" + "\" + '"' 	+ " --flagfile=\" + '"' + $osqueryd_flagfile_path + "\" + '"' + " --config_path=\" + '"' + $osqueryd_conffile_path + "\" + '"' + " --logger_path=\" + '"' + $osqueryd_logfile_path + "\" + '"'
     $osqueryd_service_name = "hubble_osqueryd"
 
     $group = "NT SERVICE\TrustedInstaller"
@@ -39,6 +40,10 @@
     $accessrule = New-Object System.Security.AccessControl.FileSystemAccessRule($group,"FullControl", $inherit, $Propagation ,,,"Allow")
     $acl.RemoveAccessRuleAll($accessrule)
     set-acl -aclobject $acl $osqueryd_path
+
+    if(!(Test-Path -Path $osqueryd_logfile_path )){
+        New-Item -Path $osqueryd_logfile_path -ItemType Directory
+    }
 
     sc.exe create $osqueryd_service_name binpath=$binpath  displayname=$osqueryd_service_name
     sc.exe config $osqueryd_service_name depend= Hubble


### PR DESCRIPTION
Following changes are made:

- Added support to dynamically generate osquery conf in JSON format using topfile. One can now create host specific osquery conf using grains
- Added support to dynamically generate osquery flagfile using topfile. One can now create host specific flagfile using grains. This can be especially helpful if we want to enable/disable certain setting on certains host(s) or enable/disable extensions on few hosts.
- Added buildinfo in grains