### PR TITLE
Persist version/buildinfo grains and add hubble_mark_3 grain

### DIFF
--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -583,9 +583,11 @@ def load_config():
     disable_modules.extend([
         'boto3_elasticache',
         'boto3_route53',
+        'boto3_sns',
         'boto_apigateway',
         'boto_asg',
         'boto_cfn',
+        'boto_cloudfront',
         'boto_cloudtrail',
         'boto_cloudwatch_event',
         'boto_cloudwatch',
@@ -606,9 +608,11 @@ def load_config():
         'boto_rds',
         'boto_route53',
         'boto_s3_bucket',
+        'boto_s3',
         'boto_secgroup',
         'boto_sns',
         'boto_sqs',
+        'boto_ssm',
         'boto_vpc',
     ])
     __opts__['disable_modules'] = disable_modules

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -722,6 +722,10 @@ def refresh_grains(initial=False):
         for grain in __opts__.get('grains_persist', []):
             if grain in __grains__:
                 persist[grain] = __grains__[grain]
+        # Hardcode these core grains as persisting
+        for grain in ['hubble_version', 'buildinfo']:
+            if grain in __grains__:
+                persist[grain] = __grains__[grain]
 
     if initial:
         __context__ = {}
@@ -732,6 +736,15 @@ def refresh_grains(initial=False):
     __grains__ = salt.loader.grains(__opts__)
     __grains__.update(persist)
     __grains__['session_uuid'] = SESSION_UUID
+
+    # This was a weird one. In older versions of hubble the version and
+    # buildinfo were not persisted automatically which means that if you
+    # installed a new version without restarting hubble, grains refresh could
+    # cause that old daemon to report grains as if it were the new version.
+    # Now if this hubble_marker_3 grain is present you know you can trust the
+    # hubble_version and buildinfo.
+    __grains__['hubble_marker_3'] = True
+
     old_grains.update(__grains__)
     __grains__ = old_grains
 


### PR DESCRIPTION
This one is a gnarly one. Since the hubble_version and buildinfo are on disk, and grains refresh *from* disk, an old version of the daemon could pick up changes to those thing on disk (perhaps from a new package install) and if you're using those grains as reporting tools, you lose insight into what is actually running on the host.

This PR makes those grains persist automatically across refreshes. But additionally it adds a new hardcoded grain `hubble_marker_3` so you can tell if a daemon is actually running the new persisting code or not. It's a hacky solution but I don't have a better one in mind.

Thoughts?

(Note, this is targeted directly at 3.0 and will hit develop when I merge forward)