### PR TITLE
Push large objects to bottom of json in Splunk returns

### DIFF
--- a/hubblestack/hec/obj.py
+++ b/hubblestack/hec/obj.py
@@ -89,7 +89,23 @@ class Payload(object):
         self.sourcetype = dat.get('sourcetype', 'hubble')
         self.time       = dat.get('time', now)
 
-        self.dat = json.dumps(dat)
+        out_str = json.dumps(dat)
+        if len(out_str) > 5000:
+            move_to_bottom = []
+            for k, v in dat['event'].iteritems():
+                try:
+                    if len(json.dumps(v)) > 500:
+                        move_to_bottom.append(k)
+                except Exception:
+                    pass
+
+            for x in move_to_bottom:
+                dat['event']['zzzzzzzzzzzzzzzzzz_%s' % x] = dat['event'].pop(x)
+
+            out_str = json.dumps(dat, sort_keys=True)
+            out_str = out_str.replace('zzzzzzzzzzzzzzzzzz_', '')
+
+        self.dat = out_str
 
     def __repr__(self):
         return 'Payload({0})'.format(self)


### PR DESCRIPTION
When you send in json events into Splunk, they are stored as raw strings, and the json is extracted at search time. This is great, all is well. However, Splunk will just stop extracting fields at 5k characters. This means that if the json event is stupid long, fields that fall after that point won't be extracted and _can't be searched on_.

The main thing this causes problems for is our identity fields: `system_uuid`, `cloud_instance_id`, etc. If they happen to fall at the bottom of a long event and don't get extracted, they won't be returned in a search based on that field.

This solution finds events that are > 5000 characters, finds the long ("long" is here defined as 500 characters) objects and pushes them to the bottom of the json object.