### PR TITLE
Provision of custom osquery build in Dockerfiles

### DIFF
--- a/pkg/amazonlinux2016.09/Dockerfile
+++ b/pkg/amazonlinux2016.09/Dockerfile
@@ -4,7 +4,36 @@
 # The resulting image is ready to run the pyinstaller on container start and drop hubble<version>-coreos.tar.gz
 # in the /data directory. Mount /data volume into a directory on the host to access the package.
 # To run the container:  docker run -it --rm -v `pwd`:/data <image_name>
+# Requires docker 17.05 or higher
 
+# Set this arguement to "local" if you want to build osquery for local code.
+# In that case, osquery folder must exist besides Dockerfile
+ARG OSQUERY_BUILD_ENV=remote
+
+#--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
+FROM alpine as osquery_local
+ONBUILD COPY osquery /osquery
+ONBUILD RUN echo "Copying osquery from local folder"
+
+
+
+#--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
+FROM alpine/git as osquery_remote
+#to pin osquery to a different version change the following envirnment variable
+ENV OSQUERY_SRC_VERSION=3.3.2
+ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
+ONBUILD RUN cd / \
+ && git clone "$OSQUERY_GIT_URL" \
+ && cd osquery/ \
+ && git checkout "$OSQUERY_SRC_VERSION" \
+ && echo "Fetching osquery from git"
+
+
+#--------------- TEMP CONTAINER FOR OSQUERY ( BASED ON ARGUMENT ) --------------
+FROM osquery_"$OSQUERY_BUILD_ENV" as osquery_image
+
+
+#--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM amazonlinux:2016.09
 
 RUN yum makecache fast && yum -y update
@@ -15,21 +44,17 @@ RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osque
 #osquery build start
 #osquery should be built first since requirements for other packages can interfere with osquery dependencies
 #to build, osquery scripts want sudo and a user to sudo with.
-#to pin to a different version change the following envirnment variable
-ENV OSQUERY_SRC_VERSION=0314871908273b2770129da9f5a7c3206f224f68
 ENV OSQUERY_BUILD_USER=osquerybuilder
-ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
 RUN yum -y install git make python ruby sudo which
 RUN useradd --shell /bin/bash --create-home --user-group --groups wheel "$OSQUERY_BUILD_USER" \
  && sed -i '0,/^#\ %wheel/s/^#\ %wheel.*/%wheel\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
+COPY --from=osquery_image /osquery /home/"$OSQUERY_BUILD_USER"/osquery
 RUN mkdir -p /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/
+ && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
+ && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
 USER $OSQUERY_BUILD_USER
 ENV SKIP_TESTS=1
-RUN cd /home/"$OSQUERY_BUILD_USER" \
- && git clone "$OSQUERY_GIT_URL" \
- && cd osquery/ \
- && git checkout "$OSQUERY_SRC_VERSION" \
+RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
  && make sysprep \
 #have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
  && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \

--- a/pkg/centos6/Dockerfile
+++ b/pkg/centos6/Dockerfile
@@ -4,7 +4,36 @@
 # The resulting image is ready to run the pyinstaller on container start and drop hubble<version>-coreos.tar.gz
 # in the /data directory. Mount /data volume into a directory on the host to access the package.
 # To run the container:  docker run -it --rm -v `pwd`:/data <image_name>
+# Requires docker 17.05 or higher
 
+# Set this arguement to "local" if you want to build osquery for local code.
+# In that case, osquery folder must exist besides Dockerfile
+ARG OSQUERY_BUILD_ENV=remote
+
+#--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
+FROM alpine as osquery_local
+ONBUILD COPY osquery /osquery
+ONBUILD RUN echo "Copying osquery from local folder"
+
+
+
+#--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
+FROM alpine/git as osquery_remote
+#to pin osquery to a different version change the following envirnment variable
+ENV OSQUERY_SRC_VERSION=3.3.2
+ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
+ONBUILD RUN cd / \
+ && git clone "$OSQUERY_GIT_URL" \
+ && cd osquery/ \
+ && git checkout "$OSQUERY_SRC_VERSION" \
+ && echo "Fetching osquery from git"
+
+
+#--------------- TEMP CONTAINER FOR OSQUERY ( BASED ON ARGUMENT ) ---------------
+FROM osquery_"$OSQUERY_BUILD_ENV" as osquery_image
+
+
+#--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM centos:6
 
 RUN yum makecache fast && yum -y update
