### PR TITLE
minor bug in queue(start) message

### DIFF
--- a/hubblestack/hec/obj.py
+++ b/hubblestack/hec/obj.py
@@ -110,6 +110,7 @@ class Payload(object):
 class HEC(object):
     flushing_queue = False
     last_flush = 0
+    direct_logging = False
 
     class Server(object):
         bad = False
@@ -224,8 +225,10 @@ class HEC(object):
         self._send(self._payload_msg(message, *a))
 
     def _queue_event(self, payload):
-        if self.queue.cn < 1:
+        if self.queue.cn < 1 and not self.direct_logging:
+            self.direct_logging = True
             self._direct_send_msg('queue(start)')
+            self.direct_logging = False
         p = str(payload)
         log.info('queueing %d octets to disk', len(p))
         try:


### PR DESCRIPTION
This prevents some annoying duplication of queue(start) messages. I thought it was in the previous PR.