### PR TITLE
Provision for building osquery with custom local code

### DIFF
--- a/pkg/dev/amazonlinux2016.09/Dockerfile
+++ b/pkg/dev/amazonlinux2016.09/Dockerfile
@@ -5,7 +5,35 @@
 # The resulting image is ready to run the pyinstaller on container start and drop hubble<version>-coreos.tar.gz
 # in the /data directory. Mount /data volume into a directory on the host to access the package.
 # To run the container:  docker run -it --rm -v `pwd`:/data <image_name>
+# Requires docker 17.05 or higher
 
+# Set this arguement to "local" if you want to build osquery for local code.
+# In that case, osquery folder must exist besides Dockerfile
+ARG OSQUERY_BUILD_ENV=remote
+
+#--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
+FROM alpine as osquery_local
+ONBUILD COPY osquery /osquery
+ONBUILD RUN echo "Copying osquery from local folder"
+
+
+
+#--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
+FROM alpine/git as osquery_remote
+ENV OSQUERY_SRC_VERSION=3.3.2
+ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
+ONBUILD RUN cd / \
+ && git clone "$OSQUERY_GIT_URL" \
+ && cd osquery/ \
+ && git checkout "$OSQUERY_SRC_VERSION" \
+ && echo "Fetching osquery from git"
+
+
+#--------------- TEMP CONTAINER FOR OSQUERY ( BASED ON ARG)  ----------------
+FROM osquery_"$OSQUERY_BUILD_ENV" as osquery_image
+
+
+#--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM amazonlinux:2016.09
 
 RUN yum makecache fast && yum -y update
@@ -17,20 +45,17 @@ RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osque
 #osquery should be built first since requirements for other packages can interfere with osquery dependencies
 #to build, osquery scripts want sudo and a user to sudo with.
 #to pin to a different version change the following envirnment variable
-ENV OSQUERY_SRC_VERSION=3.3.2
 ENV OSQUERY_BUILD_USER=osquerybuilder
-ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
 RUN yum -y install git make python ruby sudo which
 RUN useradd --shell /bin/bash --create-home --user-group --groups wheel "$OSQUERY_BUILD_USER" \
  && sed -i '0,/^#\ %wheel/s/^#\ %wheel.*/%wheel\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
+COPY --from=osquery_image /osquery /home/"$OSQUERY_BUILD_USER"/osquery
 RUN mkdir -p /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/
+ && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
+ && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
 USER $OSQUERY_BUILD_USER
 ENV SKIP_TESTS=1
-RUN cd /home/"$OSQUERY_BUILD_USER" \
- && git clone "$OSQUERY_GIT_URL" \
- && cd osquery/ \
- && git checkout "$OSQUERY_SRC_VERSION" \
+RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
  && make sysprep \
 #have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
  && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \

--- a/pkg/dev/centos6/Dockerfile
+++ b/pkg/dev/centos6/Dockerfile
@@ -5,7 +5,35 @@
 # The resulting image is ready to run the pyinstaller on container start and drop hubble<version>-coreos.tar.gz
 # in the /data directory. Mount /data volume into a directory on the host to access the package.
 # To run the container:  docker run -it --rm -v `pwd`:/data <image_name>
+# Requires docker 17.05 or higher
 
+# Set this arguement to "local" if you want to build osquery for local code.
+# In that case, osquery folder must exist besides Dockerfile
+ARG OSQUERY_BUILD_ENV=remote
+
+#--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
+FROM alpine as osquery_local
+ONBUILD COPY osquery /osquery
+ONBUILD RUN echo "Copying osquery from local folder"
+
+
+
+#--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
+FROM alpine/git as osquery_remote
+ENV OSQUERY_SRC_VERSION=3.3.2
+ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
+ONBUILD RUN cd / \
+ && git clone "$OSQUERY_GIT_URL" \
+ && cd osquery/ \
+ && git checkout "$OSQUERY_SRC_VERSION" \
+ && echo "Fetching osquery from git"
+
+
+#--------------- TEMP CONTAINER FOR OSQUERY ( BASED ON ARG)  ----------------
+FROM osquery_"$OSQUERY_BUILD_ENV" as osquery_image
+
+
+#--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM centos:6
 
 RUN yum makecache fast && yum -y update