@@ -15,21 +44,17 @@ RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osque
 #osquery build start
 #osquery should be built first since requirements for other packages can interfere with osquery dependencies
 #to build, osquery scripts want sudo and a user to sudo with.
-#to pin to a different version change the following envirnment variable
-ENV OSQUERY_SRC_VERSION=0314871908273b2770129da9f5a7c3206f224f68
 ENV OSQUERY_BUILD_USER=osquerybuilder
-ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
 RUN yum -y install xz git make python ruby sudo which python-argparse
 RUN useradd --shell /bin/bash --create-home --user-group --groups wheel "$OSQUERY_BUILD_USER" \
  && sed -i '0,/^#\ %wheel/s/^#\ %wheel.*/%wheel\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
+COPY --from=osquery_image /osquery /home/"$OSQUERY_BUILD_USER"/osquery
 RUN mkdir -p /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/
+ && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
+ && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
 USER $OSQUERY_BUILD_USER
 ENV SKIP_TESTS=1
-RUN cd /home/"$OSQUERY_BUILD_USER" \
- && git clone "$OSQUERY_GIT_URL" \
- && cd osquery/ \
- && git checkout "$OSQUERY_SRC_VERSION" \
+RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
  && make sysprep \
 #have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
  && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \

--- a/pkg/centos7/Dockerfile
+++ b/pkg/centos7/Dockerfile
@@ -19,7 +19,8 @@ ONBUILD RUN echo "Copying osquery from local folder"
 
 #--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
 FROM alpine/git as osquery_remote
-ENV OSQUERY_SRC_VERSION=0314871908273b2770129da9f5a7c3206f224f68
+#to pin osquery to a different version change the following envirnment variable
+ENV OSQUERY_SRC_VERSION=3.3.2
 ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
 ONBUILD RUN cd / \
  && git clone "$OSQUERY_GIT_URL" \
@@ -28,7 +29,7 @@ ONBUILD RUN cd / \
  && echo "Fetching osquery from git"
 
 
-#--------------- TEMP CONTAINER FOR OSQUERY ( BASED ON ARG )  ----------------
+#--------------- TEMP CONTAINER FOR OSQUERY ( BASED ON ARGUMENT ) ---------------
 FROM osquery_"$OSQUERY_BUILD_ENV" as osquery_image
 
 
@@ -42,8 +43,6 @@ RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osque
 #osquery build start
 #osquery should be built first since requirements for other packages can interfere with osquery dependencies
 #to build, osquery scripts want sudo and a user to sudo with.
-#to pin to a different version change the following envirnment variable
-
 ENV OSQUERY_BUILD_USER=osquerybuilder
 RUN yum -y install git make python ruby sudo which
 RUN useradd --shell /bin/bash --create-home --user-group --groups wheel "$OSQUERY_BUILD_USER" \

--- a/pkg/centos7/Dockerfile
+++ b/pkg/centos7/Dockerfile
@@ -4,32 +4,57 @@
 # The resulting image is ready to run the pyinstaller on container start and drop hubble<version>-coreos.tar.gz
 # in the /data directory. Mount /data volume into a directory on the host to access the package.
 # To run the container:  docker run -it --rm -v `pwd`:/data <image_name>
+# Requires docker 17.05 or higher
 
+# Set this argument to "local" if you want to build osquery for local code.
+# In that case, osquery folder must exist besides Dockerfile
+ARG OSQUERY_BUILD_ENV=remote
+
+#--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
+FROM alpine as osquery_local
+ONBUILD COPY osquery /osquery
+ONBUILD RUN echo "Copying osquery from local folder"
+
+
+
+#--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
+FROM alpine/git as osquery_remote
+ENV OSQUERY_SRC_VERSION=0314871908273b2770129da9f5a7c3206f224f68
+ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
+ONBUILD RUN cd / \
+ && git clone "$OSQUERY_GIT_URL" \
+ && cd osquery/ \
+ && git checkout "$OSQUERY_SRC_VERSION" \
+ && echo "Fetching osquery from git"
+
+
+#--------------- TEMP CONTAINER FOR OSQUERY ( BASED ON ARG )  ----------------
+FROM osquery_"$OSQUERY_BUILD_ENV" as osquery_image
+
+
+#--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM centos:7
 
 RUN yum makecache fast && yum -y update
 
 #paths that hubble or hubble parts need in the package
 RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osquery/backuplogs
