### PR TITLE
Fixing an issue with proxy in hec

### DIFF
--- a/hubblestack/hec/obj.py
+++ b/hubblestack/hec/obj.py
@@ -148,11 +148,11 @@ class HEC(object):
         self.server_uri = []
 
         if proxy and http_event_server_ssl:
-            self.proxy = {'https': 'https://{0}'.format(proxy)}
+            self.proxy = 'https://{0}'.format(proxy)
         elif proxy:
-            self.proxy = {'http': 'http://{0}'.format(proxy)}
+            self.proxy = 'http://{0}'.format(proxy)
         else:
-            self.proxy = {}
+            self.proxy = None
 
         # Set host to specified value or default to localhostname if no value provided
         if host:


### PR DESCRIPTION
As pointed out by @praksinha 
urllib3.ProxyManager in line number 204 is expecting the proxy to be a string ( and not a dictionary ).
Make a change to fix this.


The is the error which a user gets if try to use a proxy with the current code:
```
An Error occurred while loading the config: expected string or buffer
01:29:52 [ERROR] An un-handled exception was caught by salt's global exception handler:
TypeError: expected string or buffer
Traceback (most recent call last):
  File "hubble.py", line 5, in <module>
  File "hubblestack/daemon.py", line 58, in run
  File "hubblestack/daemon.py", line 700, in load_config
  File "hubblestack/log.py", line 148, in setup_splunk_logger
  File "hubblestack/splunklogging.py", line 72, in __init__
  File "hubblestack/hec/obj.py", line 204, in __init__
  File "urllib3/poolmanager.py", line 400, in __init__
  File "urllib3/util/url.py", line 204, in parse_url
TypeError: expected string or buffer
```

PR has been tested. Feel free to merge it.
Thanks