@@ -17,20 +45,17 @@ RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osque
 #osquery should be built first since requirements for other packages can interfere with osquery dependencies
 #to build, osquery scripts want sudo and a user to sudo with.
 #to pin to a different version change the following envirnment variable
-ENV OSQUERY_SRC_VERSION=3.3.2
 ENV OSQUERY_BUILD_USER=osquerybuilder
-ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
 RUN yum -y install xz git make python ruby sudo which python-argparse
 RUN useradd --shell /bin/bash --create-home --user-group --groups wheel "$OSQUERY_BUILD_USER" \
  && sed -i '0,/^#\ %wheel/s/^#\ %wheel.*/%wheel\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
+COPY --from=osquery_image /osquery /home/"$OSQUERY_BUILD_USER"/osquery
 RUN mkdir -p /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/
+ && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
+ && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
 USER $OSQUERY_BUILD_USER
 ENV SKIP_TESTS=1
-RUN cd /home/"$OSQUERY_BUILD_USER" \
- && git clone "$OSQUERY_GIT_URL" \
- && cd osquery/ \
- && git checkout "$OSQUERY_SRC_VERSION" \
+RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
  && make sysprep \
 #have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
  && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \

--- a/pkg/dev/centos7/Dockerfile
+++ b/pkg/dev/centos7/Dockerfile
@@ -5,7 +5,35 @@
 # The resulting image is ready to run the pyinstaller on container start and drop hubble<version>-coreos.tar.gz
 # in the /data directory. Mount /data volume into a directory on the host to access the package.
 # To run the container:  docker run -it --rm -v `pwd`:/data <image_name>
+# Requires docker 17.05 or higher
 
+# Set this arguement to "local" if you want to build osquery for local code.
+# In that case, osquery folder must exist besides Dockerfile
+ARG OSQUERY_BUILD_ENV=remote
+
+#--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
+FROM alpine as osquery_local
+ONBUILD COPY osquery /osquery
+ONBUILD RUN echo "Copying osquery from local folder"
+
+
+
+#--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
+FROM alpine/git as osquery_remote
+ENV OSQUERY_SRC_VERSION=3.3.2
+ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
+ONBUILD RUN cd / \
+ && git clone "$OSQUERY_GIT_URL" \
+ && cd osquery/ \
+ && git checkout "$OSQUERY_SRC_VERSION" \
+ && echo "Fetching osquery from git"
+
+
+#--------------- TEMP CONTAINER FOR OSQUERY ( BASED ON ARG)  ----------------
+FROM osquery_"$OSQUERY_BUILD_ENV" as osquery_image
+
+
+#--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM centos:7
 
 RUN yum makecache fast && yum -y update
@@ -17,20 +45,17 @@ RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osque
 #osquery should be built first since requirements for other packages can interfere with osquery dependencies
 #to build, osquery scripts want sudo and a user to sudo with.
 #to pin to a different version change the following envirnment variable
-ENV OSQUERY_SRC_VERSION=3.3.2
 ENV OSQUERY_BUILD_USER=osquerybuilder
-ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
 RUN yum -y install git make python ruby sudo which
 RUN useradd --shell /bin/bash --create-home --user-group --groups wheel "$OSQUERY_BUILD_USER" \
  && sed -i '0,/^#\ %wheel/s/^#\ %wheel.*/%wheel\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
+COPY --from=osquery_image /osquery /home/"$OSQUERY_BUILD_USER"/osquery
 RUN mkdir -p /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/
+ && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
+ && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
 USER $OSQUERY_BUILD_USER
 ENV SKIP_TESTS=1
