### PR TITLE
Saving 'paths' from vanishing in update ( pulsar )

### DIFF
--- a/hubblestack/extmods/modules/pulsar.py
+++ b/hubblestack/extmods/modules/pulsar.py
@@ -158,6 +158,7 @@ class ConfigManager(object):
         else:
             log.error('Pulsar beacon \'paths\' data improperly formatted. Should be list of paths')
 
+        to_set['paths'] = config.get('paths')
         self.nc_config = to_set
         self._abspathify()
         if config.get('verbose'):


### PR DESCRIPTION
Fixing a minor bug here.

Pulsar calls the "update" function once every 5 minutes. But in the update method, 'paths' attribute is lost.

But fortunately, the 'paths' attribute is set as soon as ConfigManager constructor is called ( this happens at this line https://github.com/hubblestack/hubble/blob/develop/hubblestack/extmods/modules/pulsar.py#L715 ).
And luckily, this constructor is being called every second.

The problem arises if a fim event is generated and this line ( https://github.com/hubblestack/hubble/blob/develop/hubblestack/extmods/modules/pulsar.py#L767 ) is hit within that second.


**How to reproduce the error:**
Just start a script to create fim events very fast ( once every 0.4 seconds worked for me ).

And you will see this error every 5 minutes:
```
2019-06-05 08:59:55 [hubblestack.daemon][ERROR   ] Error executing schedule
Traceback (most recent call last):
  File "hubblestack/daemon.py", line 165, in main
  File "hubblestack/daemon.py", line 357, in schedule
  File "/opt/hubble/hubble-libs/hubblestack/extmods/modules/pulsar.py", line 979, in top
    return process(configs, verbose=verbose)
  File "/opt/hubble/hubble-libs/hubblestack/extmods/modules/pulsar.py", line 757, in process
    config_path = config['paths'][0]
KeyError: 'paths'
```

Trying to fix this issue by preserving the 'paths' attribute.
I hope I am not messing with some original logic.
Have a look @jettero 


[ Alternatively, I could use dictionary's get method at https://github.com/hubblestack/hubble/blob/develop/hubblestack/extmods/modules/pulsar.py#L767 to handle this error ]