### PR TITLE
Fixing osquery permissions for Windows server 2019

### DIFF
--- a/pkg/windows/dockerfile
+++ b/pkg/windows/dockerfile
@@ -32,7 +32,8 @@ COPY pyinstaller-requirements.txt c:/temp/
 COPY hubble.conf C:/temp/
 #install Chocolatey, then git and git.portable, and osquery
 RUN powershell.exe -Command Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString("$env:CHOCO_URL"))
-RUN powershell.exe -Command choco install git osquery nssm -y;
+RUN powershell.exe -Command choco install git nssm -y;
+RUN powershell.exe -Command choco install osquery --version 3.3.2 -y;
 RUN powershell.exe -Command choco install git.portable --version 2.19.0 -y;
 
 #RUN powershell.exe $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")

--- a/pkg/windows/osqueryd_safe_permissions.ps1
+++ b/pkg/windows/osqueryd_safe_permissions.ps1
@@ -27,6 +27,14 @@
     $acl.RemoveAccessRuleAll($accessrule)
     set-acl -aclobject $acl $osqueryd_path
 
+    $group = "ALL APPLICATION PACKAGES"
+    $acl = Get-Acl $osqueryd_path
+    $inherit =[system.security.accesscontrol.InheritanceFlags]"ContainerInherit,ObjectInherit"
+    $propagation =[system.security.accesscontrol.PropagationFlags]"None"
+    $accessrule = New-Object System.Security.AccessControl.FileSystemAccessRule($group,"Write", $inherit, $Propagation ,,,"Deny")
+    $acl.AddAccessRule($accessrule)
+    set-acl -aclobject $acl $osqueryd_path
+
     $group = "ALL RESTRICTED APPLICATION PACKAGES"
     $acl = Get-Acl $osqueryd_path
     $inherit =[system.security.accesscontrol.InheritanceFlags]"ContainerInherit,ObjectInherit"


### PR DESCRIPTION
Following changes:
- Pinned osquery version to v3.3.2. This was required since facebook has released a new 3.4.0 version of osquery specifically for Windows.
- Fixed permissions of osquery for Windows server 2019. New permissions (explicit DENY) apply to all supported Windows platforms.
