### PR TITLE
Missing counters

### DIFF
--- a/hubblestack/extmods/modules/hstatus.py
+++ b/hubblestack/extmods/modules/hstatus.py
@@ -3,6 +3,7 @@ import re
 import logging
 import math
 import hubblestack.status
+import time
 
 log = logging.getLogger(__name__)
 
@@ -10,6 +11,7 @@ __virtualname__ = 'hstatus'
 
 SOURCETYPE = 'hubble_hec_summary'
 MSG_COUNTS_PAT = r'hubblestack.hec.obj.input:(?P<stype>[^:]+)'
+_last_send_time = 0 # track the last time we sent something
 
 def __virtual__():
     return True
@@ -24,13 +26,20 @@ def msg_counts(pat=MSG_COUNTS_PAT, emit_self=False, sourcetype=SOURCETYPE):
             sourcetype - the sourcetype for the accounting messages (default: hstatus.SOURCETYPE)
     '''
 
+    # NOTE: any logging in here *will* mess up the summary count of hubble_log
+    # (assuming hubble_log is reporting in and the logs are above the logging
+    # level)
+
     pat = re.compile(pat)
     ret = list() # events to return
     for bucket_set in hubblestack.status.HubbleStatus.short('all'):
         for k,v in bucket_set.iteritems():
             try:
                 # should be at least one count
-                if v['count'] <= 1:
+                if v['count'] < 1:
+                    continue
+                # skip records we probably already sent
+                if v['last_t'] < _last_send_time:
                     continue
             except KeyError as e:
                 continue
@@ -48,6 +57,8 @@ def msg_counts(pat=MSG_COUNTS_PAT, emit_self=False, sourcetype=SOURCETYPE):
                         'send_session_start': int(v['first_t']),
                         'send_session_end': int(math.ceil(v['last_t'])) })
     if ret:
+        global _last_send_time
+        _last_send_time = time.time()
         return { 'sourcetype': sourcetype, 'events': ret }
 
 def dump():

--- a/hubblestack/extmods/modules/hstatus.py
+++ b/hubblestack/extmods/modules/hstatus.py
@@ -31,20 +31,16 @@ def msg_counts(pat=MSG_COUNTS_PAT, reset=True, emit_self=False, sourcetype=SOURC
     for bucket_set in hubblestack.status.HubbleStatus.short('all'):
         for k,v in bucket_set.iteritems():
             try:
-                # if this counter hasn't fired at all, skip it
-                if v['first_t'] == 0 or v['last_t'] == 0:
-                    continue
-                # here should be at least one count
+                # should be at least one count
                 if v['count'] <= 1:
                     continue
             except KeyError as e:
                 continue
-
             m = pat.match(k)
             if m:
                 try:
                     stype = m.groupdict()['stype']
-                except KeyError:
+                except KeyError as e:
                     continue
                 if emit_self or stype != sourcetype:
                     ret.append({ 'stype': stype,

--- a/hubblestack/extmods/modules/hstatus.py
+++ b/hubblestack/extmods/modules/hstatus.py
@@ -14,20 +14,18 @@ MSG_COUNTS_PAT = r'hubblestack.hec.obj.input:(?P<stype>[^:]+)'
 def __virtual__():
     return True
 
-def msg_counts(pat=MSG_COUNTS_PAT, reset=True, emit_self=False, sourcetype=SOURCETYPE):
+def msg_counts(pat=MSG_COUNTS_PAT, emit_self=False, sourcetype=SOURCETYPE):
     ''' returns counter data formatted for the splunk_generic_return returner
 
         params:
             pat        - the key matching algorithm is a simple regular expression
                          (default: hstatus.MSG_COUNTS_PAT)
-            reset      - whether or not to reset the counters returned (default: True)
             emit_self  - whether to emit sourcetype counters (default: False)
             sourcetype - the sourcetype for the accounting messages (default: hstatus.SOURCETYPE)
     '''
 
     pat = re.compile(pat)
     ret = list() # events to return
-    to_reset = set()
     for bucket_set in hubblestack.status.HubbleStatus.short('all'):
         for k,v in bucket_set.iteritems():
             try:
@@ -49,12 +47,7 @@ def msg_counts(pat=MSG_COUNTS_PAT, reset=True, emit_self=False, sourcetype=SOURC
                         'event_count': v['count'],
                         'send_session_start': int(v['first_t']),
                         'send_session_end': int(math.ceil(v['last_t'])) })
-                to_reset.add(k)
-
     if ret:
-        if reset:
-            for k in to_reset:
-                hubblestack.status.HubbleStatus.reset(k)
         return { 'sourcetype': sourcetype, 'events': ret }
 
 def dump():

--- a/hubblestack/status.py
+++ b/hubblestack/status.py
@@ -488,8 +488,7 @@ class HubbleStatus(object):
 
         '''
         if bucket in ('*', 'all'):
-            # NOTE: :-1 so we skip the current bucket
-            return [ cls.short(b) for b in cls.buckets()[:-1] ]
+            return [ cls.short(b) for b in cls.buckets() ]
         return { k: v.asdict(bucket) for k,v in cls.dat.iteritems() if v.first_t > 0 }
 
     @classmethod

--- a/hubblestack/status.py
+++ b/hubblestack/status.py
@@ -268,14 +268,6 @@ class HubbleStatus(object):
                     yield i
             yield self
 
-        def reset(self):
-            ''' expunge all but the latest bucket '''
-            items = list(self)
-            mb = max(items, key=lambda x: x.bucket)
-            for node in items:
-                node.next = None
-            return mb
-
     def __init__(self, namespace, *resources):
         ''' params:
             * namespace: a namespace for the counters tracked by the instance (usually __name__)
@@ -389,17 +381,6 @@ class HubbleStatus(object):
         if invoke:
             return decorator(invoke)
         return decorator
-
-    @classmethod
-    def reset(cls, key=None):
-        # NOTE: this is janky... allowing resets on arbitrary keys on the
-        # class, not even tracked with _checkmark() ... but it's needed to make
-        # the sourcetype accounting beacon update meaningfully.
-        if key is None:
-            for k,v in cls.dat.iteritems():
-                cls.dat[k] = v.reset()
-        else:
-            cls.dat[key] = cls.dat[key].reset()
 
     @classmethod
     def stats(cls):

--- a/tests/unittests/test_counters.py
+++ b/tests/unittests/test_counters.py
@@ -49,10 +49,6 @@ def test_buckets():
         c += x['x.test1']['count']
     assert c == 100
 
-    hubble_status.reset()
-    b = hubble_status.buckets()
-    assert len(b) == 1
-
 def test_max_depth():
     t0 = 1553102100
     hubblestack.status.__opts__['hubble_status'] = { 'bucket_len': 5, 'max_buckets': 1000 }


### PR DESCRIPTION
* remove the old reset system. The memory anit-leak max-bucket limits should be enough
* remove logic that checks last_t/first_t in buckets; vestigial and not really applicable
* convince status.py to return all buckets with keyword 'all' — formerly skipped current bucket (why?)
* teach hstatus.py extmod to consider last_t as a filter, "have I already sent this?" Later, it should be asking, "have I sent this twice?" (Or perhaps thrice, or probably by `__opts__`) Repeating the information is desirable, particularly if we think things really do go missing.

This should produce really accurate counts and it should stop skipping buckets. It was really difficult trying to figure out why so many buckets were missing. So much was working that it literally took days to figure out why the missing things were missing.