### PR TITLE
Configure Splunk properties through command line.

### DIFF
--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -512,6 +512,8 @@ def load_config():
 
     if __opts__.get('configureConf', None):
         print('creating user conf')
+        configureoptions = __opts__.get('configureConf', None)
+        print(configureoptions)
         createUserConf(__opts__)
         clean_up_process(None, None)
         sys.exit(0)
@@ -857,7 +859,6 @@ def parse_args():
                         action='store_true',
                         help='Show version information')
     parser.add_argument('--configureConf',
-                        action='configure_conf',
                         help='configure hubble conf properties')
     parser.add_argument('--buildinfo',
                         action='store_true',

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -37,7 +37,7 @@ import hubblestack.utils.stdrec
 from hubblestack import __version__
 from croniter import croniter
 from datetime import datetime
-from hubblestack.extmods.utils.customUserConf import createUserConf
+from hubblestack.extmods.utils.customUserConf import create_user_conf
 from hubblestack.hangtime import hangtime_wrapper
 import hubblestack.status
 
@@ -510,11 +510,11 @@ def load_config():
     __opts__['conf_file'] = parsed_args.get('configfile')
     __opts__['install_dir'] = install_dir
 
-    if __opts__.get('configureConf', None):
+    if __opts__.get('configure', None):
         print('creating user conf')
-        configure_options = __opts__.get('configureConf', None)
+        configure_options = __opts__.get('configure', None)
         print(configure_options)
-        createUserConf(__opts__, configure_options)
+        create_user_conf(__opts__, configure_options)
         clean_up_process(None, None)
         sys.exit(0)
 
@@ -857,7 +857,7 @@ def parse_args():
     parser.add_argument('--version',
                         action='store_true',
                         help='Show version information')
-    parser.add_argument('--configureConf',
+    parser.add_argument('--configure',
                         help='configure hubble conf properties')
     parser.add_argument('--buildinfo',
                         action='store_true',

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -512,13 +512,13 @@ def load_config():
 
     if __opts__.get('configureConf', None):
         print('creating user conf')
-        createUserConf()
+        createUserConf(__opts__.get('hubblestack', []))
         clean_up_process(None, None)
         sys.exit(0)
 
     if __opts__['version']:
         print(__version__)
-        createUserConf()
+        createUserConf(__opts__.get('hubblestack', []))
         clean_up_process(None, None)
         sys.exit(0)
 

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -512,15 +512,14 @@ def load_config():
 
     if __opts__.get('configureConf', None):
         print('creating user conf')
-        configureoptions = __opts__.get('configureConf', None)
-        print(configureoptions)
-        createUserConf(__opts__)
+        configure_options = __opts__.get('configureConf', None)
+        print(configure_options)
+        createUserConf(__opts__, configure_options)
         clean_up_process(None, None)
         sys.exit(0)
 
     if __opts__['version']:
         print(__version__)
-        createUserConf(__opts__)
         clean_up_process(None, None)
         sys.exit(0)
 

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -510,7 +510,7 @@ def load_config():
     __opts__['conf_file'] = parsed_args.get('configfile')
     __opts__['install_dir'] = install_dir
 
-    if __opts__['configureConf']:
+    if __opts__.get('configureConf', None):
         print('creating user conf')
         createUserConf()
         clean_up_process(None, None)

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -512,13 +512,13 @@ def load_config():
 
     if __opts__.get('configureConf', None):
         print('creating user conf')
-        createUserConf(__opts__.get('hubblestack', []))
+        createUserConf(__opts__)
         clean_up_process(None, None)
         sys.exit(0)
 
     if __opts__['version']:
         print(__version__)
-        createUserConf(__opts__.get('hubblestack', []))
+        createUserConf(__opts__)
         clean_up_process(None, None)
         sys.exit(0)
 

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -511,10 +511,9 @@ def load_config():
     __opts__['install_dir'] = install_dir
 
     if __opts__.get('configure', None):
-        print('creating user conf')
         configure_options = __opts__.get('configure', None)
-        print(configure_options)
-        create_user_conf(__opts__, configure_options)
+        splunk_conf = __opts__.get('hubblestack', [])
+        create_user_conf(splunk_conf, configure_options, salt.utils.platform.is_windows())
         clean_up_process(None, None)
         sys.exit(0)
 

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -856,6 +856,9 @@ def parse_args():
     parser.add_argument('--version',
                         action='store_true',
                         help='Show version information')
+    parser.add_argument('--configureConf',
+                        action='configure_conf',
+                        help='configure hubble conf properties')
     parser.add_argument('--buildinfo',
                         action='store_true',
                         help='Show build information')

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -37,6 +37,7 @@ import hubblestack.utils.stdrec
 from hubblestack import __version__
 from croniter import croniter
 from datetime import datetime
+from hubblestack.extmods.utils.customUserConf import createUserConf
 from hubblestack.hangtime import hangtime_wrapper
 import hubblestack.status
 
@@ -509,8 +510,15 @@ def load_config():
     __opts__['conf_file'] = parsed_args.get('configfile')
     __opts__['install_dir'] = install_dir
 
+    if __opts__['configureConf']:
+        print('creating user conf')
+        createUserConf()
+        clean_up_process(None, None)
+        sys.exit(0)
+
     if __opts__['version']:
         print(__version__)
+        createUserConf()
         clean_up_process(None, None)
         sys.exit(0)
 

--- a/hubblestack/extmods/utils/customUserConf.py
+++ b/hubblestack/extmods/utils/customUserConf.py
@@ -1,7 +1,7 @@
 import json
 import yaml
 import logging
-base_path_linux = '/etc/hubble/hubble.d'
+base_path_linux = '/etc/hubble/hubble.d/'
 base_path_windows = 'C:\\Program Files (x86)\\Hubble\\etc\\hubble\\hubble.d\\'
 log = logging.getLogger(__name__)
 default_config_name = 'user.conf'
@@ -15,13 +15,26 @@ def parse_configure_option(configure_options):
             value = str.split("=")[1]
             configure_options_dict[key] = value
     except:
-        print('some error occured, parameters format incorrect')
+        raise Exception('some error occured, parameters format incorrect')
     return configure_options_dict
 
 
 def create_user_conf(splunk_conf, configure_options, is_windows):
+    '''
+    Function to create a user conf based on the parameters provided in the
+    command line.
+    Usage : hubble --configure "splunk_token=customToken splunk_index=customIndex confname=mycustom.conf"
+    :param splunk_conf: splunk config as mentioned in the main hubble conf
+    :param configure_options: command line args passed to the --configure method
+    :param is_windows: boolean that tells whether the OS is windows or not
+    :return: void
+    '''
     print('creating custom conf')
-    configure_options_dict = parse_configure_option(configure_options)
+    try:
+        configure_options_dict = parse_configure_option(configure_options)
+    except Exception as e:
+        print(e)
+        return
     base_path = base_path_windows if is_windows else base_path_linux
     if('confname' in configure_options_dict):
         user_config_filename = base_path + configure_options_dict['confname']

--- a/hubblestack/extmods/utils/customUserConf.py
+++ b/hubblestack/extmods/utils/customUserConf.py
@@ -1,10 +1,9 @@
 import json
 import yaml
 import logging
-import hubblestack.log
-
+base_path_linux = '/etc/hubble/hubble.d'
+base_path_windows = 'C:\\Program Files (x86)\\Hubble\\etc\\hubble\\hubble.d\\'
 log = logging.getLogger(__name__)
-base_path = '/etc/hubble/hubble.d/'
 default_config_name = 'user.conf'
 
 def parse_configure_option(configure_options):
@@ -19,10 +18,11 @@ def parse_configure_option(configure_options):
         print('some error occured, parameters format incorrect')
     return configure_options_dict
 
-def create_user_conf(__opts__, configure_options):
-    print('inside create_user_conf')
+
+def create_user_conf(splunk_conf, configure_options, is_windows):
+    print('creating custom conf')
     configure_options_dict = parse_configure_option(configure_options)
-    splunk_conf = __opts__.get('hubblestack', [])
+    base_path = base_path_windows if is_windows else base_path_linux
     if('confname' in configure_options_dict):
         user_config_filename = base_path + configure_options_dict['confname']
     else:
@@ -30,16 +30,17 @@ def create_user_conf(__opts__, configure_options):
     encoded_splunk_conf = json.dumps(splunk_conf)
     yaml_splunk_conf = yaml.safe_load(encoded_splunk_conf)
     inner_most = yaml_splunk_conf['returner']['splunk'][0]
-    if 'splunkIndex' in configure_options_dict:
-        inner_most['index'] = configure_options_dict['splunkIndex']
-    if 'splunkIndexer' in configure_options_dict:
-        inner_most['indexer'] = configure_options_dict['splunkIndexer']
-    if 'splunkToken' in configure_options_dict:
-        inner_most['token'] = configure_options_dict['splunkToken']
-    if 'splunkProxy' in configure_options_dict:
-        inner_most['proxy'] = configure_options_dict['splunkProxy']
-    if 'splunkPort' in configure_options_dict:
-        inner_most['port'] = int(configure_options_dict['splunkPort'])
+    if 'splunk_index' in configure_options_dict:
+        inner_most['index'] = configure_options_dict['splunk_index']
+    if 'splunk_indexer' in configure_options_dict:
+        inner_most['indexer'] = configure_options_dict['splunk_indexer']
+    if 'splunk_token' in configure_options_dict:
+        inner_most['token'] = configure_options_dict['splunk_token']
+    if 'splunk_proxy' in configure_options_dict:
+        inner_most['proxy'] = configure_options_dict['splunk_proxy']
+    if 'splunk_port' in configure_options_dict:
+        inner_most['port'] = int(configure_options_dict['splunk_port'])
     with open(user_config_filename, 'w') as outfile:
         yaml.safe_dump(yaml_splunk_conf, outfile, default_flow_style=False, sort_keys=False)
+    print('custom conf created at ' + user_config_filename)
     outfile.close()

--- a/hubblestack/extmods/utils/customUserConf.py
+++ b/hubblestack/extmods/utils/customUserConf.py
@@ -42,5 +42,5 @@ def create_user_conf(splunk_conf, configure_options, is_windows):
         inner_most['port'] = int(configure_options_dict['splunk_port'])
     with open(user_config_filename, 'w') as outfile:
         yaml.safe_dump(yaml_splunk_conf, outfile, default_flow_style=False, sort_keys=False)
-    print('custom conf created at ' + user_config_filename)
+    print('custom conf created at {0}'.format(user_config_filename))
     outfile.close()

--- a/hubblestack/extmods/utils/customUserConf.py
+++ b/hubblestack/extmods/utils/customUserConf.py
@@ -36,5 +36,5 @@ def createUserConf(__opts__):
             print(value)
             inner_most['token'] = splunk_token
     with open(outputFile, 'w') as outfile:
-        yaml.safe_dump(encodedsplunkConf, outfile, default_flow_style=False)
+        yaml.safe_dump(yamlSplunkConf, outfile, default_flow_style=False)
     outfile.close()

--- a/hubblestack/extmods/utils/customUserConf.py
+++ b/hubblestack/extmods/utils/customUserConf.py
@@ -20,9 +20,7 @@ def createUserConf(__opts__):
     encodedsplunkConf = json.dumps(splunkConf)
     log.info(encodedsplunkConf)
     log.info(type(encodedsplunkConf))
-    print("a")
     yamlSplunkConf = yaml.safe_load(encodedsplunkConf)
-    print("a")
     inner_most = yamlSplunkConf['returner']['splunk'][0]
     log.info(inner_most)
     for key, value in inner_most.items():
@@ -36,5 +34,5 @@ def createUserConf(__opts__):
             print(value)
             inner_most['token'] = splunk_token
     with open(outputFile, 'w') as outfile:
-        yaml.safe_dump(yamlSplunkConf, outfile, default_flow_style=False)
+        yaml.safe_dump(yamlSplunkConf, outfile, default_flow_style=False, sort_keys=False)
     outfile.close()

--- a/hubblestack/extmods/utils/customUserConf.py
+++ b/hubblestack/extmods/utils/customUserConf.py
@@ -6,12 +6,11 @@ import hubblestack.log
 log = logging.getLogger(__name__)
 global __opts__
 
-def createUserConf():
+def createUserConf(splunkConf):
     print('inside create user conf')
     splunkIndex = 'mera_personal_index'
     splunk_token = 'mera_personal_token'
     splunkIndexer = 'mera_indexer'
-    splunkConf = __opts__.get('hubblestack', [])
     log.info(type(splunkConf))
     log.info('Moody')
     log.info(splunkConf)

--- a/hubblestack/extmods/utils/customUserConf.py
+++ b/hubblestack/extmods/utils/customUserConf.py
@@ -4,6 +4,7 @@ import logging
 import hubblestack.log
 
 log = logging.getLogger(__name__)
+global __opts__
 
 def createUserConf():
     print('inside create user conf')

--- a/hubblestack/extmods/utils/customUserConf.py
+++ b/hubblestack/extmods/utils/customUserConf.py
@@ -10,11 +10,11 @@ def createUserConf(__opts__):
     splunkIndex = 'mera_personal_index'
     splunk_token = 'mera_personal_token'
     splunkIndexer = 'mera_indexer'
-    log.info(type(splunkConf))
     log.info('Moody')
     log.info(__opts__)
     splunkConf = __opts__.get('hubblestack', [])
     log.info(splunkConf)
+    log.info(type(splunkConf))
     basePath = '/etc/hubble/hubble.d/'
     outputFile = basePath + 'abc.conf'
     encodedsplunkConf = eval(json.dumps(splunkConf))

--- a/hubblestack/extmods/utils/customUserConf.py
+++ b/hubblestack/extmods/utils/customUserConf.py
@@ -17,8 +17,7 @@ def createUserConf(__opts__):
     log.info(type(splunkConf))
     basePath = '/etc/hubble/hubble.d/'
     outputFile = basePath + 'abc.conf'
-    true=True
-    encodedsplunkConf = eval(json.dumps(splunkConf))
+    encodedsplunkConf = json.dumps(splunkConf)
     log.info(encodedsplunkConf)
     inner_most = encodedsplunkConf['returner']['splunk'][0]
     log.info(inner_most)
@@ -33,5 +32,5 @@ def createUserConf(__opts__):
             print(value)
             inner_most['token'] = splunk_token
     with open(outputFile, 'w') as outfile:
-        yaml.dump(encodedsplunkConf, outfile, default_flow_style=False)
+        yaml.safe_dump(encodedsplunkConf, outfile, default_flow_style=False)
     outfile.close()

--- a/hubblestack/extmods/utils/customUserConf.py
+++ b/hubblestack/extmods/utils/customUserConf.py
@@ -54,6 +54,6 @@ def create_user_conf(splunk_conf, configure_options, is_windows):
     if 'splunk_port' in configure_options_dict:
         inner_most['port'] = int(configure_options_dict['splunk_port'])
     with open(user_config_filename, 'w') as outfile:
-        yaml.safe_dump(yaml_splunk_conf, outfile, default_flow_style=False, sort_keys=False)
+        yaml.safe_dump(yaml_splunk_conf, outfile, default_flow_style=False)
     print('custom conf created at {0}'.format(user_config_filename))
     outfile.close()

--- a/hubblestack/extmods/utils/customUserConf.py
+++ b/hubblestack/extmods/utils/customUserConf.py
@@ -19,7 +19,9 @@ def createUserConf(__opts__):
     outputFile = basePath + 'abc.conf'
     encodedsplunkConf = json.dumps(splunkConf)
     log.info(encodedsplunkConf)
-    inner_most = encodedsplunkConf['returner']['splunk'][0]
+    log.info(type(encodedsplunkConf))
+    yamlSplunkConf = yaml.safe_load(encodedsplunkConf)
+    inner_most = yamlSplunkConf['returner']['splunk'][0]
     log.info(inner_most)
     for key, value in inner_most.items():
         if key == 'index':

--- a/hubblestack/extmods/utils/customUserConf.py
+++ b/hubblestack/extmods/utils/customUserConf.py
@@ -4,15 +4,16 @@ import logging
 import hubblestack.log
 
 log = logging.getLogger(__name__)
-global __opts__
 
-def createUserConf(splunkConf):
+def createUserConf(__opts__):
     print('inside create user conf')
     splunkIndex = 'mera_personal_index'
     splunk_token = 'mera_personal_token'
     splunkIndexer = 'mera_indexer'
     log.info(type(splunkConf))
     log.info('Moody')
+    log.info(__opts__)
+    splunkConf = __opts__.get('hubblestack', [])
     log.info(splunkConf)
     basePath = '/etc/hubble/hubble.d/'
     outputFile = basePath + 'abc.conf'

--- a/hubblestack/extmods/utils/customUserConf.py
+++ b/hubblestack/extmods/utils/customUserConf.py
@@ -1,0 +1,33 @@
+import json
+import yaml
+import logging
+import hubblestack.log
+
+log = logging.getLogger(__name__)
+
+def createUserConf():
+    print('inside create user conf')
+    splunkIndex = 'mera_personal_index'
+    splunk_token = 'mera_personal_token'
+    splunkIndexer = 'mera_indexer'
+    splunkConf = __opts__.get('hubblestack', [])
+    log.info(type(splunkConf))
+    log.info('Moody')
+    log.info(splunkConf)
+    basePath = '/etc/hubble/hubble.d/'
+    outputFile = basePath + 'abc.conf'
+    encodedsplunkConf = eval(json.dumps(splunkConf))
+    inner_most = encodedsplunkConf['returner']['splunk'][0]
+    for key, value in inner_most.items():
+        if key == 'index':
+            print(value)
+            inner_most['index'] = splunkIndex
+        elif key == 'indexer':
+            print(value)
+            inner_most['indexer'] = splunkIndexer
+        elif key == 'token':
+            print(value)
+            inner_most['token'] = splunk_token
+    with open(outputFile, 'w') as outfile:
+        yaml.dump(encodedsplunkConf, outfile, default_flow_style=False)
+    outfile.close()

--- a/hubblestack/extmods/utils/customUserConf.py
+++ b/hubblestack/extmods/utils/customUserConf.py
@@ -17,8 +17,11 @@ def createUserConf(__opts__):
     log.info(type(splunkConf))
     basePath = '/etc/hubble/hubble.d/'
     outputFile = basePath + 'abc.conf'
+    true=True
     encodedsplunkConf = eval(json.dumps(splunkConf))
+    log.info(encodedsplunkConf)
     inner_most = encodedsplunkConf['returner']['splunk'][0]
+    log.info(inner_most)
     for key, value in inner_most.items():
         if key == 'index':
             print(value)

--- a/hubblestack/extmods/utils/customUserConf.py
+++ b/hubblestack/extmods/utils/customUserConf.py
@@ -4,35 +4,42 @@ import logging
 import hubblestack.log
 
 log = logging.getLogger(__name__)
+basePath = '/etc/hubble/hubble.d/'
+default_config_name = 'user.conf'
 
-def createUserConf(__opts__):
-    print('inside create user conf')
-    splunkIndex = 'mera_personal_index'
-    splunk_token = 'mera_personal_token'
-    splunkIndexer = 'mera_indexer'
-    log.info('Moody')
-    log.info(__opts__)
+def parse_configure_option(configure_options):
+    try:
+        keys = configure_options.split(" ")
+        configure_options_dict = {}
+        for str in keys:
+            key = str.split("=")[0]
+            value = str.split("=")[1]
+            configure_options_dict[key] = value
+    except:
+        print('some error occured, parameters format incorrect')
+    return configure_options_dict
+
+def createUserConf(__opts__, configure_options):
+    print('inside createUserConf')
+    configure_options_dict = parse_configure_option(configure_options)
     splunkConf = __opts__.get('hubblestack', [])
-    log.info(splunkConf)
-    log.info(type(splunkConf))
-    basePath = '/etc/hubble/hubble.d/'
-    outputFile = basePath + 'abc.conf'
+    if('filename' in configure_options_dict):
+        user_config_filename = basePath + configure_options_dict['filename']
+    else:
+        user_config_filename = basePath + default_config_name
     encodedsplunkConf = json.dumps(splunkConf)
-    log.info(encodedsplunkConf)
-    log.info(type(encodedsplunkConf))
     yamlSplunkConf = yaml.safe_load(encodedsplunkConf)
     inner_most = yamlSplunkConf['returner']['splunk'][0]
-    log.info(inner_most)
-    for key, value in inner_most.items():
-        if key == 'index':
-            print(value)
-            inner_most['index'] = splunkIndex
-        elif key == 'indexer':
-            print(value)
-            inner_most['indexer'] = splunkIndexer
-        elif key == 'token':
-            print(value)
-            inner_most['token'] = splunk_token
-    with open(outputFile, 'w') as outfile:
+    if 'splunkIndex' in configure_options_dict:
+        inner_most['index'] = configure_options_dict['splunkIndex']
+    if 'splunkIndexer' in configure_options_dict:
+        inner_most['indexer'] = configure_options_dict['splunkIndexer']
+    if 'splunkToken' in configure_options_dict:
+        inner_most['token'] = configure_options_dict['splunkToken']
+    if 'splunkProxy' in configure_options_dict:
+        inner_most['proxy'] = configure_options_dict['splunkProxy']
+    if 'splunkPort' in configure_options_dict:
+        inner_most['port'] = int(configure_options_dict['splunkPort'])
+    with open(user_config_filename, 'w') as outfile:
         yaml.safe_dump(yamlSplunkConf, outfile, default_flow_style=False, sort_keys=False)
     outfile.close()

--- a/hubblestack/extmods/utils/customUserConf.py
+++ b/hubblestack/extmods/utils/customUserConf.py
@@ -20,7 +20,9 @@ def createUserConf(__opts__):
     encodedsplunkConf = json.dumps(splunkConf)
     log.info(encodedsplunkConf)
     log.info(type(encodedsplunkConf))
+    print("a")
     yamlSplunkConf = yaml.safe_load(encodedsplunkConf)
+    print("a")
     inner_most = yamlSplunkConf['returner']['splunk'][0]
     log.info(inner_most)
     for key, value in inner_most.items():

--- a/hubblestack/extmods/utils/customUserConf.py
+++ b/hubblestack/extmods/utils/customUserConf.py
@@ -4,7 +4,7 @@ import logging
 import hubblestack.log
 
 log = logging.getLogger(__name__)
-basePath = '/etc/hubble/hubble.d/'
+base_path = '/etc/hubble/hubble.d/'
 default_config_name = 'user.conf'
 
 def parse_configure_option(configure_options):
@@ -19,17 +19,17 @@ def parse_configure_option(configure_options):
         print('some error occured, parameters format incorrect')
     return configure_options_dict
 
-def createUserConf(__opts__, configure_options):
-    print('inside createUserConf')
+def create_user_conf(__opts__, configure_options):
+    print('inside create_user_conf')
     configure_options_dict = parse_configure_option(configure_options)
-    splunkConf = __opts__.get('hubblestack', [])
-    if('filename' in configure_options_dict):
-        user_config_filename = basePath + configure_options_dict['filename']
+    splunk_conf = __opts__.get('hubblestack', [])
+    if('confname' in configure_options_dict):
+        user_config_filename = base_path + configure_options_dict['confname']
     else:
-        user_config_filename = basePath + default_config_name
-    encodedsplunkConf = json.dumps(splunkConf)
-    yamlSplunkConf = yaml.safe_load(encodedsplunkConf)
-    inner_most = yamlSplunkConf['returner']['splunk'][0]
+        user_config_filename = base_path + default_config_name
+    encoded_splunk_conf = json.dumps(splunk_conf)
+    yaml_splunk_conf = yaml.safe_load(encoded_splunk_conf)
+    inner_most = yaml_splunk_conf['returner']['splunk'][0]
     if 'splunkIndex' in configure_options_dict:
         inner_most['index'] = configure_options_dict['splunkIndex']
     if 'splunkIndexer' in configure_options_dict:
@@ -41,5 +41,5 @@ def createUserConf(__opts__, configure_options):
     if 'splunkPort' in configure_options_dict:
         inner_most['port'] = int(configure_options_dict['splunkPort'])
     with open(user_config_filename, 'w') as outfile:
-        yaml.safe_dump(yamlSplunkConf, outfile, default_flow_style=False, sort_keys=False)
+        yaml.safe_dump(yaml_splunk_conf, outfile, default_flow_style=False, sort_keys=False)
     outfile.close()


### PR DESCRIPTION
This feature enables the end user to configure splunk properties via the CLI. The usage is as follows:
hubble --configure "splunk_token=customToken splunk_index=customIndex splunk_indexer=customIndexer splunk_proxy=customProxy splunk_port=customPort confname=mycustom.conf"

The following parameters can be customized
1. Splunk Token - Authentication token for Splunk
2. Splunk Index
3. Splunk Indexer
4. Proxy - send logs to splunk via a proxy
5. Port - proxy port
6. confname - the name of the config file that the user wishes to write splunk configurations to. Defaults to 'user.conf'