### PR TITLE
bug fix: filtering opts that have dots in their name

### DIFF
--- a/hubblestack/extmods/modules/conf_publisher.py
+++ b/hubblestack/extmods/modules/conf_publisher.py
@@ -55,11 +55,11 @@ def _filter_config(opts_to_log, remove_dots=True):
     Filters out keys containing certain patterns to avoid sensitive information being sent to splunk
     '''
     patterns_to_filter = ["password", "token", "passphrase", "privkey", "keyid", "s3.key"]
-    if remove_dots:
-        for key in opts_to_log.keys():
-            if '.' in key:
-                opts_to_log[key.replace('.', '_')] = opts_to_log.pop(key)
     filtered_conf = _remove_sensitive_info(opts_to_log, patterns_to_filter)
+    if remove_dots:
+        for key in filtered_conf.keys():
+            if '.' in key:
+                filtered_conf[key.replace('.', '_')] = filtered_conf.pop(key)
     return filtered_conf
 
 


### PR DESCRIPTION
opts in the patterns_to_filter that had a dot in them weren't filtered
because the dot was replaced with underscore before _remove_sensitive_info
was called. this could have been fixed also by simply replacing the dot
with the underscore in the patterns_to_filter list but the list would have
been less intuitive to operate.