-RUN cd /home/"$OSQUERY_BUILD_USER" \
- && git clone "$OSQUERY_GIT_URL" \
- && cd osquery/ \
- && git checkout "$OSQUERY_SRC_VERSION" \
+RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
  && make sysprep \
 #have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
  && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \

--- a/pkg/dev/coreos/Dockerfile
+++ b/pkg/dev/coreos/Dockerfile
@@ -5,7 +5,33 @@
 # The resulting image is ready to run the pyinstaller on container start and drop hubble<version>-coreos.tar.gz
 # in the /data directory. Mount /data volume into a directory on the host to access the package.
 # To run the container:  docker run -it --rm -v `pwd`:/data <image_name>
+# Requires docker 17.05 or higher
 
+ARG OSQUERY_BUILD_ENV=remote
+
+#--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
+FROM alpine as osquery_local
+ONBUILD COPY osquery /osquery
+ONBUILD RUN echo "Copying osquery from local folder"
+
+
+
+#--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
+FROM alpine/git as osquery_remote
+ENV OSQUERY_SRC_VERSION=3.3.2
+ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
+ONBUILD RUN cd / \
+ && git clone "$OSQUERY_GIT_URL" \
+ && cd osquery/ \
+ && git checkout "$OSQUERY_SRC_VERSION" \
+ && echo "Fetching osquery from git"
+
+
+#--------------- TEMP CONTAINER FOR OSQUERY ( BASED UPON FLAG)  ----------------
+FROM osquery_"$OSQUERY_BUILD_ENV" as osquery
+
+
+#--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM debian:9
 
 RUN apt-get update     \
@@ -33,20 +59,17 @@ RUN mkdir -p "$PATCHELF_TEMP" \
 #osquery should be built first since requirements for other packages can interfere with osquery dependencies
 #to build, osquery scripts want sudo and a user to sudo with.
 #to pin to a different version change the following envirnment variable
-ENV OSQUERY_SRC_VERSION=3.3.2
 ENV OSQUERY_BUILD_USER=osquerybuilder
-ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
 RUN apt-get -y install git make python ruby sudo curl
 RUN useradd --shell /bin/bash --create-home --user-group --groups sudo "$OSQUERY_BUILD_USER" \
  && sed -i 's/^%sudo.*/%sudo\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
+COPY --from=osquery /osquery /home/"$OSQUERY_BUILD_USER"/osquery
 RUN mkdir -p /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/
+ && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
+ && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
 USER $OSQUERY_BUILD_USER
 ENV SKIP_TESTS=1
-RUN cd /home/"$OSQUERY_BUILD_USER" \
- && git clone "$OSQUERY_GIT_URL" \
- && cd osquery/ \
- && git checkout "$OSQUERY_SRC_VERSION" \
+RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
  && make sysprep \
 #have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
  && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \

--- a/pkg/dev/debian7/Dockerfile
+++ b/pkg/dev/debian7/Dockerfile
@@ -5,7 +5,33 @@
 # The resulting image is ready to run the pyinstaller on container start and drop hubble<version>-coreos.tar.gz
 # in the /data directory. Mount /data volume into a directory on the host to access the package.
 # To run the container:  docker run -it --rm -v `pwd`:/data <image_name>
+# Requires docker 17.05 or higher
 
+ARG OSQUERY_BUILD_ENV=remote
+
+#--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
+FROM alpine as osquery_local
+ONBUILD COPY osquery /osquery
+ONBUILD RUN echo "Copying osquery from local folder"
+
+
+
+#--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
+FROM alpine/git as osquery_remote
+ENV OSQUERY_SRC_VERSION=3.3.2
+ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
+ONBUILD RUN cd / \
+ && git clone "$OSQUERY_GIT_URL" \
+ && cd osquery/ \
+ && git checkout "$OSQUERY_SRC_VERSION" \
+ && echo "Fetching osquery from git"
+
+
+#--------------- TEMP CONTAINER FOR OSQUERY ( BASED UPON FLAG)  ----------------
+FROM osquery_"$OSQUERY_BUILD_ENV" as osquery
+
+
+#--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM debian:7
 
 RUN apt-get update     \
