### PR TITLE
Correcting the pyinstaller command in centos6 Dockerfile

### DIFF
--- a/pkg/centos6/Dockerfile
+++ b/pkg/centos6/Dockerfile
@@ -176,7 +176,7 @@ VOLUME /data
 WORKDIR /hubble_build
 ENTRYPOINT [ "/bin/bash", "-o", "xtrace", "-c" ]
 CMD [ "if [ -f /data/hubble_buildinfo ] ; then echo \"\" >> /hubble_build/hubblestack/__init__.py ; cat /data/hubble_buildinfo >> /hubble_build/hubblestack/__init__.py; fi \
-    && pyinstaller --onedir --noconfirm --log-level ${_BINARY_LOG_LEVEL} --additional-hooks-dir=${_HOOK_DIR} --runtime-hook=pkg/pyinstaller-runtimehooks/pathopthubble.py hubble.py \
+    && scl enable python27 'pyinstaller --onedir --noconfirm --log-level ${_BINARY_LOG_LEVEL} --additional-hooks-dir=${_HOOK_DIR} --runtime-hook=pkg/pyinstaller-runtimehooks/pathopthubble.py hubble.py' \
     && mkdir -p /var/log/hubble_osquery/backuplogs \
 # hubble default configuration file
     && cp -rf /hubble_build/conf/hubble /etc/hubble/ \


### PR DESCRIPTION
Hi @basepi 

I made a mistake in my old PR https://github.com/hubblestack/hubble/pull/527

Basically I broke the pyinstaller command. So I am not able to create builds for centos6 ( from pkg Dockerfiles ) anymore.
This PR should fix it.

Thanks.