### PR TITLE
I tried a lot of stuff here. This is the best solution imo.

### DIFF
--- a/hubblestack/hec/obj.py
+++ b/hubblestack/hec/obj.py
@@ -317,7 +317,8 @@ class HEC(object):
                 server.bad = True
                 continue
             except Exception as e:
-                log.error('presumed minor error with "%s" (mark fail and continue): %s', server.uri, e)
+                log.error('presumed minor error with "%s" (mark fail and continue): %s',
+                    server.uri, repr(e), exc_info=True)
                 possible_queue = True
                 server.fails += 1
                 continue


### PR DESCRIPTION
We need to know precisely what's causing the mysterious "presumed minor" errors. I suspect it's not actually something form the two lines (one is an assignment, so one line really). I suspect the "maximum recursion" errors are actually text strings from something out there on the web -- but I just don't know.

So I just turned on traces for the error. I think the "presumed" class errors are rare enough that we should just leave the traces here.