@@ -33,23 +59,20 @@ RUN mkdir -p "$PATCHELF_TEMP" \
 #osquery should be built first since requirements for other packages can interfere with osquery dependencies
 #to build, osquery scripts want sudo and a user to sudo with.
 #to pin to a different version change the following envirnment variable
-ENV OSQUERY_SRC_VERSION=3.3.2
 ENV OSQUERY_BUILD_USER=osquerybuilder
-ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
 RUN apt-get -y install git make python ruby sudo locales curl
 RUN useradd --shell /bin/bash --create-home --user-group --groups sudo "$OSQUERY_BUILD_USER" \
  && sed -i 's/^%sudo.*/%sudo\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
+COPY --from=osquery /osquery /home/"$OSQUERY_BUILD_USER"/osquery
 RUN mkdir -p /usr/local/osquery/ \
  && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
+ && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery \
  && echo "LC_ALL=en_US.UTF-8" >> /etc/default/locale \
  && sed -i '/en_US.UTF-8\ UTF-8/s/^#//' /etc/locale.gen \
  && locale-gen
 USER $OSQUERY_BUILD_USER
 ENV SKIP_TESTS=1
-RUN cd /home/"$OSQUERY_BUILD_USER" \
- && git clone "$OSQUERY_GIT_URL" \
- && cd osquery/ \
- && git checkout "$OSQUERY_SRC_VERSION" \
+RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
  && make sysprep \
 #have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
  && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \

--- a/pkg/dev/debian8/Dockerfile
+++ b/pkg/dev/debian8/Dockerfile
@@ -5,7 +5,33 @@
 # The resulting image is ready to run the pyinstaller on container start and drop hubble<version>-coreos.tar.gz
 # in the /data directory. Mount /data volume into a directory on the host to access the package.
 # To run the container:  docker run -it --rm -v `pwd`:/data <image_name>
+# Requires docker 17.05 or higher
 
+ARG OSQUERY_BUILD_ENV=remote
+
+#--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
+FROM alpine as osquery_local
+ONBUILD COPY osquery /osquery
+ONBUILD RUN echo "Copying osquery from local folder"
+
+
+
+#--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
+FROM alpine/git as osquery_remote
+ENV OSQUERY_SRC_VERSION=3.3.2
+ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
+ONBUILD RUN cd / \
+ && git clone "$OSQUERY_GIT_URL" \
+ && cd osquery/ \
+ && git checkout "$OSQUERY_SRC_VERSION" \
+ && echo "Fetching osquery from git"
+
+
+#--------------- TEMP CONTAINER FOR OSQUERY ( BASED UPON FLAG)  ----------------
+FROM osquery_"$OSQUERY_BUILD_ENV" as osquery
+
+
+#--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM debian:8
 
 RUN apt-get update     \
@@ -33,23 +59,20 @@ RUN mkdir -p "$PATCHELF_TEMP" \
 #osquery should be built first since requirements for other packages can interfere with osquery dependencies
 #to build, osquery scripts want sudo and a user to sudo with.
 #to pin to a different version change the following envirnment variable
-ENV OSQUERY_SRC_VERSION=3.3.2
 ENV OSQUERY_BUILD_USER=osquerybuilder
-ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
 RUN apt-get -y install git make python ruby sudo locales curl xz-utils
 RUN useradd --shell /bin/bash --create-home --user-group --groups sudo "$OSQUERY_BUILD_USER" \
  && sed -i 's/^%sudo.*/%sudo\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
+COPY --from=osquery /osquery /home/"$OSQUERY_BUILD_USER"/osquery
 RUN mkdir -p /usr/local/osquery/ \
  && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
+ && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery \
  && echo "LC_ALL=en_US.UTF-8" >> /etc/default/locale \
  && sed -i '/en_US.UTF-8\ UTF-8/s/^#//' /etc/locale.gen \
  && locale-gen
 USER $OSQUERY_BUILD_USER
 ENV SKIP_TESTS=1