-
 #osquery build start
 #osquery should be built first since requirements for other packages can interfere with osquery dependencies
 #to build, osquery scripts want sudo and a user to sudo with.
 #to pin to a different version change the following envirnment variable
-ENV OSQUERY_SRC_VERSION=0314871908273b2770129da9f5a7c3206f224f68
+
 ENV OSQUERY_BUILD_USER=osquerybuilder
-ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
 RUN yum -y install git make python ruby sudo which
 RUN useradd --shell /bin/bash --create-home --user-group --groups wheel "$OSQUERY_BUILD_USER" \
  && sed -i '0,/^#\ %wheel/s/^#\ %wheel.*/%wheel\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
+COPY --from=osquery_image /osquery /home/"$OSQUERY_BUILD_USER"/osquery
 RUN mkdir -p /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/
+ && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
+ && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
 USER $OSQUERY_BUILD_USER
 ENV SKIP_TESTS=1
-RUN cd /home/"$OSQUERY_BUILD_USER" \
- && git clone "$OSQUERY_GIT_URL" \
- && cd osquery/ \
- && git checkout "$OSQUERY_SRC_VERSION" \
+RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
  && make sysprep \
 #have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
  && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \

--- a/pkg/coreos/Dockerfile
+++ b/pkg/coreos/Dockerfile
@@ -197,5 +197,5 @@ CMD [ "if [ -f /data/hubble_buildinfo ] ; then echo \"\" >> /hubble_build/hubble
     && cp /usr/lib/x86_64-linux-gnu/libssh2.so.1 /opt/hubble/hubble-libs \
     && mkdir -p /etc/systemd/system \
     && cp -f /hubble_build/pkg/hubble.service /etc/systemd/system \
-    && tar -cPvzf /data/hubblestack-${HUBBLE_VERSION}-${HUBBLE_ITERATION}-coreos.tar.gz /etc/hubble /opt/hubble /opt/osquery /etc/profile.d/hubble-profile.sh /etc/systemd/system /var/log/hubble_osquery/backuplogs \
-    && openssl dgst -sha256 /data/hubblestack-${HUBBLE_VERSION}-${HUBBLE_ITERATION}-coreos.tar.gz > /data/hubblestack-${HUBBLE_VERSION}-${HUBBLE_ITERATION}-coreos.tar.gz.sha256" ]
+    && tar -cPvzf /data/hubblestack-${HUBBLE_VERSION}-${HUBBLE_ITERATION}.coreos.tar.gz /etc/hubble /opt/hubble /opt/osquery /etc/profile.d/hubble-profile.sh /etc/systemd/system /var/log/hubble_osquery/backuplogs \
+    && openssl dgst -sha256 /data/hubblestack-${HUBBLE_VERSION}-${HUBBLE_ITERATION}.coreos.tar.gz > /data/hubblestack-${HUBBLE_VERSION}-${HUBBLE_ITERATION}.coreos.tar.gz.sha256" ]

--- a/pkg/coreos/Dockerfile
+++ b/pkg/coreos/Dockerfile
@@ -4,7 +4,34 @@
 # The resulting image is ready to run the pyinstaller on container start and drop hubble<version>-coreos.tar.gz
 # in the /data directory. Mount /data volume into a directory on the host to access the package.
 # To run the container:  docker run -it --rm -v `pwd`:/data <image_name>
+# Requires docker 17.05 or higher
 
+ARG OSQUERY_BUILD_ENV=remote
+
+#--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
+FROM alpine as osquery_local
+ONBUILD COPY osquery /osquery
+ONBUILD RUN echo "Copying osquery from local folder"
+
+
+
+#--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
+FROM alpine/git as osquery_remote
+#to osquery pin to a different version change the following envirnment variable
+ENV OSQUERY_SRC_VERSION=3.3.2
+ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
+ONBUILD RUN cd / \
+ && git clone "$OSQUERY_GIT_URL" \
+ && cd osquery/ \
+ && git checkout "$OSQUERY_SRC_VERSION" \
+ && echo "Fetching osquery from git"
+
+
+#--------------- TEMP CONTAINER FOR OSQUERY ( BASED UPON ARGUMENT ) -------------
+FROM osquery_"$OSQUERY_BUILD_ENV" as osquery
+
+
+#--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM debian:9
 
 RUN apt-get update     \
@@ -31,21 +58,17 @@ RUN mkdir -p "$PATCHELF_TEMP" \
 #osquery build start
 #osquery should be built first since requirements for other packages can interfere with osquery dependencies
 #to build, osquery scripts want sudo and a user to sudo with.
-#to pin to a different version change the following envirnment variable
-ENV OSQUERY_SRC_VERSION=0314871908273b2770129da9f5a7c3206f224f68
 ENV OSQUERY_BUILD_USER=osquerybuilder
-ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
 RUN apt-get -y install git make python ruby sudo curl
 RUN useradd --shell /bin/bash --create-home --user-group --groups sudo "$OSQUERY_BUILD_USER" \
  && sed -i 's/^%sudo.*/%sudo\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
+COPY --from=osquery /osquery /home/"$OSQUERY_BUILD_USER"/osquery
 RUN mkdir -p /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/
+ && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
+ && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
 USER $OSQUERY_BUILD_USER
 ENV SKIP_TESTS=1
-RUN cd /home/"$OSQUERY_BUILD_USER" \
- && git clone "$OSQUERY_GIT_URL" \
- && cd osquery/ \
- && git checkout "$OSQUERY_SRC_VERSION" \
+RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
  && make sysprep \
 #have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
  && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \

--- a/pkg/debian7/Dockerfile
+++ b/pkg/debian7/Dockerfile
@@ -4,7 +4,34 @@
 # The resulting image is ready to run the pyinstaller on container start and drop hubble<version>-coreos.tar.gz
 # in the /data directory. Mount /data volume into a directory on the host to access the package.
 # To run the container:  docker run -it --rm -v `pwd`:/data <image_name>
+# Requires docker 17.05 or higher
 
+ARG OSQUERY_BUILD_ENV=remote
+
+#--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
+FROM alpine as osquery_local
+ONBUILD COPY osquery /osquery
+ONBUILD RUN echo "Copying osquery from local folder"
+
+
+
+#--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
+FROM alpine/git as osquery_remote
+#to pin osquery to a different version change the following envirnment variable
+ENV OSQUERY_SRC_VERSION=3.3.2
+ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
+ONBUILD RUN cd / \
+ && git clone "$OSQUERY_GIT_URL" \
+ && cd osquery/ \
+ && git checkout "$OSQUERY_SRC_VERSION" \
+ && echo "Fetching osquery from git"
+
+
+#--------------- TEMP CONTAINER FOR OSQUERY ( BASED UPON ARGUMENT )  ----------------
+FROM osquery_"$OSQUERY_BUILD_ENV" as osquery
+
+
+#--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM debian:7
 
 RUN apt-get update     \
@@ -31,24 +58,20 @@ RUN mkdir -p "$PATCHELF_TEMP" \
 #osquery build start
 #osquery should be built first since requirements for other packages can interfere with osquery dependencies
 #to build, osquery scripts want sudo and a user to sudo with.
-#to pin to a different version change the following envirnment variable
-ENV OSQUERY_SRC_VERSION=0314871908273b2770129da9f5a7c3206f224f68
 ENV OSQUERY_BUILD_USER=osquerybuilder
-ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
 RUN apt-get -y install git make python ruby sudo locales curl
 RUN useradd --shell /bin/bash --create-home --user-group --groups sudo "$OSQUERY_BUILD_USER" \
  && sed -i 's/^%sudo.*/%sudo\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
+COPY --from=osquery /osquery /home/"$OSQUERY_BUILD_USER"/osquery
 RUN mkdir -p /usr/local/osquery/ \
  && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
+ && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery \
  && echo "LC_ALL=en_US.UTF-8" >> /etc/default/locale \
  && sed -i '/en_US.UTF-8\ UTF-8/s/^#//' /etc/locale.gen \
  && locale-gen
 USER $OSQUERY_BUILD_USER
 ENV SKIP_TESTS=1
-RUN cd /home/"$OSQUERY_BUILD_USER" \
- && git clone "$OSQUERY_GIT_URL" \
- && cd osquery/ \
- && git checkout "$OSQUERY_SRC_VERSION" \
+RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
  && make sysprep \
 #have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
  && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \

--- a/pkg/debian7/Dockerfile
+++ b/pkg/debian7/Dockerfile
@@ -248,6 +248,6 @@ CMD [ "if [ -f /data/hubble_buildinfo ] ; then echo \"\" >> /hubble_build/hubble
        --after-upgrade /hubble_build/conf/afterupgrade.sh \
        --before-remove /hubble_build/conf/beforeremove.sh \
        etc opt usr /var/log/hubble_osquery/backuplogs \
-    && cp hubblestack_${HUBBLE_VERSION}-${HUBBLE_ITERATION}_amd64.deb /data/hubblestack_${HUBBLE_VERSION}-${HUBBLE_ITERATION}deb7_amd64.deb \
-    && openssl dgst -sha256 /data/hubblestack_${HUBBLE_VERSION}-${HUBBLE_ITERATION}deb7_amd64.deb \
-                          > /data/hubblestack_${HUBBLE_VERSION}-${HUBBLE_ITERATION}deb7_amd64.deb.sha256" ]
+    && cp hubblestack_${HUBBLE_VERSION}-${HUBBLE_ITERATION}_amd64.deb /data/hubblestack_${HUBBLE_VERSION}-${HUBBLE_ITERATION}.deb7.amd64.deb \
+    && openssl dgst -sha256 /data/hubblestack_${HUBBLE_VERSION}-${HUBBLE_ITERATION}.deb7.amd64.deb \
+                          > /data/hubblestack_${HUBBLE_VERSION}-${HUBBLE_ITERATION}.deb7.amd64.deb.sha256" ]

--- a/pkg/debian8/Dockerfile
+++ b/pkg/debian8/Dockerfile
@@ -229,6 +229,6 @@ CMD [ "if [ -f /data/hubble_buildinfo ] ; then echo \"\" >> /hubble_build/hubble
        --after-upgrade /hubble_build/conf/afterupgrade.sh \
        --before-remove /hubble_build/conf/beforeremove.sh \
        etc/hubble etc/init.d opt usr /var/log/hubble_osquery/backuplogs \
-    && cp hubblestack_${HUBBLE_VERSION}-${HUBBLE_ITERATION}_amd64.deb /data/hubblestack_${HUBBLE_VERSION}-${HUBBLE_ITERATION}deb8_amd64.deb \
-    && openssl dgst -sha256 /data/hubblestack_${HUBBLE_VERSION}-${HUBBLE_ITERATION}deb8_amd64.deb \
-                          > /data/hubblestack_${HUBBLE_VERSION}-${HUBBLE_ITERATION}deb8_amd64.deb.sha256" ]
+    && cp hubblestack_${HUBBLE_VERSION}-${HUBBLE_ITERATION}_amd64.deb /data/hubblestack_${HUBBLE_VERSION}-${HUBBLE_ITERATION}.deb8.amd64.deb \
+    && openssl dgst -sha256 /data/hubblestack_${HUBBLE_VERSION}-${HUBBLE_ITERATION}.deb8.amd64.deb \
+                          > /data/hubblestack_${HUBBLE_VERSION}-${HUBBLE_ITERATION}.deb8.amd64.deb.sha256" ]

--- a/pkg/debian8/Dockerfile
+++ b/pkg/debian8/Dockerfile
@@ -4,7 +4,34 @@
 # The resulting image is ready to run the pyinstaller on container start and drop hubble<version>-coreos.tar.gz
 # in the /data directory. Mount /data volume into a directory on the host to access the package.
 # To run the container:  docker run -it --rm -v `pwd`:/data <image_name>
+# Requires docker 17.05 or higher
 
+ARG OSQUERY_BUILD_ENV=remote
+
+#--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
+FROM alpine as osquery_local
+ONBUILD COPY osquery /osquery
+ONBUILD RUN echo "Copying osquery from local folder"
+
+
+
+#--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
+FROM alpine/git as osquery_remote
+#to osquery pin to a different version change the following envirnment variable
+ENV OSQUERY_SRC_VERSION=3.3.2
+ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
+ONBUILD RUN cd / \
+ && git clone "$OSQUERY_GIT_URL" \
+ && cd osquery/ \
+ && git checkout "$OSQUERY_SRC_VERSION" \
+ && echo "Fetching osquery from git"
+
+
+#--------------- TEMP CONTAINER FOR OSQUERY ( BASED UPON ARGUMENT )  ----------------
+FROM osquery_"$OSQUERY_BUILD_ENV" as osquery
+
+
+#--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM debian:8
 
 RUN apt-get update     \
@@ -31,24 +58,20 @@ RUN mkdir -p "$PATCHELF_TEMP" \
 #osquery build start
 #osquery should be built first since requirements for other packages can interfere with osquery dependencies
 #to build, osquery scripts want sudo and a user to sudo with.
-#to pin to a different version change the following envirnment variable
-ENV OSQUERY_SRC_VERSION=0314871908273b2770129da9f5a7c3206f224f68
 ENV OSQUERY_BUILD_USER=osquerybuilder
-ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
 RUN apt-get -y install git make python ruby sudo locales curl xz-utils
 RUN useradd --shell /bin/bash --create-home --user-group --groups sudo "$OSQUERY_BUILD_USER" \
  && sed -i 's/^%sudo.*/%sudo\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
+COPY --from=osquery /osquery /home/"$OSQUERY_BUILD_USER"/osquery
 RUN mkdir -p /usr/local/osquery/ \
  && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
+ && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery \
  && echo "LC_ALL=en_US.UTF-8" >> /etc/default/locale \
  && sed -i '/en_US.UTF-8\ UTF-8/s/^#//' /etc/locale.gen \
  && locale-gen
 USER $OSQUERY_BUILD_USER
 ENV SKIP_TESTS=1
-RUN cd /home/"$OSQUERY_BUILD_USER" \
- && git clone "$OSQUERY_GIT_URL" \
- && cd osquery/ \
- && git checkout "$OSQUERY_SRC_VERSION" \
+RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
  && make sysprep \
 #have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
  && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \

--- a/pkg/debian9/Dockerfile
+++ b/pkg/debian9/Dockerfile
@@ -225,6 +225,6 @@ CMD [ "if [ -f /data/hubble_buildinfo ] ; then echo \"\" >> /hubble_build/hubble
        --after-upgrade /hubble_build/conf/afterupgrade.sh \
        --before-remove /hubble_build/conf/beforeremove.sh \
        etc/hubble etc/init.d opt usr /var/log/hubble_osquery/backuplogs \
-    && cp hubblestack_${HUBBLE_VERSION}-${HUBBLE_ITERATION}_amd64.deb /data/hubblestack_${HUBBLE_VERSION}-${HUBBLE_ITERATION}deb9_amd64.deb \
-    && openssl dgst -sha256 /data/hubblestack_${HUBBLE_VERSION}-${HUBBLE_ITERATION}deb9_amd64.deb \
-                          > /data/hubblestack_${HUBBLE_VERSION}-${HUBBLE_ITERATION}deb9_amd64.deb.sha256" ]
+    && cp hubblestack_${HUBBLE_VERSION}-${HUBBLE_ITERATION}_amd64.deb /data/hubblestack_${HUBBLE_VERSION}-${HUBBLE_ITERATION}.deb9.amd64.deb \
+    && openssl dgst -sha256 /data/hubblestack_${HUBBLE_VERSION}-${HUBBLE_ITERATION}.deb9.amd64.deb \
+                          > /data/hubblestack_${HUBBLE_VERSION}-${HUBBLE_ITERATION}.deb9.amd64.deb.sha256" ]

--- a/pkg/debian9/Dockerfile
+++ b/pkg/debian9/Dockerfile
@@ -4,7 +4,34 @@
 # The resulting image is ready to run the pyinstaller on container start and drop hubble<version>-coreos.tar.gz
 # in the /data directory. Mount /data volume into a directory on the host to access the package.
 # To run the container:  docker run -it --rm -v `pwd`:/data <image_name>
+# Requires docker 17.05 or higher
 
+ARG OSQUERY_BUILD_ENV=remote
+
+#--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
+FROM alpine as osquery_local
+ONBUILD COPY osquery /osquery
+ONBUILD RUN echo "Copying osquery from local folder"
+
+
+
+#--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
+FROM alpine/git as osquery_remote
+#to osquery pin to a different version change the following envirnment variable
+ENV OSQUERY_SRC_VERSION=3.3.2
+ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
+ONBUILD RUN cd / \
+ && git clone "$OSQUERY_GIT_URL" \
+ && cd osquery/ \
+ && git checkout "$OSQUERY_SRC_VERSION" \
+ && echo "Fetching osquery from git"
+
+
+#--------------- TEMP CONTAINER FOR OSQUERY ( BASED UPON ARGUMENT )  ------------
+FROM osquery_"$OSQUERY_BUILD_ENV" as osquery
+
+
+#--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM debian:9
 
 RUN apt-get update     \
@@ -31,21 +58,17 @@ RUN mkdir -p "$PATCHELF_TEMP" \
 #osquery build start
 #osquery should be built first since requirements for other packages can interfere with osquery dependencies
 #to build, osquery scripts want sudo and a user to sudo with.
-#to pin to a different version change the following envirnment variable
-ENV OSQUERY_SRC_VERSION=0314871908273b2770129da9f5a7c3206f224f68
 ENV OSQUERY_BUILD_USER=osquerybuilder
-ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
 RUN apt-get -y install git make python ruby sudo curl
 RUN useradd --shell /bin/bash --create-home --user-group --groups sudo "$OSQUERY_BUILD_USER" \
  && sed -i 's/^%sudo.*/%sudo\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
+COPY --from=osquery /osquery /home/"$OSQUERY_BUILD_USER"/osquery
 RUN mkdir -p /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/
+ && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
+ && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
 USER $OSQUERY_BUILD_USER
 ENV SKIP_TESTS=1
-RUN cd /home/"$OSQUERY_BUILD_USER" \
- && git clone "$OSQUERY_GIT_URL" \
- && cd osquery/ \
- && git checkout "$OSQUERY_SRC_VERSION" \
+RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
  && make sysprep \
 #have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
  && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \

--- a/pkg/dev/coreos/Dockerfile
+++ b/pkg/dev/coreos/Dockerfile
@@ -188,7 +188,7 @@ CMD [ "if [ -f /data/hubble_buildinfo ] ; then echo \"\" >> /hubble_build/hubble
 #possile to optionally include a custom one with the package
     && if [ -f /data/hubble ] ; then cp /data/hubble /etc/hubble/ ; fi \
 #also bring in anything from a /data/opt/ directory so we can bundle other executables if needed
-    && if [ -d /data/opt ] ; then cp -r /data/opt/* /hubble_build/debbuild/hubblestack-${HUBBLE_VERSION}/opt/ ; fi \
+    && if [ -d /data/opt ] ; then cp -r /data/opt/* /opt/ ; fi \
     && cp -rf /hubble_build/conf/hubble-profile.sh /etc/profile.d/ \
     && cp -pr /hubble_build/dist/hubble /opt/hubble/hubble-libs \
     && ln -s /opt/hubble/hubble-libs/hubble /opt/hubble/hubble \


### PR DESCRIPTION
Making changes in Dockerfiles similar to https://github.com/hubblestack/hubble/commit/890463de97766349977466e0e6b13109a9f3d5a1

After this change, one can build hubble with custom osquery code.

@basepi I have made these changes in just centos7 for now. Please answer these questions so that I can proceed to make these changes for all OS:

1. Is '3.0' the correct branch to make these changes ? I am assuming that the changes made here will propagate to 'master' branch Dockerfiles so that we can build hubble 3.0 using master Dockerfiles.

2. What should be the value of OSQUERY_SRC_VERSION ? ( see the comment in code for more details )

3. I have just focused on bringing the changes from 'dev' to 'pkg' dockerfiles related to the aforementioned commit for now. If there are any more changes which should copy from 'dev' to 'pkg' Dockerfiles in this PR, let me know.

