### PR TITLE
Fix linting for hubbleuuid.py

### DIFF
--- a/hubblestack/extmods/grains/hubbleuuid.py
+++ b/hubblestack/extmods/grains/hubbleuuid.py
@@ -7,7 +7,7 @@ import logging
 import os
 import uuid
 
-log = logging.getLogger(__name__)
+LOG = logging.getLogger(__name__)
 
 
 def hubble_uuid():
@@ -19,31 +19,30 @@ def hubble_uuid():
     existing_uuid = __opts__.get('hubble_uuid', None)
     try:
         if os.path.isfile(cached_uuid_path):
-            with open(cached_uuid_path, 'r') as f:
-                cached_uuid = f.read()
+            with open(cached_uuid_path, 'r') as uuid_file:
+                cached_uuid = uuid_file.read()
                 # Check if it's changed out from under us -- problem!
                 if existing_uuid and cached_uuid != existing_uuid:
-                    log.error('hubble_uuid changed on disk unexpectedly!'
-                              '\nPrevious: {0}\nNew: {1}\nKeeping previous.'
-                              .format(existing_uuid, cached_uuid))
+                    LOG.error('hubble_uuid changed on disk unexpectedly!'
+                              '\nPrevious: %s\nNew: %s\nKeeping previous.',
+                              existing_uuid, cached_uuid)
                     # Write the previous UUID to the cache file
                     try:
-                        with open(cached_uuid_path, 'w') as f:
-                            f.write(existing_uuid)
+                        with open(cached_uuid_path, 'w') as cache_file:
+                            cache_file.write(existing_uuid)
                     except Exception:
-                        log.exception('Problem writing cached hubble uuid to file: {0}'
-                                      .format(cached_uuid_path))
+                        LOG.exception('Problem writing cached hubble uuid to file: %s',
+                                      cached_uuid_path)
                     return {'hubble_uuid': existing_uuid}
                 return {'hubble_uuid': cached_uuid}
         elif existing_uuid:
-            log.error('hubble_uuid was previously generated, but the cached '
-                      'file is no longer present: {0}'.format(cached_uuid_path))
+            LOG.error('hubble_uuid was previously generated, but the cached '
+                      'file is no longer present: %s', cached_uuid_path)
         else:
-            log.warning('generating fresh uuid, no cache file found. '
-                       '(probably not a problem)')
+            LOG.warning('generating fresh uuid, no cache file found. '
+                        '(probably not a problem)')
     except Exception:
-        log.exception('Problem retrieving cached hubble uuid from file: {0}'
-                      .format(cached_uuid_path))
+        LOG.exception('Problem retrieving cached hubble uuid from file: %s', cached_uuid_path)
 
     # Generate a fresh one if needed
     if not existing_uuid:
@@ -51,10 +50,9 @@ def hubble_uuid():
 
     # Cache the new (or old if it needs re-caching) uuid
     try:
-        with open(cached_uuid_path, 'w') as f:
-            f.write(existing_uuid)
+        with open(cached_uuid_path, 'w') as uuid_file:
+            uuid_file.write(existing_uuid)
     except Exception:
-        log.exception('Problem writing cached hubble uuid to file: {0}'
-                      .format(cached_uuid_path))
+        LOG.exception('Problem writing cached hubble uuid to file: %s', cached_uuid_path)
 
     return {'hubble_uuid': existing_uuid}

--- a/hubblestack/extmods/grains/systemuuid.py
+++ b/hubblestack/extmods/grains/systemuuid.py
@@ -8,7 +8,7 @@ import salt.utils.path
 import salt.modules.cmdmod
 
 __salt__ = {'cmd.run_stdout': salt.modules.cmdmod.run_stdout}
-log = logging.getLogger(__name__)
+LOG = logging.getLogger(__name__)
 
 
 def get_system_uuid():
@@ -27,10 +27,11 @@ def get_system_uuid():
     hubble_uuid = __opts__.get('hubble_uuid', None)
 
     if not hubble_uuid:
-        cached_hubble_uuid_path = os.path.join(os.path.dirname(__opts__['configfile']), 'hubble_cached_uuid')
+        cached_hubble_uuid_path = os.path.join(os.path.dirname(__opts__['configfile']),
+                                               'hubble_cached_uuid')
         try:
