### PR TITLE
Add support for account_contains in win_secedit.py

### DIFF
--- a/hubblestack/files/hubblestack_nova/win_secedit.py
+++ b/hubblestack/files/hubblestack_nova/win_secedit.py
@@ -339,6 +339,15 @@ def _translate_value_type(current, value, evaluator, __sidaccounts__=False):
             return True
         else:
             return False
+    elif 'account_contains' in value:  # Require an account to be present, but not exclusively.
+        if "*S-" not in evaluator:
+            evaluator = _account_audit(evaluator, __sidaccounts__)
+        evaluator_list = evaluator.split(',')
+        current_list = current.split(',')
+        for list_item in evaluator_list:
+            if list_item not in current_list:
+                return False
+        return True
     elif 'contains' in value:
         if type(evaluator) != list:
             evaluator = evaluator.split(',')


### PR DESCRIPTION
This will allow using the user/group name in checks where a user or group must be present in a list, but other items are allowed in the list.