### PR TITLE
Using ltsc2016 tag in win dockerfile

### DIFF
--- a/pkg/windows/dockerfile
+++ b/pkg/windows/dockerfile
@@ -8,7 +8,7 @@
 #                    3. Copy over any other items you want to include with hubble and place them in <host folder>/opt
 #                    4. docker run -it --rm -v <host folder>:c:\data <image_name>
 #build docker image from windowscore
-FROM microsoft/windowsservercore
+FROM microsoft/windowsservercore:ltsc2016
 #Needed to just work
 ENV PYTHONIOENCODING='UTF-8'
 ENV CHOCO_URL=https://chocolatey.org/install.ps1


### PR DESCRIPTION
This dockerfile does not work any more  because mircosoft has depercated the "latest" tag which we were using to pull windowservercore.

See the bottom part:
https://techcommunity.microsoft.com/t5/Containers/Windows-Server-2019-Now-Available/ba-p/382430

In other words, you can't make any new windows build using current Dockerfile ( unless you have already cached windowsserver in the past ).

@basepi 
Let me know if I am supposed to raise PR for develop branch also.