### PR TITLE
Match the cruft between returners

### DIFF
--- a/hubblestack/extmods/returners/splunk_fdg_return.py
+++ b/hubblestack/extmods/returners/splunk_fdg_return.py
@@ -67,6 +67,16 @@ def returner(ret):
 
         for opts in opts_list:
             logging.debug('Options: %s' % json.dumps(opts))
+            custom_fields = opts['custom_fields']
+
+            # Set up the fields to be extracted at index time. The field values must be strings.
+            # Note that these fields will also still be available in the event data
+            index_extracted_fields = []
+            try:
+                index_extracted_fields.extend(__opts__.get('splunk_index_extracted_fields', []))
+            except TypeError:
+                pass
+
             args, kwargs = make_hec_args(opts)
             hec = http_event_collector(*args, **kwargs)
 


### PR DESCRIPTION
Since index-extracted fields are handled in stdrec.py, we can
probably remove these references everywhere. But as of now, all the
other returners still have this cruft, so I'm adding it back here. `cloud_details` can also probably be removed everywhere as well.

@jettero I'll probably have you clean all of these up for our next release.