### PR TITLE
Remove 'master' from all returner events

### DIFF
--- a/hubblestack/extmods/returners/graylog_nebula_return.py
+++ b/hubblestack/extmods/returners/graylog_nebula_return.py
@@ -46,7 +46,6 @@ def returner(ret):
         data = ret['return']
         minion_id = ret['id']
         jid = ret['jid']
-        master = __grains__['master']
         fqdn = __grains__['fqdn']
         fqdn = fqdn if fqdn else minion_id
         try:
@@ -70,7 +69,6 @@ def returner(ret):
                         event.update(d)
                         event.update({'query': query_name})
                         event.update({'job_id': jid})
-                        event.update({'master': master})
                         event.update({'minion_id': minion_id})
                         event.update({'dest_host': fqdn})
                         event.update({'dest_ip': fqdn_ip4})

--- a/hubblestack/extmods/returners/graylog_nova_return.py
+++ b/hubblestack/extmods/returners/graylog_nova_return.py
@@ -48,7 +48,6 @@ def returner(ret):
         fqdn = __grains__['fqdn']
         # Sometimes fqdn is blank. If it is, replace it with minion_id
         fqdn = fqdn if fqdn else minion_id
-        master = __grains__['master']
         try:
             fqdn_ip4 = __grains__['fqdn_ip4'][0]
         except IndexError:
@@ -58,11 +57,6 @@ def returner(ret):
                 if ip4_addr and not ip4_addr.startswith('127.'):
                     fqdn_ip4 = ip4_addr
                     break
