### PR TITLE
Attempt to detect cloned hubble installs

### DIFF
--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -22,6 +22,7 @@ import math
 import salt.fileclient
 import salt.fileserver
 import salt.fileserver.gitfs
+import salt.modules.cmdmod
 import salt.utils
 import salt.utils.platform
 import salt.utils.jid
@@ -651,7 +652,6 @@ def load_config():
     cached_uuid_path = os.path.join(os.path.dirname(__opts__['configfile']), 'hubble_cached_uuid')
     cached_system_uuid_path = os.path.join(os.path.dirname(__opts__['configfile']),
                                            'hubble_cached_system_uuid')
-
     try:
         if os.path.isfile(cached_uuid_path) and os.path.isfile(cached_system_uuid_path):
             with open(cached_uuid_path, 'r') as f, open(cached_system_uuid_path, 'r') as g:
@@ -663,7 +663,7 @@ def load_config():
                 osqueryipaths = ('/opt/osquery/osqueryi', 'osqueryi', '/usr/bin/osqueryi')
                 for path in osqueryipaths:
                     if salt.utils.path.which(path):
-                        live_uuid = __salt__['cmd.run_stdout']('{0} {1}'.format(path, query), output_loglevel='quiet')
+                        live_uuid = salt.modules.cmdmod.run_stdout('{0} {1}'.format(path, query), output_loglevel='quiet')
                         live_uuid = str(live_uuid).upper()
                         if len(live_uuid) == 36 and live_uuid != cached_system_uuid:
                             log.error("potentially cloned system detected: System_uuid grain "

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -663,7 +663,7 @@ def load_config():
                 osqueryipaths = ('/opt/osquery/osqueryi', 'osqueryi', '/usr/bin/osqueryi')
                 for path in osqueryipaths:
                     if salt.utils.path.which(path):
-                        live_uuid = __salt__['cmd.run']('{0} {1}'.format(path, query))
+                        live_uuid = __salt__['cmd.run_stdout']('{0} {1}'.format(path, query), output_loglevel='quiet')
                         live_uuid = str(live_uuid).upper()
                         if len(live_uuid) == 36 and live_uuid != cached_system_uuid:
                             log.error("potentially cloned system detected: System_uuid grain "

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -649,6 +649,31 @@ def load_config():
     os.chmod(parsed_args.get('configfile'), 384)
 
     # Check for a cloned system with existing hubble_uuid
+    def _get_uuid_from_system():
+        query = '"SELECT uuid AS system_uuid FROM osquery_info;" --header=false --csv'
+
+        # Prefer our /opt/osquery/osqueryi if present
+        osqueryipaths = ('/opt/osquery/osqueryi', 'osqueryi', '/usr/bin/osqueryi')
+        for path in osqueryipaths:
+            if salt.utils.path.which(path):
+                live_uuid = salt.modules.cmdmod.run_stdout('{0} {1}'.format(path, query), output_loglevel='quiet')
+                live_uuid = str(live_uuid).upper()
+                if len(live_uuid) == 36:
+                    return live_uuid
+                else:
+                    return None
+        # If osquery isn't available, attempt to get uuid from /sys path (linux only)
+        try:
+            with open('/sys/devices/virtual/dmi/id/product_uuid', 'r') as f:
+                file_uuid = f.read()
+            file_uuid = str(file_uuid).upper()
+            if len(file_uuid) == 36:
+                return file_uuid
+            else:
+                return None
+        except Exception:
+            return None
+
     cached_uuid_path = os.path.join(os.path.dirname(__opts__['configfile']), 'hubble_cached_uuid')
     cached_system_uuid_path = os.path.join(os.path.dirname(__opts__['configfile']),
                                            'hubble_cached_system_uuid')
@@ -658,19 +683,13 @@ def load_config():
                 cached_uuid = f.read()
                 cached_system_uuid = g.read()
             if cached_uuid != cached_system_uuid:
-                query = '"SELECT uuid AS system_uuid FROM osquery_info;" --header=false --csv'
-                # Prefer our /opt/osquery/osqueryi if present
-                osqueryipaths = ('/opt/osquery/osqueryi', 'osqueryi', '/usr/bin/osqueryi')
-                for path in osqueryipaths:
-                    if salt.utils.path.which(path):
-                        live_uuid = salt.modules.cmdmod.run_stdout('{0} {1}'.format(path, query), output_loglevel='quiet')
-                        live_uuid = str(live_uuid).upper()
-                        if len(live_uuid) == 36 and live_uuid != cached_system_uuid:
-                            log.error("potentially cloned system detected: System_uuid grain "
-                                      "previously saved on disk doesn't match live system value.\n"
-                                      "Resettig cached hubble_uuid value.")
-                            os.remove(cached_uuid_path)
-                        break
+                live_uuid = _get_uuid_from_system()
+                if live_uuid != cached_system_uuid:
+                    log.error("potentially cloned system detected: System_uuid grain "
+                              "previously saved on disk doesn't match live system value.\n"
+                              "Resettig cached hubble_uuid value.")
+                    os.remove(cached_uuid_path)
+
     except Exception:
         log.exception("Problem opening cache files while checking for previously cloned system")
 

--- a/hubblestack/extmods/grains/systemuuid.py
+++ b/hubblestack/extmods/grains/systemuuid.py
@@ -2,15 +2,18 @@
 '''
 Gather the system uuid via osquery
 '''
+import logging
+import os
 import salt.utils.path
 import salt.modules.cmdmod
 
 __salt__ = {'cmd.run': salt.modules.cmdmod._run_quiet}
+log = logging.getLogger(__name__)
 
 
 def get_system_uuid():
     '''
-    Gather the system uuid via osquery
+    Gather the system uuid via osquery and store it on disk.
 
     If osquery can't get a hardware-based value, it'll just randomly generate a new uuid every time.
     If that happens, fall back to the hubble_uuid.
@@ -18,24 +21,66 @@ def get_system_uuid():
     # Provides:
     #   system_uuid
 
-    options = '"SELECT uuid AS system_uuid FROM osquery_info;" --header=false --csv'
+    cached_system_uuid_path = os.path.join(os.path.dirname(__opts__['configfile']),
+                                           'hubble_cached_system_uuid')
+    previous_system_uuid = __opts__.get('system_uuid', None)
+
+    # Get the system uuid via osquery. If it changes, fall back to hubble_uuid
+    live_system_uuid = _get_uuid_from_system() or __opts__.get('hubble_uuid', None)
+
+    if not live_system_uuid:
+        # Can't reliably get system_uuid, and hubble_uuid not yet generated. Aborting.
+        return {}
+
+    try:
+        if os.path.isfile(cached_system_uuid_path):
+            with open(cached_system_uuid_path, 'r') as f:
+                cached_system_uuid = f.read()
+            # Check if it's changed out from under us -- problem!
+            if cached_system_uuid != live_system_uuid:
+                log.error("system_uuid on disk doesn't match live system value"
+                          '\nLive: {0}\nOn Disk: {1}\nRewriting cached value'
+                          .format(live_system_uuid, cached_system_uuid))
+                _write_system_uuid_to_file(cached_system_uuid_path, live_system_uuid)
+            return {'system_uuid': live_system_uuid}
+        elif previous_system_uuid:
+            log.error('system_uuid was previously cached, but the cached '
+                      'file is no longer present: {0}'.format(cached_system_uuid_path))
+        else:
+            log.warning('no cache file found, caching system_uuid. '
+                        '(probably not a problem)')
+    except Exception:
+        log.exception('Problem retrieving cached system uuid from file: {0}'
+                      .format(cached_system_uuid_path))
+
+    # Cache the system uuid if needed
+    _write_system_uuid_to_file(cached_system_uuid_path, live_system_uuid)
+    return {'system_uuid': live_system_uuid}
+
+
+def _write_system_uuid_to_file(path, uuid):
+    try:
+        with open(path, 'w') as f:
+            f.write(uuid)
+    except Exception:
+        log.exception('Problem writing cached system uuid to file: {0}'
+                      .format(path))
+
+
+def _get_uuid_from_system():
+    query = '"SELECT uuid AS system_uuid FROM osquery_info;" --header=false --csv'
 
     # Prefer our /opt/osquery/osqueryi if present
     osqueryipaths = ('/opt/osquery/osqueryi', 'osqueryi', '/usr/bin/osqueryi')
-    grains = {}
     for path in osqueryipaths:
         if salt.utils.path.which(path):
-            first_run = __salt__['cmd.run']('{0} {1}'.format(path, options))
+            first_run = __salt__['cmd.run']('{0} {1}'.format(path, query))
             first_run = str(first_run).upper()
 
-            second_run = __salt__['cmd.run']('{0} {1}'.format(path, options))
+            second_run = __salt__['cmd.run']('{0} {1}'.format(path, query))
             second_run = str(second_run).upper()
 
             if len(first_run) == 36 and first_run == second_run:
-                grains = {"system_uuid": first_run}
+                return first_run
             else:
-                existing_uuid = __opts__.get('hubble_uuid', None)
-                if existing_uuid:
-                    {"system_uuid": existing_uuid}
-            break
-    return grains
+                return None

--- a/hubblestack/extmods/grains/systemuuid.py
+++ b/hubblestack/extmods/grains/systemuuid.py
@@ -7,7 +7,7 @@ import os
 import salt.utils.path
 import salt.modules.cmdmod
 
-__salt__ = {'cmd.run': salt.modules.cmdmod._run_quiet}
+__salt__ = {'cmd.run_stdout': salt.modules.cmdmod.run_stdout}
 log = logging.getLogger(__name__)
 
 
@@ -74,10 +74,10 @@ def _get_uuid_from_system():
     osqueryipaths = ('/opt/osquery/osqueryi', 'osqueryi', '/usr/bin/osqueryi')
     for path in osqueryipaths:
         if salt.utils.path.which(path):
-            first_run = __salt__['cmd.run']('{0} {1}'.format(path, query))
+            first_run = __salt__['cmd.run_stdout']('{0} {1}'.format(path, query), output_loglevel='quiet')
             first_run = str(first_run).upper()
 
-            second_run = __salt__['cmd.run']('{0} {1}'.format(path, query))
+            second_run = __salt__['cmd.run_stdout']('{0} {1}'.format(path, query), output_loglevel='quiet')
             second_run = str(second_run).upper()
 
             if len(first_run) == 36 and first_run == second_run:

--- a/hubblestack/extmods/grains/systemuuid.py
+++ b/hubblestack/extmods/grains/systemuuid.py
@@ -24,9 +24,18 @@ def get_system_uuid():
     cached_system_uuid_path = os.path.join(os.path.dirname(__opts__['configfile']),
                                            'hubble_cached_system_uuid')
     previous_system_uuid = __opts__.get('system_uuid', None)
+    hubble_uuid = __opts__.get('hubble_uuid', None)
+
+    if not hubble_uuid:
+        cached_hubble_uuid_path = os.path.join(os.path.dirname(__opts__['configfile']), 'hubble_cached_uuid')
+        try:
+            with open(cached_hubble_uuid_path, 'r') as f:
+                hubble_uuid = f.read()
+        except Exception:
+            hubble_uuid = None
 
     # Get the system uuid via osquery. If it changes, fall back to hubble_uuid
-    live_system_uuid = _get_uuid_from_system() or __opts__.get('hubble_uuid', None)
+    live_system_uuid = _get_uuid_from_system() or hubble_uuid
 
     if not live_system_uuid:
         # Can't reliably get system_uuid, and hubble_uuid not yet generated. Aborting.

--- a/hubblestack/extmods/grains/systemuuid.py
+++ b/hubblestack/extmods/grains/systemuuid.py
@@ -84,3 +84,14 @@ def _get_uuid_from_system():
                 return first_run
             else:
                 return None
+    # If osquery isn't available, attempt to get uuid from /sys path (linux only)
+    try:
+        with open('/sys/devices/virtual/dmi/id/product_uuid', 'r') as f:
+            file_uuid = f.read()
+        file_uuid = str(file_uuid).upper()
+        if len(file_uuid) == 36:
+            return file_uuid
+        else:
+            return None
+    except Exception:
+        return None


### PR DESCRIPTION
This makes a handful of small changes to address a corner case: If Hubble is installed on a system and run at least once, a hubble_uuid cache file is generated. If this system is then cloned (an AMI is made, for example), the cloned systems will all have the same hubble_uuid. This attempts to work around that by first checking the system_uuid to see if the current system value is different from the cached value. If it is, it invalidates the hubble_uuid cache.

- Start caching the system_uuid grain to a file, similar to hubble_uuid
- Copy system_uuid into `__opts__`
- Add logic to theload_config function to detect cloned systems and delete the hubble_uuid cache file in those cases.