### PR TITLE
updated counters with buckets

### DIFF
--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -797,6 +797,7 @@ def refresh_grains(initial=False):
     hubblestack.splunklogging.__opts__ = __opts__
 
     hubblestack.status.__opts__ = __opts__
+    hubblestack.status.__salt__ = __salt__
     hubble_status.start_sigusr1_signal_handler()
 
     if not initial and __salt__['config.get']('splunklogging', False):

--- a/hubblestack/status.py
+++ b/hubblestack/status.py
@@ -453,12 +453,17 @@ class HubbleStatus(object):
                   }
                 }
         '''
-        r = self.short()
+
+        r = cls.short()
+
         min_dt = min([ x['dt'] for x in r.values() ])
         max_t  = max([ x['last_t'] for x in r.values() ])
         min_t  = min([ x['first_t'] for x in r.values() if x['first_t'] > 0 ])
         h1 = {'time': max_t, 'dt': min_dt, 'start': min_t}
-        r['HEALTH'] = h2 = {'last_activity': h1}
+        r['HEALTH'] = h2 = {
+            'buckets': cls.buckets(),
+            'last_activity': h1,
+        }
         r['__doc__'] = {
             'service.name.here': {
                 "count": 'number of times the counter was called',

--- a/tests/unittests/test_counters.py
+++ b/tests/unittests/test_counters.py
@@ -1,0 +1,72 @@
+# coding: utf-8
+
+import time
+import pytest
+import hubblestack.status
+
+def sleep_100ms_and_mark(st=0.1):
+    time.sleep(st)
+    return time.time()
+
+def test_one_count():
+    hubble_status = hubblestack.status.HubbleStatus('x', 'test1', 'test2')
+    t0 = time.time()
+    m = hubble_status.mark('test1')
+    t1 = sleep_100ms_and_mark()
+    m.fin()
+    s1 = hubble_status.short()
+    assert s1['x.test1']['count'] == 1
+    assert s1['x.test1']['dt'] == pytest.approx(0.1, rel=1e2)
+
+    m1 = hubble_status.mark('test1')
+    m2 = hubble_status.mark('test2')
+    t2 = sleep_100ms_and_mark()
+    m1.fin()
+    m2.fin()
+    s2 = hubble_status.short()
+    assert s2['x.test1']['count'] == 2
+    assert s2['x.test1']['dt'] == pytest.approx(0.1, rel=1e2)
+    assert s2['x.test2']['count'] == 1
+    assert s2['x.test2']['dt'] == pytest.approx(0.1, rel=1e2)
+
+def test_buckets():
+    t0 = 1553102100
+    hubblestack.status.MAX_DEPTH = 100
+    hubblestack.status.__opts__['hubble_status'] = { 'bucket_len': 5 }
+    hubble_status = hubblestack.status.HubbleStatus('x', 'test1')
+
+    for t in range(t0, t0+100):
+        hubble_status.mark('test1', t=t)
+
+    b = hubble_status.buckets()
+    assert len(b) == 1 + 100/5 # the extra is the bucket for the current time
+    assert b[0] == t0
+    assert b[-2] == t0+100-5
+
+    c = 0
+    for bucket in b[0:-1]:
+        x = hubble_status.short(bucket)
+        assert x['x.test1']['bucket'] == bucket
+        c += x['x.test1']['count']
+    assert c == 100
+
+    hubble_status.reset()
+    b = hubble_status.buckets()
+    assert len(b) == 1
+
+def test_max_depth():
+    t0 = 1553102100
+    hubblestack.status.__opts__['hubble_status'] = { 'bucket_len': 5 }
+    hubble_status = hubblestack.status.HubbleStatus('x', 'test1')
+
+    for t in range(t0, t0+100):
+        hubble_status.mark('test1', t=t)
+
+    b1 = hubble_status.buckets()
+
+    hubblestack.status.MAX_DEPTH = 3
+    hubble_status.mark('test1', t0+99)
+
+    b2 = hubble_status.buckets()
+    assert len(b1) == 1 + 100/5
+    assert len(b2) == 3

--- a/tests/unittests/test_counters.py
+++ b/tests/unittests/test_counters.py
@@ -31,8 +31,7 @@ def test_one_count():
 
 def test_buckets():
     t0 = 1553102100
-    hubblestack.status.MAX_DEPTH = 100
-    hubblestack.status.__opts__['hubble_status'] = { 'bucket_len': 5 }
+    hubblestack.status.__opts__['hubble_status'] = { 'bucket_len': 5, 'max_buckets': 1000 }
     hubble_status = hubblestack.status.HubbleStatus('x', 'test1')
 
     for t in range(t0, t0+100):
@@ -56,7 +55,7 @@ def test_buckets():
 
 def test_max_depth():
     t0 = 1553102100
-    hubblestack.status.__opts__['hubble_status'] = { 'bucket_len': 5 }
+    hubblestack.status.__opts__['hubble_status'] = { 'bucket_len': 5, 'max_buckets': 1000 }
     hubble_status = hubblestack.status.HubbleStatus('x', 'test1')
 
     for t in range(t0, t0+100):
@@ -64,7 +63,7 @@ def test_max_depth():
 
     b1 = hubble_status.buckets()
 
-    hubblestack.status.MAX_DEPTH = 3
+    hubblestack.status.__opts__['hubble_status']['max_buckets'] = 3
     hubble_status.mark('test1', t0+99)
 
     b2 = hubble_status.buckets()


### PR DESCRIPTION
There's a new setting "bucket_len" for "hubble_status". It defaults to 3600. The idea is to drop the counters into clock-aligned buckets so they're easier to line up with splunk counts by time. If the periods are predictable, then all the accounting is that much easier.

I think I increased the tech-debt a bit as this is pretty hard to read now; but it's worth it as it'll be a zillion times easier to line up with splunk event counts in searches.

I'm still testing this. (Should I add myself as a reviewer?)