-
-        if __grains__['master']:
-            master = __grains__['master']
-        else:
-            master = socket.gethostname()  # We *are* the master, so use our hostname
 
         if not isinstance(data, dict):
             log.error('Data sent to graylog_nova_return was not formed as a '
@@ -82,7 +76,6 @@ def returner(ret):
                 for key, value in fai[check_id].iteritems():
                     if key not in ['tag']:
                         event[key] = value
-            event.update({'master': master})
             event.update({'minion_id': minion_id})
             event.update({'dest_host': fqdn})
             event.update({'dest_ip': fqdn_ip4})
@@ -119,7 +112,6 @@ def returner(ret):
                 for key, value in suc[check_id].iteritems():
                     if key not in ['tag']:
                         event[key] = value
-            event.update({'master': master})
             event.update({'minion_id': minion_id})
             event.update({'dest_host': fqdn})
             event.update({'dest_ip': fqdn_ip4})
@@ -148,7 +140,6 @@ def returner(ret):
             event = {}
             event.update({'job_id': jid})
             event.update({'compliance_percentage': data['Compliance']})
-            event.update({'master': master})
             event.update({'minion_id': minion_id})
             event.update({'dest_host': fqdn})
             event.update({'dest_ip': fqdn_ip4})

--- a/hubblestack/extmods/returners/graylog_pulsar_return.py
+++ b/hubblestack/extmods/returners/graylog_pulsar_return.py
@@ -57,7 +57,6 @@ def returner(ret):
         minion_id = __opts__['id']
         fqdn = __grains__['fqdn']
         fqdn = fqdn if fqdn else minion_id
-        master = __grains__['master']
         try:
             fqdn_ip4 = __grains__['fqdn_ip4'][0]
         except IndexError:
@@ -166,7 +165,6 @@ def returner(ret):
                 # TODO: Should we be reporting 'EntryType' or 'TimeGenerated?
                 #   EntryType reports whether attempt to change was successful.
 
-            event.update({'master': master})
             event.update({'minion_id': minion_id})
             event.update({'dest_host': fqdn})
             event.update({'dest_ip': fqdn_ip4})

--- a/hubblestack/extmods/returners/logstash_nebula_return.py
+++ b/hubblestack/extmods/returners/logstash_nebula_return.py
@@ -52,7 +52,6 @@ def returner(ret):
         data = ret['return']
         minion_id = ret['id']
         jid = ret['jid']
-        master = __grains__['master']
         fqdn = __grains__['fqdn']
         fqdn = fqdn if fqdn else minion_id
         try:
@@ -76,7 +75,6 @@ def returner(ret):
                         event.update(query_result)
                         event.update({'query': query_name})
                         event.update({'job_id': jid})
-                        event.update({'master': master})
                         event.update({'minion_id': minion_id})
                         event.update({'dest_host': fqdn})
                         event.update({'dest_ip': fqdn_ip4})

--- a/hubblestack/extmods/returners/logstash_nova_return.py
+++ b/hubblestack/extmods/returners/logstash_nova_return.py
@@ -53,7 +53,6 @@ def returner(ret):
         fqdn = __grains__['fqdn']
         # Sometimes fqdn is blank. If it is, replace it with minion_id
         fqdn = fqdn if fqdn else minion_id
-        master = __grains__['master']
         try:
             fqdn_ip4 = __grains__['fqdn_ip4'][0]
         except IndexError:
@@ -63,11 +62,6 @@ def returner(ret):
                 if ip4_addr and not ip4_addr.startswith('127.'):
                     fqdn_ip4 = ip4_addr
                     break
-
-        if __grains__['master']:
-            master = __grains__['master']
-        else:
-            master = socket.gethostname()  # We *are* the master, so use our hostname
 
         if not isinstance(data, dict):
             log.error('Data sent to splunk_nova_return was not formed as a '
@@ -87,7 +81,6 @@ def returner(ret):
                 for key, value in fai[check_id].iteritems():
                     if key not in ['tag']:
                         event[key] = value
-            event.update({'master': master})
             event.update({'minion_id': minion_id})
             event.update({'dest_host': fqdn})
             event.update({'dest_ip': fqdn_ip4})
@@ -124,7 +117,6 @@ def returner(ret):
                 for key, value in suc[check_id].iteritems():
                     if key not in ['tag']:
                         event[key] = value
-            event.update({'master': master})
             event.update({'minion_id': minion_id})
             event.update({'dest_host': fqdn})
             event.update({'dest_ip': fqdn_ip4})
@@ -153,7 +145,6 @@ def returner(ret):
             event = {}
             event.update({'job_id': jid})
             event.update({'compliance_percentage': data['Compliance']})
-            event.update({'master': master})
             event.update({'minion_id': minion_id})
             event.update({'dest_host': fqdn})
             event.update({'dest_ip': fqdn_ip4})

--- a/hubblestack/extmods/returners/logstash_pulsar_return.py
+++ b/hubblestack/extmods/returners/logstash_pulsar_return.py
@@ -63,7 +63,6 @@ def returner(ret):
         minion_id = __opts__['id']
         fqdn = __grains__['fqdn']
         fqdn = fqdn if fqdn else minion_id
-        master = __grains__['master']
         try:
             fqdn_ip4 = __grains__['fqdn_ip4'][0]
         except IndexError:
@@ -172,7 +171,6 @@ def returner(ret):
                 # TODO: Should we be reporting 'EntryType' or 'TimeGenerated?
                 #   EntryType reports whether attempt to change was successful.
 
-            event.update({'master': master})
             event.update({'minion_id': minion_id})
             event.update({'dest_host': fqdn})
             event.update({'dest_ip': fqdn_ip4})

--- a/hubblestack/extmods/returners/splunk_fdg_return.py
+++ b/hubblestack/extmods/returners/splunk_fdg_return.py
@@ -86,7 +86,6 @@ def returner(ret):
             fun = ret['fun']
             global RETRY
             RETRY = ret['retry']
-            master = __grains__['master']
             fqdn = __grains__['fqdn']
             # Sometimes fqdn is blank. If it is, replace it with minion_id
             fqdn = fqdn if fqdn else minion_id
@@ -138,7 +137,6 @@ def returner(ret):
                         event.update({'fdg_file': fdg_file})
                         event.update({'fdg_starting_chained': starting_chained})
                         event.update({'job_id': jid})
-                        event.update({'master': master})
                         event.update({'minion_id': minion_id})
                         event.update({'dest_host': fqdn})
                         event.update({'dest_ip': fqdn_ip4})

--- a/hubblestack/extmods/returners/splunk_nebula_return.py
+++ b/hubblestack/extmods/returners/splunk_nebula_return.py
@@ -83,7 +83,6 @@ def returner(ret):
             jid = ret['jid']
             global RETRY
             RETRY = ret['retry']
-            master = __grains__['master']
             fqdn = __grains__['fqdn']
             # Sometimes fqdn is blank. If it is, replace it with minion_id
             fqdn = fqdn if fqdn else minion_id
@@ -127,7 +126,6 @@ def returner(ret):
                             event.update(query_result)
                             event.update({'query': query_name})
                             event.update({'job_id': jid})
-                            event.update({'master': master})
                             event.update({'minion_id': minion_id})
                             event.update({'dest_host': fqdn})
                             event.update({'dest_ip': fqdn_ip4})

--- a/hubblestack/extmods/returners/splunk_nova_return.py
+++ b/hubblestack/extmods/returners/splunk_nova_return.py
@@ -83,7 +83,6 @@ def returner(ret):
             fqdn = __grains__['fqdn']
             # Sometimes fqdn is blank. If it is, replace it with minion_id
             fqdn = fqdn if fqdn else minion_id
-            master = __grains__['master']
             try:
                 fqdn_ip4 = __grains__.get('local_ip4')
                 if not fqdn_ip4:
@@ -108,11 +107,6 @@ def returner(ret):
                     new_fqdn = fqdn_ip4
                 fqdn = new_fqdn
 
-            if __grains__['master']:
-                master = __grains__['master']
-            else:
-                master = socket.gethostname()  # We *are* the master, so use our hostname
-
             if not isinstance(data, dict):
                 log.error('Data sent to splunk_nova_return was not formed as a '
                           'dict:\n{0}'.format(data))
@@ -134,7 +128,6 @@ def returner(ret):
                     for key, value in fai[check_id].iteritems():
                         if key not in ['tag']:
                             event[key] = value
-                event.update({'master': master})
                 event.update({'minion_id': minion_id})
                 event.update({'dest_host': fqdn})
                 event.update({'dest_ip': fqdn_ip4})
@@ -180,7 +173,6 @@ def returner(ret):
                     for key, value in suc[check_id].iteritems():
                         if key not in ['tag']:
                             event[key] = value
-                event.update({'master': master})
                 event.update({'minion_id': minion_id})
                 event.update({'dest_host': fqdn})
                 event.update({'dest_ip': fqdn_ip4})
@@ -224,7 +216,6 @@ def returner(ret):
                 event = {}
                 event.update({'job_id': jid})
                 event.update({'compliance_percentage': data['Compliance']})
-                event.update({'master': master})
                 event.update({'minion_id': minion_id})
                 event.update({'dest_host': fqdn})
                 event.update({'dest_ip': fqdn_ip4})

--- a/hubblestack/extmods/returners/splunk_osqueryd_return.py
+++ b/hubblestack/extmods/returners/splunk_osqueryd_return.py
@@ -83,7 +83,6 @@ def returner(ret):
             jid = ret['jid']
             global RETRY
             RETRY = ret['retry']
-            master = __grains__['master']
             fqdn = __grains__['fqdn']
             # Sometimes fqdn is blank. If it is, replace it with minion_id
             fqdn = fqdn if fqdn else minion_id
@@ -122,7 +121,6 @@ def returner(ret):
                     query_name = query_results['name']
                     event.update({'query': query_name})
                     event.update({'job_id': jid})
-                    event.update({'master': master})
                     event.update({'minion_id': minion_id})
                     event.update({'dest_host': fqdn})
                     event.update({'dest_ip': fqdn_ip4})

--- a/hubblestack/extmods/returners/splunk_pulsar_return.py
+++ b/hubblestack/extmods/returners/splunk_pulsar_return.py
@@ -93,7 +93,6 @@ def returner(ret):
             fqdn = __grains__['fqdn']
             # Sometimes fqdn is blank. If it is, replace it with minion_id
             fqdn = fqdn if fqdn else minion_id
-            master = __grains__['master']
             try:
                 fqdn_ip4 = __grains__.get('local_ip4')
                 if not fqdn_ip4:
@@ -252,7 +251,6 @@ def returner(ret):
                             event['file_hash'] = chk
                             event['file_hash_type'] = alert.get('checksum_type', 'unknown')
 
-                event.update({'master': master})
                 event.update({'minion_id': minion_id})
                 event.update({'dest_host': fqdn})
                 event.update({'dest_ip': fqdn_ip4})

--- a/hubblestack/extmods/returners/sumo_nebula_return.py
+++ b/hubblestack/extmods/returners/sumo_nebula_return.py
@@ -40,7 +40,6 @@ def returner(ret):
         data = ret['return']
         minion_id = ret['id']
         jid = ret['jid']
-        master = __grains__['master']
         fqdn = __grains__['fqdn']
         fqdn = fqdn if fqdn else minion_id
         try:
@@ -63,7 +62,6 @@ def returner(ret):
                         event.update(d)
                         event.update({'query': query_name})
                         event.update({'job_id': jid})
-                        event.update({'master': master})
                         event.update({'minion_id': minion_id})
                         event.update({'dest_host': fqdn})
                         event.update({'dest_ip': fqdn_ip4})

--- a/hubblestack/extmods/returners/sumo_nova_return.py
+++ b/hubblestack/extmods/returners/sumo_nova_return.py
@@ -41,7 +41,6 @@ def returner(ret):
         fqdn = __grains__['fqdn']
         # Sometimes fqdn is blank. If it is, replace it with minion_id
         fqdn = fqdn if fqdn else minion_id
-        master = __grains__['master']
         try:
             fqdn_ip4 = __grains__['fqdn_ip4'][0]
         except IndexError:
@@ -51,11 +50,6 @@ def returner(ret):
                 if ip4_addr and not ip4_addr.startswith('127.'):
                     fqdn_ip4 = ip4_addr
                     break
-
-        if __grains__['master']:
-            master = __grains__['master']
-        else:
-            master = socket.gethostname()  # We *are* the master, so use our hostname
 
         if not isinstance(data, dict):
             log.error('Data sent to sumo_nova_return was not formed as a '
@@ -74,7 +68,6 @@ def returner(ret):
                 for key, value in fai[check_id].iteritems():
                     if key not in ['tag']:
                         event[key] = value
-            event.update({'master': master})
             event.update({'minion_id': minion_id})
             event.update({'dest_host': fqdn})
             event.update({'dest_ip': fqdn_ip4})
@@ -96,7 +89,6 @@ def returner(ret):
                 for key, value in suc[check_id].iteritems():
                     if key not in ['tag']:
                         event[key] = value
-            event.update({'master': master})
             event.update({'minion_id': minion_id})
             event.update({'dest_host': fqdn})
             event.update({'dest_ip': fqdn_ip4})
@@ -110,7 +102,6 @@ def returner(ret):
             event = {}
             event.update({'job_id': jid})
             event.update({'compliance_percentage': data['Compliance']})
-            event.update({'master': master})
             event.update({'minion_id': minion_id})
             event.update({'dest_host': fqdn})
             event.update({'dest_ip': fqdn_ip4})

--- a/hubblestack/extmods/returners/sumo_pulsar_return.py
+++ b/hubblestack/extmods/returners/sumo_pulsar_return.py
@@ -51,7 +51,6 @@ def returner(ret):
         minion_id = __opts__['id']
         fqdn = __grains__['fqdn']
         fqdn = fqdn if fqdn else minion_id
-        master = __grains__['master']
         try:
             fqdn_ip4 = __grains__['fqdn_ip4'][0]
         except IndexError:
@@ -159,7 +158,6 @@ def returner(ret):
                 # TODO: Should we be reporting 'EntryType' or 'TimeGenerated?
                 #   EntryType reports whether attempt to change was successful.
 
-            event.update({'master': master})
             event.update({'minion_id': minion_id})
             event.update({'dest_host': fqdn})
             event.update({'dest_ip': fqdn_ip4})

--- a/hubblestack/splunklogging.py
+++ b/hubblestack/splunklogging.py
@@ -72,7 +72,6 @@ class SplunkHandler(logging.Handler):
             hec = http_event_collector(*args, **kwargs)
 
             minion_id = __grains__['id']
-            master = __grains__['master']
             fqdn = __grains__['fqdn']
             # Sometimes fqdn is blank. If it is, replace it with minion_id
             fqdn = fqdn if fqdn else minion_id

--- a/hubblestack/utils/stdrec.py
+++ b/hubblestack/utils/stdrec.py
@@ -10,9 +10,8 @@ import socket
 
 def std_info():
     ''' Generate and return hubble standard host data for use in events:
-          master, minion_id, dest_host, dest_ip, dest_fqdn and system_uuid
+          minion_id, dest_host, dest_ip, dest_fqdn and system_uuid
     '''
-    master = __grains__['master']
     minion_id = __opts__['id']
     fqdn = __grains__['fqdn']
     fqdn = fqdn if fqdn else minion_id
@@ -41,7 +40,6 @@ def std_info():
         fqdn = new_fqdn
 
     ret = {
-        'master': master,
         'minion_id': minion_id,
         'dest_host': fqdn,
         'dest_ip': fqdn_ip4,


### PR DESCRIPTION
This is a holdover from hubble-salt and is no longer needed. We don't
use or care about masters, and it always defaults to 'salt' anyway.