-            with open(cached_hubble_uuid_path, 'r') as f:
-                hubble_uuid = f.read()
+            with open(cached_hubble_uuid_path, 'r') as uuid_file:
+                hubble_uuid = uuid_file.read()
         except Exception:
             hubble_uuid = None
 
@@ -43,24 +44,24 @@ def get_system_uuid():
 
     try:
         if os.path.isfile(cached_system_uuid_path):
-            with open(cached_system_uuid_path, 'r') as f:
-                cached_system_uuid = f.read()
+            with open(cached_system_uuid_path, 'r') as uuid_file:
+                cached_system_uuid = uuid_file.read()
             # Check if it's changed out from under us -- problem!
             if cached_system_uuid != live_system_uuid:
-                log.error("system_uuid on disk doesn't match live system value"
-                          '\nLive: {0}\nOn Disk: {1}\nRewriting cached value'
-                          .format(live_system_uuid, cached_system_uuid))
+                LOG.error("system_uuid on disk doesn't match live system value"
+                          '\nLive: %s\nOn Disk: %s\nRewriting cached value',
+                          live_system_uuid, cached_system_uuid)
                 _write_system_uuid_to_file(cached_system_uuid_path, live_system_uuid)
             return {'system_uuid': live_system_uuid}
         elif previous_system_uuid:
-            log.error('system_uuid was previously cached, but the cached '
-                      'file is no longer present: {0}'.format(cached_system_uuid_path))
+            LOG.error('system_uuid was previously cached, but the cached '
+                      'file is no longer present: %s', cached_system_uuid_path)
         else:
-            log.warning('no cache file found, caching system_uuid. '
+            LOG.warning('no cache file found, caching system_uuid. '
                         '(probably not a problem)')
     except Exception:
-        log.exception('Problem retrieving cached system uuid from file: {0}'
-                      .format(cached_system_uuid_path))
+        LOG.exception('Problem retrieving cached system uuid from file: %s',
+                      cached_system_uuid_path)
 
     # Cache the system uuid if needed
     _write_system_uuid_to_file(cached_system_uuid_path, live_system_uuid)
@@ -69,11 +70,10 @@ def get_system_uuid():
 
 def _write_system_uuid_to_file(path, uuid):
     try:
-        with open(path, 'w') as f:
-            f.write(uuid)
+        with open(path, 'w') as out_file:
+            out_file.write(uuid)
     except Exception:
-        log.exception('Problem writing cached system uuid to file: {0}'
-                      .format(path))
+        LOG.exception('Problem writing cached system uuid to file: %s', path)
 
 
 def _get_uuid_from_system():
@@ -83,24 +83,24 @@ def _get_uuid_from_system():
     osqueryipaths = ('/opt/osquery/osqueryi', 'osqueryi', '/usr/bin/osqueryi')
     for path in osqueryipaths:
         if salt.utils.path.which(path):
-            first_run = __salt__['cmd.run_stdout']('{0} {1}'.format(path, query), output_loglevel='quiet')
+            first_run = __salt__['cmd.run_stdout']('{0} {1}'.format(path, query),
+                                                   output_loglevel='quiet')
             first_run = str(first_run).upper()
 
-            second_run = __salt__['cmd.run_stdout']('{0} {1}'.format(path, query), output_loglevel='quiet')
+            second_run = __salt__['cmd.run_stdout']('{0} {1}'.format(path, query),
+                                                    output_loglevel='quiet')
             second_run = str(second_run).upper()
 
             if len(first_run) == 36 and first_run == second_run:
                 return first_run
-            else:
-                return None
+            return None
     # If osquery isn't available, attempt to get uuid from /sys path (linux only)
     try:
-        with open('/sys/devices/virtual/dmi/id/product_uuid', 'r') as f:
-            file_uuid = f.read()
+        with open('/sys/devices/virtual/dmi/id/product_uuid', 'r') as input_file:
+            file_uuid = input_file.read()
         file_uuid = str(file_uuid).upper()
         if len(file_uuid) == 36:
             return file_uuid
-        else:
-            return None
+        return None
     except Exception:
         return None


### PR DESCRIPTION
I was thinking here instead of `Exception`, it would work with `(OSError, IOError)` since it's for the `open()` clause but I'm not entirely sure so I left it like this to be safe