### PR TITLE
add default_index to hec.obj

### DIFF
--- a/hubblestack/extmods/returners/splunk_fdg_return.py
+++ b/hubblestack/extmods/returners/splunk_fdg_return.py
@@ -75,6 +75,7 @@ def returner(ret):
             timeout = opts['timeout']
             custom_fields = opts['custom_fields']
             http_event_collector_ssl_verify = opts['http_event_collector_ssl_verify']
+            http_event_index = opts['http_event_index']
 
             # Set up the fields to be extracted at index time. The field values must be strings.
             # Note that these fields will also still be available in the event data
@@ -88,6 +89,7 @@ def returner(ret):
             hec = http_event_collector(http_event_collector_key, http_event_collector_host,
                                        http_event_port=http_event_collector_port, http_event_server_ssl=hec_ssl,
                                        http_event_collector_ssl_verify=http_event_collector_ssl_verify,
+                                       http_event_index=http_event_index,
                                        proxy=proxy, timeout=timeout)
 
             data = ret['return']

--- a/hubblestack/extmods/returners/splunk_fdg_return.py
+++ b/hubblestack/extmods/returners/splunk_fdg_return.py
@@ -75,7 +75,7 @@ def returner(ret):
             timeout = opts['timeout']
             custom_fields = opts['custom_fields']
             http_event_collector_ssl_verify = opts['http_event_collector_ssl_verify']
-            http_event_index = opts['http_event_index']
+            index = opts['index']
 
             # Set up the fields to be extracted at index time. The field values must be strings.
             # Note that these fields will also still be available in the event data
@@ -86,7 +86,7 @@ def returner(ret):
                 pass
 
             # Set up the collector
