### PR TITLE
Avoiding last commit info in master builds 

### DIFF
--- a/pkg/amazonlinux2016.09/Dockerfile
+++ b/pkg/amazonlinux2016.09/Dockerfile
@@ -168,7 +168,7 @@ RUN git clone "$HUBBLE_GIT_URL" "$HUBBLE_SRC_PATH" \
  && git checkout "$HUBBLE_CHECKOUT" \
  && cp -rf "$HUBBLE_SRC_PATH" /hubble_build \
  && sed -i "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT}/g" /hubble_build/hubblestack/__init__.py \
- && sed -i "s/COMMIT_NOT_SET/`git describe`/g" /hubble_build/hubblestack/__init__.py
+ && sed -i "s/COMMIT_NOT_SET/TAGGED_BUILD/g" /hubble_build/hubblestack/__init__.py
 RUN mkdir /data
 VOLUME /data
 WORKDIR /hubble_build

--- a/pkg/centos6/Dockerfile
+++ b/pkg/centos6/Dockerfile
@@ -170,7 +170,7 @@ RUN git clone "$HUBBLE_GIT_URL" "$HUBBLE_SRC_PATH" \
  && git checkout "$HUBBLE_CHECKOUT" \
  && cp -rf "$HUBBLE_SRC_PATH" /hubble_build \
  && sed -i "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT}/g" /hubble_build/hubblestack/__init__.py \
- && sed -i "s/COMMIT_NOT_SET/`git describe`/g" /hubble_build/hubblestack/__init__.py
+ && sed -i "s/COMMIT_NOT_SET/TAGGED_BUILD/g" /hubble_build/hubblestack/__init__.py
 RUN mkdir /data
 VOLUME /data
 WORKDIR /hubble_build

--- a/pkg/centos7/Dockerfile
+++ b/pkg/centos7/Dockerfile
@@ -166,7 +166,7 @@ RUN git clone "$HUBBLE_GIT_URL" "$HUBBLE_SRC_PATH" \
  && git checkout "$HUBBLE_CHECKOUT" \
  && cp -rf "$HUBBLE_SRC_PATH" /hubble_build \
  && sed -i "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT}/g" /hubble_build/hubblestack/__init__.py \
- && sed -i "s/COMMIT_NOT_SET/`git describe`/g" /hubble_build/hubblestack/__init__.py
+ && sed -i "s/COMMIT_NOT_SET/TAGGED_BUILD/g" /hubble_build/hubblestack/__init__.py
 RUN mkdir /data
 VOLUME /data
 WORKDIR /hubble_build

--- a/pkg/coreos/Dockerfile
+++ b/pkg/coreos/Dockerfile
@@ -173,7 +173,7 @@ RUN git clone ${HUBBLE_GIT_URL} "$HUBBLE_SRC_PATH" \
  && git checkout ${HUBBLE_CHECKOUT} \
  && cp -rf "$HUBBLE_SRC_PATH" /hubble_build \
  && sed -i "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT}/g" /hubble_build/hubblestack/__init__.py \
- && sed -i "s/COMMIT_NOT_SET/`git describe`/g" /hubble_build/hubblestack/__init__.py
+ && sed -i "s/COMMIT_NOT_SET/TAGGED_BUILD/g" /hubble_build/hubblestack/__init__.py
 RUN mkdir /data
 VOLUME /data
 WORKDIR /hubble_build

--- a/pkg/debian7/Dockerfile
+++ b/pkg/debian7/Dockerfile
@@ -202,7 +202,7 @@ RUN git clone ${HUBBLE_GIT_URL} "$HUBBLE_SRC_PATH" \
  && git checkout ${HUBBLE_CHECKOUT} \
  && cp -rf "$HUBBLE_SRC_PATH" /hubble_build \
  && sed -i "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT}/g" /hubble_build/hubblestack/__init__.py \
- && sed -i "s/COMMIT_NOT_SET/`git describe`/g" /hubble_build/hubblestack/__init__.py
+ && sed -i "s/COMMIT_NOT_SET/TAGGED_BUILD/g" /hubble_build/hubblestack/__init__.py
 RUN mkdir /data
 VOLUME /data
 WORKDIR /hubble_build

--- a/pkg/debian8/Dockerfile
+++ b/pkg/debian8/Dockerfile
@@ -183,7 +183,7 @@ RUN git clone "$HUBBLE_GIT_URL" "$HUBBLE_SRC_PATH" \
  && git checkout "$HUBBLE_CHECKOUT" \
  && cp -rf "$HUBBLE_SRC_PATH" /hubble_build \
  && sed -i "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT}/g" /hubble_build/hubblestack/__init__.py \
- && sed -i "s/COMMIT_NOT_SET/`git describe`/g" /hubble_build/hubblestack/__init__.py
+ && sed -i "s/COMMIT_NOT_SET/TAGGED_BUILD/g" /hubble_build/hubblestack/__init__.py
 RUN mkdir /data
 VOLUME /data
 WORKDIR /hubble_build


### PR DESCRIPTION

Hi @basepi ,
I noticed that I made another mistake in my old PR https://github.com/hubblestack/hubble/pull/527

The idea behind PR 527 was to be able to distinguish between builds created from pkg and dev Dockerfiles. I am quoting a comment from old PR 527 :  

```
'branch' and 'last_commit' will be populated in the docker build step.

If you use the "pkg" dockerfile, you will end up with
{ 'branch' : '2.4.7' , 'last_commit' : 'TAGGED_BUILD' }

If you use the "pkg/dev" dockerfile, you will end up with
{ 'branch' : 'develop' , 'last_commit' : 'v2.4.7-197-g83ef7c0' }
```
But it seems that I made the corresponding change only in debian9 Dockerfile.
( So if I build centos7 from pkg Dockerile now, I will get some hash in 'last_commit' field. But I want it to show 'TAGGED_BUILD' in 'last_commit').

This PR aims to make these changes in pkg Dockerfiles of all OS.

[ Last commit can be extracted anyways from github by referring to the branch ( which is a tag actually ) field.   ]