### PR TITLE
attempt to fully fix dup hec summary messages

### DIFF
--- a/hubblestack/extmods/modules/hstatus.py
+++ b/hubblestack/extmods/modules/hstatus.py
@@ -48,15 +48,24 @@ def msg_counts(pat=MSG_COUNTS_PAT, emit_self=False, sourcetype=SOURCETYPE):
                     continue
                 if emit_self or stype != sourcetype:
                     rep = hubblestack.status.HubbleStatus.get_reported(k, v['bucket'])
+                    skip = False
                     if isinstance(rep, list):
-                        rep.append(now)
-                    ret.append({ 'stype': stype,
-                        'bucket': v['bucket'],
-                        'bucket_len': v['bucket_len'],
-                        'reported': rep,
-                        'event_count': v['count'],
-                        'send_session_start': int(v['first_t']),
-                        'send_session_end': int(math.ceil(v['last_t'])) })
+                        if len(rep) < 4:
+                            rep.append(now)
+                        else:
+                            skip = True
+                    else:
+                        # This is just in case the bucket can't be found
+                        # it should otherwise always be populated as a list
+                        rep = "unknown reported format: " + repr(rep)
+                    if not skip:
+                        ret.append({ 'stype': stype,
+                            'bucket': v['bucket'],
+                            'bucket_len': v['bucket_len'],
+                            'reported': rep,
+                            'event_count': v['count'],
+                            'send_session_start': int(v['first_t']),
+                            'send_session_end': int(math.ceil(v['last_t'])) })
     if ret:
         return { 'time': now, 'sourcetype': sourcetype, 'events': ret }
 

--- a/hubblestack/extmods/modules/hstatus.py
+++ b/hubblestack/extmods/modules/hstatus.py
@@ -29,6 +29,8 @@ def msg_counts(pat=MSG_COUNTS_PAT, emit_self=False, sourcetype=SOURCETYPE):
     # (assuming hubble_log is reporting in and the logs are above the logging
     # level)
 
+    summary_repeat = __opts__.get('hubble_status', {}).get('summary_repeat', 4)
+
     now = int(time.time())
     pat = re.compile(pat)
     ret = list() # events to return
@@ -50,7 +52,7 @@ def msg_counts(pat=MSG_COUNTS_PAT, emit_self=False, sourcetype=SOURCETYPE):
                     rep = hubblestack.status.HubbleStatus.get_reported(k, v['bucket'])
                     skip = False
                     if isinstance(rep, list):
-                        if len(rep) < 4:
+                        if len(rep) < summary_repeat:
                             rep.append(now)
                         else:
                             skip = True

--- a/hubblestack/extmods/modules/hstatus.py
+++ b/hubblestack/extmods/modules/hstatus.py
@@ -11,7 +11,6 @@ __virtualname__ = 'hstatus'
 
 SOURCETYPE = 'hubble_hec_summary'
 MSG_COUNTS_PAT = r'hubblestack.hec.obj.input:(?P<stype>[^:]+)'
-_last_send_time = 0 # track the last time we sent something
 
 def __virtual__():
     return True
@@ -39,7 +38,7 @@ def msg_counts(pat=MSG_COUNTS_PAT, emit_self=False, sourcetype=SOURCETYPE):
                 if v['count'] < 1:
                     continue
                 # skip records we probably already sent
-                if v['last_t'] < _last_send_time:
+                if v['last_t'] < hubblestack.status.last_send_time:
                     continue
             except KeyError as e:
                 continue
@@ -57,8 +56,7 @@ def msg_counts(pat=MSG_COUNTS_PAT, emit_self=False, sourcetype=SOURCETYPE):
                         'send_session_start': int(v['first_t']),
                         'send_session_end': int(math.ceil(v['last_t'])) })
     if ret:
-        global _last_send_time
-        _last_send_time = time.time()
+        hubblestack.status.last_send_time = time.time()
         return { 'sourcetype': sourcetype, 'events': ret }
 
 def dump():

--- a/hubblestack/status.py
+++ b/hubblestack/status.py
@@ -40,10 +40,6 @@ import os
 
 log = logging.getLogger(__name__)
 
-# This global is used by the extmods/modules/hstatus to persist last send time
-# info. Best not to fiddle with it outside of that module.
-last_send_time = 0
-
 DEFAULTS = {
     'dumpster': 'status.json', # '/var/cache/hubble/status.json',
     'hung_time':   900,
@@ -187,6 +183,9 @@ class HubbleStatus(object):
             self.ema_dt = None
             self.dur = None
             self.ema_dur = None
+            # reported is used exclusively by extmods/modules/hstatus
+            # cleared on every mark()
+            self.reported = list()
 
         def get_bucket(self, bucket, no_append=False):
             bucket, _ = t_bucket(t=bucket)
@@ -254,6 +253,7 @@ class HubbleStatus(object):
             dt = self.dt
             self.last_t = t
             self.ema_dt = dt if self.ema_dt is None else 0.5*self.ema_dt + 0.5*dt
+            self.reported = list()
             return self
 
         def fin(self):
@@ -337,6 +337,12 @@ class HubbleStatus(object):
         r = self.dat[n].mark(t=t)
         self._check_depth(n)
         return r
+
+    @classmethod
+    def get_reported(cls, n, bucket):
+        b = cls.dat[n].find_bucket(bucket)
+        if b:
+            return b.reported
 
     @classmethod
     def buckets(cls, n=None):

--- a/hubblestack/status.py
+++ b/hubblestack/status.py
@@ -40,6 +40,10 @@ import os
 
 log = logging.getLogger(__name__)
 
+# This global is used by the extmods/modules/hstatus to persist last send time
+# info. Best not to fiddle with it outside of that module.
+last_send_time = 0
+
 DEFAULTS = {
     'dumpster': 'status.json', # '/var/cache/hubble/status.json',
     'hung_time':   900,


### PR DESCRIPTION
Fixing the dup hec summary messages has the unintneded side effect of ensuring no repeat messages are ever submitted. So this change also submits intentional repeats (adjustable via `hubble_status:summary_repeat` in `__opts__`).