-            hec = http_event_collector(http_event_collector_key, http_event_collector_host,
+            hec = http_event_collector(http_event_collector_key, index, http_event_collector_host,
                                        http_event_port=http_event_collector_port, http_event_server_ssl=hec_ssl,
                                        http_event_collector_ssl_verify=http_event_collector_ssl_verify,
                                        http_event_index=http_event_index,

--- a/hubblestack/extmods/returners/splunk_generic_return.py
+++ b/hubblestack/extmods/returners/splunk_generic_return.py
@@ -53,6 +53,7 @@ def _build_hec(opts):
     http_event_collector_host = opts['indexer']
     http_event_collector_port = opts['port']
     hec_ssl = opts['http_event_server_ssl']
+    http_event_index = opts['http_event_index']
     proxy = opts['proxy']
     timeout = opts['timeout']
     http_event_collector_ssl_verify = opts['http_event_collector_ssl_verify']
@@ -61,6 +62,7 @@ def _build_hec(opts):
                                http_event_port=http_event_collector_port,
                                http_event_server_ssl=hec_ssl,
                                http_event_collector_ssl_verify=http_event_collector_ssl_verify,
+                               http_event_index=http_event_index,
                                proxy=proxy, timeout=timeout)
 
     return hec

--- a/hubblestack/extmods/returners/splunk_generic_return.py
+++ b/hubblestack/extmods/returners/splunk_generic_return.py
@@ -18,7 +18,7 @@ event collector. Required config/pillar settings:
 
 import time
 import hubblestack.utils.stdrec as stdrec
-from hubblestack.hec import http_event_collector, get_splunk_options
+from hubblestack.hec import http_event_collector, get_splunk_options, make_hec_args
 
 def _get_key(dat, key, default_value=None):
     '''
@@ -49,22 +49,8 @@ def _build_hec(opts):
     opts
         dict containing Splunk options to be passed to the `http_event_collector`
     '''
-    http_event_collector_key = opts['token']
-    http_event_collector_host = opts['indexer']
-    http_event_collector_port = opts['port']
-    hec_ssl = opts['http_event_server_ssl']
-    http_event_index = opts['http_event_index']
-    proxy = opts['proxy']
-    timeout = opts['timeout']
-    http_event_collector_ssl_verify = opts['http_event_collector_ssl_verify']
-
-    hec = http_event_collector(http_event_collector_key, http_event_collector_host,
-                               http_event_port=http_event_collector_port,
-                               http_event_server_ssl=hec_ssl,
-                               http_event_collector_ssl_verify=http_event_collector_ssl_verify,
-                               http_event_index=http_event_index,
-                               proxy=proxy, timeout=timeout)
-
+    args, kwargs = make_hec_args(opts)
+    hec = http_event_collector(*args, **kwargs)
     return hec
 
 

--- a/hubblestack/hec/obj.py
+++ b/hubblestack/hec/obj.py
@@ -131,6 +131,7 @@ class HEC(object):
 
 
     def __init__(self, token, http_event_server, host='', http_event_port='8088',
+                 http_event_index='default',
                  http_event_server_ssl=True, http_event_collector_ssl_verify=True,
                  max_bytes=_max_content_bytes, proxy=None, timeout=9.05,
                  disk_queue=False,
@@ -141,6 +142,7 @@ class HEC(object):
 
         self.timeout = timeout
         self.token = token
+        self.default_index = http_event_index
         self.batchEvents = []
         self.maxByteLength = max_bytes
         self.currentByteLength = 0
@@ -217,7 +219,8 @@ class HEC(object):
 
     def _payload_msg(self, message, *a):
         event = dict(loggername='hubblestack.hec.obj', message=message % a)
-        payload = dict(time=int(time.time()), sourcetype='hubble_log', event=event)
+        payload = dict(index=self.default_index,
+            time=int(time.time()), sourcetype='hubble_log', event=event)
         update_payload(payload)
         return str(Payload(payload))
 

--- a/hubblestack/hec/obj.py
+++ b/hubblestack/hec/obj.py
@@ -130,8 +130,7 @@ class HEC(object):
             return r
 
 
-    def __init__(self, token, http_event_server, host='', http_event_port='8088',
-                 http_event_index='default',
+    def __init__(self, token, index, http_event_server, host='', http_event_port='8088',
                  http_event_server_ssl=True, http_event_collector_ssl_verify=True,
                  max_bytes=_max_content_bytes, proxy=None, timeout=9.05,
                  disk_queue=False,
@@ -142,7 +141,7 @@ class HEC(object):
 
         self.timeout = timeout
         self.token = token
-        self.default_index = http_event_index
+        self.default_index = index
         self.batchEvents = []
         self.maxByteLength = max_bytes
         self.currentByteLength = 0

--- a/hubblestack/hec/opt.py
+++ b/hubblestack/hec/opt.py
@@ -137,6 +137,7 @@ def make_hec_args(opts):
     a  = (opts['token'], opts['indexer'])
     kw = {
         'http_event_port': opts['port'],
+        'http_event_index': opts['index'],
         'http_event_server_ssl': opts['http_event_server_ssl'],
         'http_event_collector_ssl_verify': opts['http_event_collector_ssl_verify'],
         'proxy': opts['proxy'],

--- a/hubblestack/hec/opt.py
+++ b/hubblestack/hec/opt.py
@@ -134,10 +134,9 @@ def get_splunk_options(*spaces, **kw):
 def make_hec_args(opts):
     if isinstance(opts, (tuple,list)):
         return [ make_hec_args(i) for i in opts ]
-    a  = (opts['token'], opts['indexer'])
+    a  = (opts['token'], opts['index'], opts['indexer'])
     kw = {
         'http_event_port': opts['port'],
-        'http_event_index': opts['index'],
         'http_event_server_ssl': opts['http_event_server_ssl'],
         'http_event_collector_ssl_verify': opts['http_event_collector_ssl_verify'],
         'proxy': opts['proxy'],


### PR DESCRIPTION
the mysterious default indexing ... is a null index field.

I think there's still a couple returners (including my own generic return) that don't use `make_hec_args()`; the other is fdg.

Arguably the hec.obj should check for missing index and set it to the new `self.default_index` when missing.
