### PR TITLE
Revert "Avoiding last commit info in master builds "

### DIFF
--- a/pkg/amazonlinux2016.09/Dockerfile
+++ b/pkg/amazonlinux2016.09/Dockerfile
@@ -168,7 +168,7 @@ RUN git clone "$HUBBLE_GIT_URL" "$HUBBLE_SRC_PATH" \
  && git checkout "$HUBBLE_CHECKOUT" \
  && cp -rf "$HUBBLE_SRC_PATH" /hubble_build \
  && sed -i "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT}/g" /hubble_build/hubblestack/__init__.py \
- && sed -i "s/COMMIT_NOT_SET/TAGGED_BUILD/g" /hubble_build/hubblestack/__init__.py
+ && sed -i "s/COMMIT_NOT_SET/`git describe`/g" /hubble_build/hubblestack/__init__.py
 RUN mkdir /data
 VOLUME /data
 WORKDIR /hubble_build

--- a/pkg/centos6/Dockerfile
+++ b/pkg/centos6/Dockerfile
@@ -170,7 +170,7 @@ RUN git clone "$HUBBLE_GIT_URL" "$HUBBLE_SRC_PATH" \
  && git checkout "$HUBBLE_CHECKOUT" \
  && cp -rf "$HUBBLE_SRC_PATH" /hubble_build \
  && sed -i "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT}/g" /hubble_build/hubblestack/__init__.py \
- && sed -i "s/COMMIT_NOT_SET/TAGGED_BUILD/g" /hubble_build/hubblestack/__init__.py
+ && sed -i "s/COMMIT_NOT_SET/`git describe`/g" /hubble_build/hubblestack/__init__.py
 RUN mkdir /data
 VOLUME /data
 WORKDIR /hubble_build

--- a/pkg/centos7/Dockerfile
+++ b/pkg/centos7/Dockerfile
@@ -166,7 +166,7 @@ RUN git clone "$HUBBLE_GIT_URL" "$HUBBLE_SRC_PATH" \
  && git checkout "$HUBBLE_CHECKOUT" \
  && cp -rf "$HUBBLE_SRC_PATH" /hubble_build \
  && sed -i "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT}/g" /hubble_build/hubblestack/__init__.py \
- && sed -i "s/COMMIT_NOT_SET/TAGGED_BUILD/g" /hubble_build/hubblestack/__init__.py
+ && sed -i "s/COMMIT_NOT_SET/`git describe`/g" /hubble_build/hubblestack/__init__.py
 RUN mkdir /data
 VOLUME /data
 WORKDIR /hubble_build

--- a/pkg/coreos/Dockerfile
+++ b/pkg/coreos/Dockerfile
@@ -173,7 +173,7 @@ RUN git clone ${HUBBLE_GIT_URL} "$HUBBLE_SRC_PATH" \
  && git checkout ${HUBBLE_CHECKOUT} \
  && cp -rf "$HUBBLE_SRC_PATH" /hubble_build \
  && sed -i "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT}/g" /hubble_build/hubblestack/__init__.py \
- && sed -i "s/COMMIT_NOT_SET/TAGGED_BUILD/g" /hubble_build/hubblestack/__init__.py
+ && sed -i "s/COMMIT_NOT_SET/`git describe`/g" /hubble_build/hubblestack/__init__.py
 RUN mkdir /data
 VOLUME /data
 WORKDIR /hubble_build

--- a/pkg/debian7/Dockerfile
+++ b/pkg/debian7/Dockerfile
@@ -202,7 +202,7 @@ RUN git clone ${HUBBLE_GIT_URL} "$HUBBLE_SRC_PATH" \
  && git checkout ${HUBBLE_CHECKOUT} \
  && cp -rf "$HUBBLE_SRC_PATH" /hubble_build \
  && sed -i "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT}/g" /hubble_build/hubblestack/__init__.py \
- && sed -i "s/COMMIT_NOT_SET/TAGGED_BUILD/g" /hubble_build/hubblestack/__init__.py
+ && sed -i "s/COMMIT_NOT_SET/`git describe`/g" /hubble_build/hubblestack/__init__.py
 RUN mkdir /data
 VOLUME /data
 WORKDIR /hubble_build

--- a/pkg/debian8/Dockerfile
+++ b/pkg/debian8/Dockerfile
@@ -183,7 +183,7 @@ RUN git clone "$HUBBLE_GIT_URL" "$HUBBLE_SRC_PATH" \
  && git checkout "$HUBBLE_CHECKOUT" \
  && cp -rf "$HUBBLE_SRC_PATH" /hubble_build \
  && sed -i "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT}/g" /hubble_build/hubblestack/__init__.py \
- && sed -i "s/COMMIT_NOT_SET/TAGGED_BUILD/g" /hubble_build/hubblestack/__init__.py
+ && sed -i "s/COMMIT_NOT_SET/`git describe`/g" /hubble_build/hubblestack/__init__.py
 RUN mkdir /data
 VOLUME /data
 WORKDIR /hubble_build


### PR DESCRIPTION
Reverts hubblestack/hubble#646

@yassingh After chatting with @fossam he thinks it's harder to work with the last_commit field in splunk when it's a special string like this.

I also did some testing, and if you're on a tag, `git describe` just returns the tag itself:

```
basepi@mustafar:~/src/work/hubble$ git checkout v3.0.1
Note: checking out 'v3.0.1'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b <new-branch-name>

HEAD is now at 39c7491 Rev to v3.0.1
basepi@mustafar:~/src/work/hubble$ git describe
v3.0.1
```

I think we should leave the `git describe` in all cases. More info is better, and it's still very clean on the tag itself.

Thoughts?