### PR TITLE
More counter fields

### DIFF
--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -29,6 +29,7 @@ import salt.utils.gitfs
 import salt.log.setup
 import hubblestack.splunklogging
 import hubblestack.hec.opt
+import hubblestack.utils.stdrec
 from hubblestack import __version__
 from croniter import croniter
 from datetime import datetime
@@ -732,6 +733,9 @@ def refresh_grains(initial=False):
     # the only things that turn up in here (and that get preserved)
     # are pulsar.queue, pulsar.notifier and cp.fileclient_###########
     # log.debug('keys in __context__: {}'.format(list(__context__)))
+
+    hubblestack.utils.stdrec.__grains__ = __grains__
+    hubblestack.utils.stdrec.__opts__ = __opts__
 
     hubblestack.hec.opt.__grains__ = __grains__
     hubblestack.hec.opt.__salt__ = __salt__

--- a/hubblestack/extmods/returners/splunk_generic_return.py
+++ b/hubblestack/extmods/returners/splunk_generic_return.py
@@ -17,6 +17,7 @@ event collector. Required config/pillar settings:
 '''
 
 import time
+import hubblestack.utils.stdrec as stdrec
 from hubblestack.hec import http_event_collector, get_splunk_options
 
 def _get_key(dat, k, d=None):
@@ -62,5 +63,7 @@ def returner(retdata):
             payload = {'host': __grains__.get('fqdn', __grains__.get('id')), 'event': event,
                 'sourcetype': _get_key(event, 'sourcetype', t_sourcetype),
                 'time': str(int(_get_key(event, 'time', t_time)))}
+            # add various std host info data and index extracted fields
+            stdrec.update_payload(payload)
             hec.batchEvent(payload)
         hec.flushBatch()

--- a/hubblestack/extmods/returners/splunk_pulsar_return.py
+++ b/hubblestack/extmods/returners/splunk_pulsar_return.py
@@ -54,7 +54,6 @@ RETRY = False
 
 log = logging.getLogger(__name__)
 
-
 def returner(ret):
     try:
         if isinstance(ret, dict) and not ret.get('return'):

--- a/hubblestack/utils/stdrec.py
+++ b/hubblestack/utils/stdrec.py
@@ -1,0 +1,69 @@
+# -*- encoding: utf-8 -*-
+
+def std_info():
+    master = __grains__['master']
+    minion_id = __opts__['id']
+    fqdn = __grains__['fqdn']
+    fqdn = fqdn if fqdn else minion_id
+    try:
+        fqdn_ip4 = __grains__.get('local_ip4')
+        if not fqdn_ip4:
+            fqdn_ip4 = __grains__['fqdn_ip4'][0]
+    except IndexError:
+        try:
+            fqdn_ip4 = __grains__['ipv4'][0]
+        except IndexError:
+            raise Exception('No ipv4 grains found. Is net-tools installed?')
+    if fqdn_ip4.startswith('127.'):
+        for ip4_addr in __grains__['ipv4']:
+            if ip4_addr and not ip4_addr.startswith('127.'):
+                fqdn_ip4 = ip4_addr
+                break
+    local_fqdn = __grains__.get('local_fqdn', __grains__['fqdn'])
+
+    # Sometimes fqdn reports a value of localhost. If that happens, try another method.
+    bad_fqdns = ['localhost', 'localhost.localdomain', 'localhost6.localdomain6']
+    if fqdn in bad_fqdns:
+        new_fqdn = socket.gethostname()
+        if '.' not in new_fqdn or new_fqdn in bad_fqdns:
+            new_fqdn = fqdn_ip4
+        fqdn = new_fqdn
+
+    ret = {
+        'master': master,
+        'minion_id': minion_id,
+        'dest_host': fqdn,
+        'dest_ip': fqdn_ip4,
+        'dest_fqdn': local_fqdn,
+        'system_uuid': __grains__.get('system_uuid'),
+    }
+
+    ret.update(__grains__.get('cloud_details', {}))
+
+    return ret
+
+def index_extracted(payload):
+    if not isinstance(payload.get('event'), dict):
+        return
+    index_extracted_fields = []
+    try:
+        index_extracted_fields.extend(__opts__.get('splunk_index_extracted_fields', []))
+    except TypeError:
+        pass
+
+    fields = {}
+    for item in index_extracted_fields:
+        if item in payload['event']:
+            val = payload['event'][item]
+            if not isinstance(val, (list, dict, tuple)):
+                fields[item] = str(val)
+    return fields
+
+def update_payload(payload):
+    if 'event' not in payload:
+        payload['event'] = dict()
+    if isinstance(payload['event'], dict):
+        payload['event'].update(std_info())
+    fields = index_extracted(payload)
+    if fields:
+        payload['fields'] = fields

--- a/hubblestack/utils/stdrec.py
+++ b/hubblestack/utils/stdrec.py
@@ -1,6 +1,15 @@
 # -*- encoding: utf-8 -*-
+'''
+This is intended to generate data for splunk returners in a standard way.
+Currently each returner seems to generate these data by hand in their own way.
+This is being tested/used in the generic returner and probably only from
+hstatus exec module (for now).
+'''
 
 def std_info():
+    ''' Generate and return hubble standard host data for use in events:
+          master, minion_id, dest_host, dest_ip, dest_fqdn and system_uuid
+    '''
     master = __grains__['master']
     minion_id = __opts__['id']
     fqdn = __grains__['fqdn']
@@ -43,6 +52,8 @@ def std_info():
     return ret
 
 def index_extracted(payload):
+    ''' generate index extracted fields dictionary from the given payload based
+    on the options in the config file '''
     if not isinstance(payload.get('event'), dict):
         return
     index_extracted_fields = []
@@ -60,6 +71,8 @@ def index_extracted(payload):
     return fields
 
 def update_payload(payload):
+    ''' update the given payload with index extracted fields (if applicable)
+    and append std host data to the event (iff it's a dictionary) '''
     if 'event' not in payload:
         payload['event'] = dict()
     if isinstance(payload['event'], dict):


### PR DESCRIPTION
This seems to do the job @fossam was asking for (adding std host fields).

I attempted to split out the generation of the std host fields from splunk_pulsar_return; with the intention of literally standardizing those fields generation between the various splunk returners. (not totally sure that's a great idea, comments welcome).