### PR TITLE
Remove salt logging and consolidate logging system

### DIFF
--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -50,24 +50,11 @@ __opts__ = {}
 # This should work fine until we go to multiprocessing
 SESSION_UUID = str(uuid.uuid4())
 
-early_log_handler = None
 
 def run():
     '''
     Set up program, daemonize if needed
     '''
-
-    # before running load_config -> salt.config.minion_config -> salt.config.load_config,
-    # salt populates logging handlers with a salt null-handler and a salt store logging handler
-    # if there are errors in the config, it then reports those errors to Null and invokes sys.exit
-    # ...
-    # add a stream logger for now, but remember it so we can ensure its not part of the loggers later
-    global early_log_handler
-    early_log_handler = logging.StreamHandler()
-    early_log_handler.setLevel(logging.INFO)
-    early_log_handler.setFormatter( logging.Formatter('%(asctime)s %(levelname)s %(name)s: %(message)s') )
-    logging.root.handlers.insert(0, early_log_handler)
-
     try:
         load_config()
     except Exception as e:
@@ -642,10 +629,6 @@ def load_config():
         'max_bytes': __opts__.get('logfile_maxbytes', 100000000),
         'backup_count': __opts__.get('logfile_backups', 1),
     }
-
-    # remove early console logging from the handlers
-    if early_log_handler in logging.root.handlers:
-        logging.root.handlers.remove(early_log_handler)
 
     # Setup logging
     hubblestack.log.setup_console_logger(**console_logging_opts)

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -631,13 +631,13 @@ def load_config():
     # Console logging is probably the same, but can be different
     console_logging_opts = {
         'log_level': __opts__.get('console_log_level', __opts__['log_level']),
-        'log_format': __opts__.get('console_log_format', '[%(levelname)-8s] %(message)s'),
+        'log_format': __opts__.get('console_log_format', '%(asctime)s [%(levelname)-5s] %(message)s'),
         'date_format': __opts__.get('console_log_date_format', '%H:%M:%S'),
     }
     file_logging_opts = {
         'log_file': __opts__.get('log_file', '/var/log/hubble'),
         'log_level': __opts__['log_level'],
-        'log_format': __opts__.get('log_format', '%(asctime)s,%(msecs)03d [%(levelname)][%(name)-17s:%(lineno)-4d] %(message)s'),
+        'log_format': __opts__.get('log_format', '%(asctime)s,%(msecs)03d [%(levelname)-5s] [%(name)s:%(lineno)d]  %(message)s'),
         'date_format': __opts__.get('log_date_format', '%Y-%m-%d %H:%M:%S'),
         'max_bytes': __opts__.get('logfile_maxbytes', 100000000),
         'backup_count': __opts__.get('logfile_backups', 1),

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -631,8 +631,16 @@ def load_config():
     # Console logging is probably the same, but can be different
     console_logging_opts = {
         'log_level': __opts__.get('console_log_level', __opts__['log_level']),
-        'log_format': __opts__.get('console_log_format'),
-        'date_format': __opts__.get('console_log_date_format'),
+        'log_format': __opts__.get('console_log_format', '[%(levelname)-8s] %(message)s'),
+        'date_format': __opts__.get('console_log_date_format', '%H:%M:%S'),
+    }
+    file_logging_opts = {
+        'log_file': __opts__.get('log_file', '/var/log/hubble'),
+        'log_level': __opts__['log_level'],
+        'log_format': __opts__.get('log_format', '%(asctime)s,%(msecs)03d [%(levelname)][%(name)-17s:%(lineno)-4d] %(message)s'),
+        'date_format': __opts__.get('log_date_format', '%Y-%m-%d %H:%M:%S'),
+        'max_bytes': __opts__.get('logfile_maxbytes', 100000000),
+        'backup_count': __opts__.get('logfile_backups', 1),
     }
 
     # remove early console logging from the handlers
@@ -641,10 +649,7 @@ def load_config():
 
     # Setup logging
     hubblestack.log.setup_console_logger(**console_logging_opts)
-    hubblestack.log.setup_file_logger(__opts__['log_file'],
-                                      __opts__['log_level'],
-                                      max_bytes=__opts__.get('logfile_maxbytes', 100000000),
-                                      backup_count=__opts__.get('logfile_backups', 1))
+    hubblestack.log.setup_file_logger(**file_logging_opts)
 
     with open(__opts__['log_file'], 'a') as fh:
         pass # ensure the file exists before we set perms on it

--- a/hubblestack/extmods/modules/conf_publisher.py
+++ b/hubblestack/extmods/modules/conf_publisher.py
@@ -3,7 +3,7 @@
 Module to send config options to splunk
 '''
 import logging
-import hubblestack.splunklogging
+import hubblestack.log
 import copy
 import time
 
@@ -32,22 +32,10 @@ def publish(report_directly_to_splunk=True, *args):
             if arg in  __opts__:
                 opts_to_log[arg] = __opts__[arg]
 
+    filtered_conf = _filter_config(opts_to_log)
+
     if report_directly_to_splunk:
-        hubblestack.splunklogging.__grains__ = __grains__
-        hubblestack.splunklogging.__salt__ = __salt__
-        hubblestack.splunklogging.__opts__ = __opts__
-
-        filtered_conf = _filter_config(opts_to_log)
-
-        class MockRecord(object):
-                def __init__(self, message, levelname, asctime, name):
-                    self.message = message
-                    self.levelname = levelname
-                    self.asctime = asctime
-                    self.name = name
-
-        handler = hubblestack.splunklogging.SplunkHandler()
-        handler.emit(MockRecord(filtered_conf, 'INFO', time.asctime(), 'hubblestack.hubble_config'))
+        hubblestack.log.emit_to_splunk(filtered_conf, 'INFO', 'hubblestack.hubble_config')
         log.debug('Published config to splunk')
 
     return filtered_conf

--- a/hubblestack/log.py
+++ b/hubblestack/log.py
@@ -100,7 +100,7 @@ def setup_console_logger(log_level='error',
 
 def setup_file_logger(log_file,
                       log_level='error',
-                      log_format='%(asctime)s,%(msecs)03d [%(name)-17s:%(lineno)-4d][%(levelname)-8s][%(process)d] %(message)s',
+                      log_format='%(asctime)s,%(msecs)03d [%(levelname)][%(name)-17s:%(lineno)-4d] %(message)s',
                       date_format='%Y-%m-%d %H:%M:%S',
                       max_bytes=100000000,
                       backup_count=1):

--- a/hubblestack/log.py
+++ b/hubblestack/log.py
@@ -88,7 +88,7 @@ def setup_console_logger(log_level='error',
     '''
     rootlogger = logging.getLogger()
 
-    handler = logging.handlers.StreamHandler()
+    handler = logging.StreamHandler()
     handler.setLevel(LOG_LEVELS.get(log_level, logging.ERROR))
 
     formatter = logging.Formatter(log_format, date_format)

--- a/hubblestack/log.py
+++ b/hubblestack/log.py
@@ -1,0 +1,146 @@
+# -*- coding: utf-8 -*-
+'''
+Logging for the hubble daemon
+'''
+
+from __future__ import print_function
+
+import logging
+import time
+
+import hubblestack.splunklogging
+
+# While hubble doesn't use these, salt modules can, so let's define them anyway
+SPLUNK = logging.SPLUNK = 25
+PROFILE = logging.PROFILE = 15
+TRACE = logging.TRACE = 5
+GARBAGE = logging.GARBAGE = 1
+QUIET = logging.QUIET = 1000
+
+LOG_LEVELS = {
+    'all': logging.NOTSET,
+    'debug': logging.DEBUG,
+    'error': logging.ERROR,
+    'critical': logging.CRITICAL,
+    'garbage': GARBAGE,
+    'info': logging.INFO,
+    'profile': PROFILE,
+    'quiet': QUIET,
+    'trace': TRACE,
+    'warning': logging.WARNING,
+}
+
+logging.addLevelName(SPLUNK, 'SPLUNK')
+logging.addLevelName(QUIET, 'QUIET')
+logging.addLevelName(PROFILE, 'PROFILE')
+logging.addLevelName(TRACE, 'TRACE')
+logging.addLevelName(GARBAGE, 'GARBAGE')
+
+
+def _splunk(self, message, *args, **kwargs):
+    if self.isEnabledFor(logging.SPLUNK):
+        self._log(logging.SPLUNK, message, args, **kwargs)
+
+
+def _quiet(self, message, *args, **kwargs):
+    if self.isEnabledFor(logging.QUIET):
+        self._log(logging.QUIET, message, args, **kwargs)
+
+
+def _profile(self, message, *args, **kwargs):
+    if self.isEnabledFor(logging.PROFILE):
+        self._log(logging.PROFILE, message, args, **kwargs)
+
+
+def _trace(self, message, *args, **kwargs):
+    if self.isEnabledFor(logging.TRACE):
+        self._log(logging.TRACE, message, args, **kwargs)
+
+
+def _garbage(self, message, *args, **kwargs):
+    if self.isEnabledFor(logging.GARBAGE):
+        self._log(logging.GARBAGE, message, args, **kwargs)
+
+
+logging.Logger.splunk = _splunk
+logging.Logger.quiet = _quiet
+logging.Logger.profile = _profile
+logging.Logger.trace = _trace
+logging.Logger.garbage = _garbage
+
+SPLUNK_HANDLER = None
+
+
+class MockRecord(object):
+    def __init__(self, message, levelname, asctime, name):
+        self.message = message
+        self.levelname = levelname
+        self.asctime = asctime
+        self.name = name
+
+
+def setup_console_logger(log_level='error',
+                         log_format='[%(levelname)-8s] %(message)s',
+                         date_format='%H:%M:%S'):
+    '''
+    Sets up logging to STDERR, allowing for configurable level, format, and
+    date format.
+    '''
+    rootlogger = logging.getLogger()
+
+    handler = logging.StreamHandler()
+    handler.setLevel(LOG_LEVELS.get(log_level, logging.ERROR))
+
+    formatter = logging.Formatter(log_format, date_format)
+
+    handler.setFormatter(formatter)
+
+    rootlogger.addHandler(handler)
+
+
+def setup_file_logger(log_file,
+                      log_level='error',
+                      log_format='%(asctime)s,%(msecs)03d [%(name)-17s:%(lineno)-4d][%(levelname)-8s][%(process)d] %(message)s',
+                      date_format='%Y-%m-%d %H:%M:%S',
+                      max_bytes=100000000,
+                      backup_count=1):
+    '''
+    Sets up logging to a file. By default will auto-rotate those logs every
+    100MB and keep one backup.
+    '''
+    rootlogger = logging.getLogger()
+
+    handler = logging.RotatingFileHandler(log_file, maxBytes=max_bytes, backupCount=backup_count)
+    handler.setLevel(LOG_LEVELS.get(log_level, logging.ERROR))
+
+    formatter = logging.Formatter(log_format, date_format)
+
+    handler.setFormatter(formatter)
+
+    rootlogger.addHandler(handler)
+
+
+def setup_splunk_logger():
+    '''
+    Sets up logging to splunk.
+    '''
+    rootlogger = logging.getLogger()
+
+    handler = hubblestack.splunklogging.SplunkHandler()
+    handler.setLevel(logging.SPLUNK)
+
+    rootlogger.addHandler(handler)
+
+    global SPLUNK_HANDLER
+    SPLUNK_HANDLER = handler
+
+
+def emit_to_splunk(message, level, name):
+    '''
+    Emit a single message to splunk
+    '''
+    if SPLUNK_HANDLER is None:
+        return False
+    handler = SPLUNK_HANDLER
+
+    handler.emit(MockRecord(message, level, time.asctime(), name))

--- a/hubblestack/log.py
+++ b/hubblestack/log.py
@@ -80,7 +80,7 @@ class MockRecord(object):
 
 
 def setup_console_logger(log_level='error',
-                         log_format='[%(levelname)-8s] %(message)s',
+                         log_format='%(asctime)s [%(levelname)-5s] %(message)s',
                          date_format='%H:%M:%S'):
     '''
     Sets up logging to STDERR, allowing for configurable level, format, and
@@ -100,7 +100,7 @@ def setup_console_logger(log_level='error',
 
 def setup_file_logger(log_file,
                       log_level='error',
-                      log_format='%(asctime)s,%(msecs)03d [%(levelname)][%(name)-17s:%(lineno)-4d] %(message)s',
+                      log_format='%(asctime)s,%(msecs)03d [%(levelname)-5s] [%(name)s:%(lineno)d]  %(message)s',
                       date_format='%Y-%m-%d %H:%M:%S',
                       max_bytes=100000000,
                       backup_count=1):

--- a/hubblestack/log.py
+++ b/hubblestack/log.py
@@ -88,7 +88,7 @@ def setup_console_logger(log_level='error',
     '''
     rootlogger = logging.getLogger()
 
-    handler = logging.StreamHandler()
+    handler = logging.handlers.StreamHandler()
     handler.setLevel(LOG_LEVELS.get(log_level, logging.ERROR))
 
     formatter = logging.Formatter(log_format, date_format)
@@ -110,7 +110,7 @@ def setup_file_logger(log_file,
     '''
     rootlogger = logging.getLogger()
 
-    handler = logging.RotatingFileHandler(log_file, maxBytes=max_bytes, backupCount=backup_count)
+    handler = logging.handlers.RotatingFileHandler(log_file, maxBytes=max_bytes, backupCount=backup_count)
     handler.setLevel(LOG_LEVELS.get(log_level, logging.ERROR))
 
     formatter = logging.Formatter(log_format, date_format)

--- a/hubblestack/log.py
+++ b/hubblestack/log.py
@@ -79,6 +79,22 @@ class MockRecord(object):
         self.name = name
 
 
+# Set up an early log handler for use while we're generating config.
+# Will be removed when we set up the console or file logger.
+TEMP_HANDLER = logging.StreamHandler()
+TEMP_HANDLER.setLevel(logging.INFO)
+TEMP_HANDLER.setFormatter( logging.Formatter('%(asctime)s %(levelname)s %(name)s: %(message)s') )
+logging.root.handlers.insert(0, TEMP_HANDLER)
+
+
+def _remove_temp_handler():
+    '''
+    Remove temporary handler if it exists
+    '''
+    if TEMP_HANDLER and TEMP_HANDLER in logging.root.handlers:
+        logging.root.handlers.remove(TEMP_HANDLER)
+
+
 def setup_console_logger(log_level='error',
                          log_format='%(asctime)s [%(levelname)-5s] %(message)s',
                          date_format='%H:%M:%S'):
@@ -86,6 +102,7 @@ def setup_console_logger(log_level='error',
     Sets up logging to STDERR, allowing for configurable level, format, and
     date format.
     '''
+    _remove_temp_handler()
     rootlogger = logging.getLogger()
 
     handler = logging.StreamHandler()
@@ -108,6 +125,7 @@ def setup_file_logger(log_file,
     Sets up logging to a file. By default will auto-rotate those logs every
     100MB and keep one backup.
     '''
+    _remove_temp_handler()
     rootlogger = logging.getLogger()
 
     handler = logging.handlers.RotatingFileHandler(log_file, maxBytes=max_bytes, backupCount=backup_count)
@@ -124,6 +142,7 @@ def setup_splunk_logger():
     '''
     Sets up logging to splunk.
     '''
+    _remove_temp_handler()
     rootlogger = logging.getLogger()
 
     handler = hubblestack.splunklogging.SplunkHandler()

--- a/hubblestack/status.py
+++ b/hubblestack/status.py
@@ -525,18 +525,10 @@ class HubbleStatus(object):
         try:
             if __salt__['config.get']('splunklogging', False):
                 # lazy load to avoid circular import
-                import hubblestack.splunklogging
-                handler = hubblestack.splunklogging.SplunkHandler()
-                class MockRecord(object):
-                    def __init__(self, message, levelname, asctime, name):
-                        self.message = message
-                        self.levelname = levelname
-                        self.asctime = asctime
-                        self.name = name
-                handler.emit(MockRecord('Signal {0} detected'.format(signal.SIGUSR1),
-                                        'INFO',
-                                        time.asctime(),
-                                        'hubblestack.signals'))
+                import hubblestack.log
+                hubblestack.log.emit_to_splunk('Signal {0} detected'.format(signal.SIGUSR1),
+                                               'INFO',
+                                               'hubblestack.signals')
         finally:
             dumpster = get_hubble_status_opt('dumpster') or 'status.json'
             if not dumpster.startswith('/'):


### PR DESCRIPTION
We found a memory leak in the salt logging system which I then confirmed with some of the salt engineers. Rather than wait for the fix, I just pulled salt's logging out, and consolidated our logging into hubblestack/log.py

It resulted in much cleaner setup and cleaned up some of our direct-to-splunk emitting elsewhere.

And it's working great!