### PR TITLE
The default is to use certs.

### DIFF
--- a/hubblestack/hec/obj.py
+++ b/hubblestack/hec/obj.py
@@ -194,6 +194,7 @@ class HEC(object):
         if http_event_collector_ssl_verify:
             pm_kw.update({'cert_reqs': 'CERT_REQUIRED', 'ca_certs': certifi.where()})
         else:
+            pm_kw.update({'cert_reqs': 'CERT_NONE'})
             urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
         if self.proxy:


### PR DESCRIPTION
We should be explicit here to avoid accidentally using certs where we've told
it we don't want to. Probably only applicable in my lab at home, but I think
there's other places this could be useful sometimes (or perhaps temporarily).