### PR TITLE
Let pylint fail

### DIFF
--- a/.pipeline
+++ b/.pipeline
@@ -21,6 +21,7 @@ pipeline {
                     source /etc/profile.d/kersplat.sh
                     pyenv local 2.7.14
                     pyenv shell 2.7.14
+                    rm -rf ./vlib ./venv
                     pip install --cache-dir ./pip.cache -t ./vlib virtualenv
                     PYTHONPATH=./vlib ./vlib/bin/virtualenv ./venv
                     source ./venv/bin/activate

--- a/.pipeline
+++ b/.pipeline
@@ -56,10 +56,12 @@ pipeline {
                             else find hubblestack -name "*.py" -exec git diff --name-only "$LHS" "$RHS" {} +
                             fi > pylint-manifest.txt
                             '''
-                        sh '''#!/bin/bash
-                            source ./venv/bin/activate
-                            < pylint-manifest.txt xargs -r pylint -f colorized
-                            '''
+                        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                            sh '''#!/bin/bash
+                                source ./venv/bin/activate
+                                < pylint-manifest.txt xargs -r pylint -f colorized
+                                '''
+                        }
                     }
                 }
             }


### PR DESCRIPTION
1. fix some unusual/rare build problems by removing venv/ and vlib/ before build setup
2. instruct jenkins to let pylint fail without reporting blocked-merge to github