### PR TITLE
Remove splunklogging.emit_data

### DIFF
--- a/hubblestack/extmods/modules/nebula_osquery.py
+++ b/hubblestack/extmods/modules/nebula_osquery.py
@@ -499,7 +499,7 @@ def check_disk_usage(path=None):
         if __salt__['config.get']('splunklogging', False):
             log.debug('Logging disk usage stats to splunk')
             stats = {'disk_stats': disk_stats, 'schedule_time': time.time()}
-            hubblestack.log.emit_to_splunk(stats, 'INFO', 'hubblestack.osquery_disk_usage')
+            hubblestack.log.emit_to_splunk(stats, 'INFO', 'hubblestack.disk_usage')
 
     return disk_stats
 

--- a/hubblestack/extmods/modules/nebula_osquery.py
+++ b/hubblestack/extmods/modules/nebula_osquery.py
@@ -42,7 +42,7 @@ import salt.utils.platform
 from hashlib import md5
 from salt.exceptions import CommandExecutionError
 from hubblestack import __version__
-import hubblestack.splunklogging
+import hubblestack.log
 
 log = logging.getLogger(__name__)
 
@@ -226,14 +226,10 @@ def queries(query_group,
         return None
 
     if __salt__['config.get']('splunklogging', False):
-        log.info('Logging osquery timing data to splunk')
-        hubblestack.splunklogging.__grains__ = __grains__
-        hubblestack.splunklogging.__salt__ = __salt__
-        hubblestack.splunklogging.__opts__ = __opts__
-        handler = hubblestack.splunklogging.SplunkHandler()
+        log.debug('Logging osquery timing data to splunk')
         timing_data = {'query_run_length': timing,
                        'schedule_time': schedule_time}
-        handler.emit_data(timing_data)
+        hubblestack.log.emit_to_splunk(timing_data, 'INFO', 'hubblestack.osquery_timing')
 
     if query_group == 'day' and report_version_with_day:
         ret.append(hubble_versions())
@@ -502,12 +498,8 @@ def check_disk_usage(path=None):
 
         if __salt__['config.get']('splunklogging', False):
             log.debug('Logging disk usage stats to splunk')
-            hubblestack.splunklogging.__grains__ = __grains__
-            hubblestack.splunklogging.__salt__ = __salt__
-            hubblestack.splunklogging.__opts__ = __opts__
-            handler = hubblestack.splunklogging.SplunkHandler()
             stats = {'disk_stats': disk_stats, 'schedule_time': time.time()}
-            handler.emit_data(stats)
+            hubblestack.log.emit_to_splunk(stats, 'INFO', 'hubblestack.osquery_disk_usage')
 
     return disk_stats
 

--- a/hubblestack/splunklogging.py
+++ b/hubblestack/splunklogging.py
@@ -165,21 +165,6 @@ class SplunkHandler(logging.Handler):
             hec.flushBatch()
         return True
 
-    def emit_data(self, data):
-        '''
-        Add the given data (in dict format!) to the event template and emit as
-        usual
-        '''
-        for hec, event, payload in self.endpoint_list:
-            event = copy.deepcopy(event)
-            payload = copy.deepcopy(payload)
-            event.update(data)
-            payload['event'] = event
-            # no_queue tells the hec never to queue the data to disk
-            hec.batchEvent(payload, eventtime=time.time(), no_queue=True)
-            hec.flushBatch()
-        return True
-
     def format_record(self, record):
         '''
         Format the log record into a dictionary for easy insertion into a

--- a/hubblestack/splunklogging.py
+++ b/hubblestack/splunklogging.py
@@ -42,6 +42,7 @@ import json
 import time
 import copy
 from hubblestack.hec import http_event_collector, get_splunk_options, make_hec_args
+import hubblestack.utils.stdrec
 
 import logging
 
@@ -54,9 +55,6 @@ class SplunkHandler(logging.Handler):
 
         self.opts_list = get_splunk_options()
         self.endpoint_list = []
-
-        # Get cloud details
-        cloud_details = __grains__.get('cloud_details', {})
 
         for opts in self.opts_list:
             custom_fields = opts['custom_fields']
@@ -102,13 +100,7 @@ class SplunkHandler(logging.Handler):
                 fqdn = new_fqdn
 
             event = {}
-            event.update({'master': master})
-            event.update({'minion_id': minion_id})
-            event.update({'dest_host': fqdn})
-            event.update({'dest_ip': fqdn_ip4})
-            event.update({'system_uuid': __grains__.get('system_uuid')})
-
-            event.update(cloud_details)
+            event.update(hubblestack.utils.stdrec.std_info())
 
             for custom_field in custom_fields:
                 custom_field_name = 'custom_' + custom_field


### PR DESCRIPTION
No need for these manual instances now that we have
hubblestack.log.emit_to_splunk

Note, these will now show up under different logger names in splunk --
rather than logging under the module name, they will log under the
new names `hubblestack.osquery_timing` and
`hubblestack.osquery_disk_usage`.