### PR TITLE
fix memory leak in pulsar

### DIFF
--- a/hubblestack/extmods/modules/pulsar.py
+++ b/hubblestack/extmods/modules/pulsar.py
@@ -615,8 +615,6 @@ class delta_t(object):
         self.last_mark = name
         self.marks[name] = time.time()
 
-_wtf_counter = 0
-
 @hubble_status.watch
 def process(configfile='salt://hubblestack_pulsar/hubblestack_pulsar_config.yaml',
             verbose=False):
@@ -716,13 +714,6 @@ def process(configfile='salt://hubblestack_pulsar/hubblestack_pulsar_config.yaml
 
     cm = ConfigManager(configfile=configfile, verbose=verbose)
     config = cm.config
-
-    log.debug('WTF( %s %s )', config.get('refresh_interval'), cm._last_update)
-    global _wtf_counter
-    import json
-    with open('/tmp/wtf-{:04d}.json'.format(_wtf_counter), 'w') as fh:
-        json.dump(config, fh, indent=2)
-        _wtf_counter += 1
 
     if config.get('verbose'):
         log.debug('Pulsar beacon called.')


### PR DESCRIPTION
I had briefly toyed with using deep copy to prevent modifying `__opts__` but decided that was fine and fine to log to splunk.

I also toyed with a global pattern database, etc, but finally found the problem was with the list merge in the config combiner logic.  This small patch fixes a rather large (over time) memory leak ... and probably a CPU leak (if there is such a thing); re-re-re-considering patterns for exclusion is certainly something like a CPU leak.