-RUN cd /home/"$OSQUERY_BUILD_USER" \
- && git clone "$OSQUERY_GIT_URL" \
- && cd osquery/ \
- && git checkout "$OSQUERY_SRC_VERSION" \
+RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
  && make sysprep \
 #have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
  && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \

--- a/pkg/dev/debian9/Dockerfile
+++ b/pkg/dev/debian9/Dockerfile
@@ -5,7 +5,33 @@
 # The resulting image is ready to run the pyinstaller on container start and drop hubble<version>-coreos.tar.gz
 # in the /data directory. Mount /data volume into a directory on the host to access the package.
 # To run the container:  docker run -it --rm -v `pwd`:/data <image_name>
+# Requires docker 17.05 or higher
 
+ARG OSQUERY_BUILD_ENV=remote
+
+#--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
+FROM alpine as osquery_local
+ONBUILD COPY osquery /osquery
+ONBUILD RUN echo "Copying osquery from local folder"
+
+
+
+#--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
+FROM alpine/git as osquery_remote
+ENV OSQUERY_SRC_VERSION=3.3.2
+ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
+ONBUILD RUN cd / \
+ && git clone "$OSQUERY_GIT_URL" \
+ && cd osquery/ \
+ && git checkout "$OSQUERY_SRC_VERSION" \
+ && echo "Fetching osquery from git"
+
+
+#--------------- TEMP CONTAINER FOR OSQUERY ( BASED UPON FLAG)  ----------------
+FROM osquery_"$OSQUERY_BUILD_ENV" as osquery
+
+
+#--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM debian:9
 
 RUN apt-get update     \
@@ -33,20 +59,17 @@ RUN mkdir -p "$PATCHELF_TEMP" \
 #osquery should be built first since requirements for other packages can interfere with osquery dependencies
 #to build, osquery scripts want sudo and a user to sudo with.
 #to pin to a different version change the following envirnment variable
-ENV OSQUERY_SRC_VERSION=3.3.2
 ENV OSQUERY_BUILD_USER=osquerybuilder
-ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
 RUN apt-get -y install git make python ruby sudo curl
 RUN useradd --shell /bin/bash --create-home --user-group --groups sudo "$OSQUERY_BUILD_USER" \
  && sed -i 's/^%sudo.*/%sudo\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
+COPY --from=osquery /osquery /home/"$OSQUERY_BUILD_USER"/osquery
 RUN mkdir -p /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/
+ && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
+ && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
 USER $OSQUERY_BUILD_USER
 ENV SKIP_TESTS=1
-RUN cd /home/"$OSQUERY_BUILD_USER" \
- && git clone "$OSQUERY_GIT_URL" \
- && cd osquery/ \
- && git checkout "$OSQUERY_SRC_VERSION" \
+RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
  && make sysprep \
 #have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
  && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \


### PR DESCRIPTION
#CAN BE MERGED
I am changing Dockerfiles so that one can build osquery from custom code as well.
This behavior is governed by the docker build argument "OSQUERY_BUILD_ENV"

By default, its value is "remote". In this case, docker will bring the osquery code from the GIT url specified in the Dockerfile.

If its value is "local", then docker will try to copy "osquery" folder into the image. So you should place your osquery code in a folder name "osquery" and this folder should be located in the same directory that contains Dockerfile.
On using "--build-arg=OSQUERY_BUILD_ENV=local", osquery is built from the custom code and packed into the hubble build.

This change uses "multi-stage" feature of docker, so this dockerfile will run on docker 17.05 or later version.
Refer this :
https://docs.docker.com/develop/develop-images/multistage-build/

I have already tested the dockerfiles around my changes.
But still, I want this code to be merged only after I have created a successful build from all these Dockerfiles.
Will let you know after I complete my testing ( perhaps by tomorrow).

@basepi @fossam 
