### PR TITLE
Add missing import

### DIFF
--- a/hubblestack/utils/stdrec.py
+++ b/hubblestack/utils/stdrec.py
@@ -5,6 +5,8 @@ Currently each returner seems to generate these data by hand in their own way.
 This is being tested/used in the generic returner and probably only from
 hstatus exec module (for now).
 '''
+import socket
+
 
 def std_info():
     ''' Generate and return hubble standard host data for use in events:


### PR DESCRIPTION
This would only happen if a host had a `localhost` domain so I didn't
spot it until today