### PR TITLE
Add meta_ to all index time extracted fields

### DIFF
--- a/hubblestack/extmods/returners/splunk_fdg_return.py
+++ b/hubblestack/extmods/returners/splunk_fdg_return.py
@@ -183,7 +183,7 @@ def returner(ret):
                         fields = {}
                         for item in index_extracted_fields:
                             if item in payload['event'] and not isinstance(payload['event'][item], (list, dict, tuple)):
-                                fields[item] = str(payload['event'][item])
+                                fields["meta_%s" % item] = str(payload['event'][item])
                         if fields:
                             payload.update({'fields': fields})
 

--- a/hubblestack/extmods/returners/splunk_nebula_return.py
+++ b/hubblestack/extmods/returners/splunk_nebula_return.py
@@ -163,7 +163,7 @@ def returner(ret):
                             fields = {}
                             for item in index_extracted_fields:
                                 if item in payload['event'] and not isinstance(payload['event'][item], (list, dict, tuple)):
-                                    fields[item] = str(payload['event'][item])
+                                    fields["meta_%s" % item] = str(payload['event'][item])
                             if fields:
                                 payload.update({'fields': fields})
 

--- a/hubblestack/extmods/returners/splunk_nova_return.py
+++ b/hubblestack/extmods/returners/splunk_nova_return.py
@@ -161,7 +161,7 @@ def returner(ret):
                 fields = {}
                 for item in index_extracted_fields:
                     if item in payload['event'] and not isinstance(payload['event'][item], (list, dict, tuple)):
-                        fields[item] = str(payload['event'][item])
+                        fields["meta_%s" % item] = str(payload['event'][item])
                 if fields:
                     payload.update({'fields': fields})
 
@@ -213,7 +213,7 @@ def returner(ret):
                 fields = {}
                 for item in index_extracted_fields:
                     if item in payload['event'] and not isinstance(payload['event'][item], (list, dict, tuple)):
-                        fields[item] = str(payload['event'][item])
+                        fields["meta_%s" % item] = str(payload['event'][item])
                 if fields:
                     payload.update({'fields': fields})
 
@@ -251,7 +251,7 @@ def returner(ret):
                 fields = {}
                 for item in index_extracted_fields:
                     if item in payload['event'] and not isinstance(payload['event'][item], (list, dict, tuple)):
-                        fields[item] = str(payload['event'][item])
+                        fields["meta_%s" % item] = str(payload['event'][item])
                 if fields:
                     payload.update({'fields': fields})
 

--- a/hubblestack/extmods/returners/splunk_osqueryd_return.py
+++ b/hubblestack/extmods/returners/splunk_osqueryd_return.py
@@ -206,7 +206,7 @@ def _generate_and_send_payload(hec,
     fields = {}
     for item in index_extracted_fields:
         if item in payload['event'] and not isinstance(payload['event'][item], (list, dict, tuple)):
-            fields[item] = str(payload['event'][item])
+            fields["meta_%s" % item] = str(payload['event'][item])
     if fields:
         payload.update({'fields': fields})
 

--- a/hubblestack/extmods/returners/splunk_pulsar_return.py
+++ b/hubblestack/extmods/returners/splunk_pulsar_return.py
@@ -285,7 +285,7 @@ def returner(ret):
                 fields = {}
                 for item in index_extracted_fields:
                     if item in payload['event'] and not isinstance(payload['event'][item], (list, dict, tuple)):
-                        fields[item] = str(payload['event'][item])
+                        fields["meta_%s" % item] = str(payload['event'][item])
 
                 if fields:
                     payload.update({'fields': fields})

--- a/hubblestack/splunklogging.py
+++ b/hubblestack/splunklogging.py
@@ -128,7 +128,7 @@ class SplunkHandler(logging.Handler):
             fields = {}
             for item in index_extracted_fields:
                 if item in event and not isinstance(event[item], (list, dict, tuple)):
-                    fields[item] = str(event[item])
+                    fields["meta_%s" % item] = str(event[item])
             if fields:
                 payload.update({'fields': fields})
 

--- a/hubblestack/utils/stdrec.py
+++ b/hubblestack/utils/stdrec.py
@@ -67,7 +67,7 @@ def index_extracted(payload):
         if item in payload['event']:
             val = payload['event'][item]
             if not isinstance(val, (list, dict, tuple)):
-                fields[item] = str(val)
+                fields["meta_%s" % item] = str(val)
     return fields
 
 def update_payload(payload):


### PR DESCRIPTION
I think the idea is that, for anything listed in the config file under {splunk_index_extracted_fields}, we find the value in the event, then stick it in {fields} with {meta_} prepended to the name. @fossam, that's what we were thinking, right?

I think this does it, but @jettero, you might want to double check I didn't miss anything.