### PR TITLE
Re-adding the ability to read splunk config from hubble.d

### DIFF
--- a/hubblestack/extmods/grains/splunkconfig.py
+++ b/hubblestack/extmods/grains/splunkconfig.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+'''
+Attempt to load alternate splunk config from the hubble.d/ directory and store
+in grains for use by the splunk returners. This way splunk config changes don't
+require a hubble restart.
+'''
+import os
+import yaml
+
+
+def splunkconfig():
+    '''
+    Walk the hubble.d/ directory and read in any .conf files using YAML. If
+    splunk config is found, place it in grains and return.
+    '''
+    configdir = os.path.join(os.path.dirname(__opts__['configfile']), 'hubble.d')
+    ret = {}
+    if not os.path.isdir(configdir):
+        return ret
+    try:
+        for root, dirs, files in os.walk(configdir):
+            for f in files:
+                if f.endswith('.conf'):
+                    fpath = os.path.join(root, f)
+                    try:
+                        with open(fpath, 'r') as fh:
+                            config = yaml.safe_load(fh)
+                        if config.get('hubblestack', {}).get('returner', {}).get('splunk'):
+                            ret = {'hubblestack': config['hubblestack']}
+                    except:
+                        pass
+    except:
+        pass
+    return ret

--- a/hubblestack/hec/opt.py
+++ b/hubblestack/hec/opt.py
@@ -29,7 +29,7 @@ class Required(object):
 REQUIRED = Required()
 del Required
 
-MODALITIES = ('grains.get',) # config.get does not update splunk config on runtime
+MODALITIES = ('grains.get','config.get',) # config.get does not update splunk config on runtime
 
 def _get_splunk_options(space, modality, **kw):
     ret = list()

--- a/hubblestack/hec/opt.py
+++ b/hubblestack/hec/opt.py
@@ -29,7 +29,7 @@ class Required(object):
 REQUIRED = Required()
 del Required
 
-MODALITIES = ('grains.get','config.get',) # config.get does not update splunk config on runtime
+MODALITIES = ('grains.get','config.get',) # search in grains first, fallback to config.get
 
 def _get_splunk_options(space, modality, **kw):
     ret = list()

--- a/hubblestack/hec/opt.py
+++ b/hubblestack/hec/opt.py
@@ -29,7 +29,7 @@ class Required(object):
 REQUIRED = Required()
 del Required
 
-MODALITIES = ('config.get',) # used to house grains.get before config.get
+MODALITIES = ('grains.get',) # config.get does not update splunk config on runtime
 
 def _get_splunk_options(space, modality, **kw):
     ret = list()


### PR DESCRIPTION
Somewhere along the way to 3.0.1 build, hubble lost its ability to pickup splunk configuration dynmaically.
As a result, hubble needs to be restarted if we intend to update the splunk config.

Some of our functionalities are dependent of this feature.
Making some changes in this PR to add that functionality back to hubble.

In this PR, I am recreating the file which was deleted in https://github.com/hubblestack/hubble/pull/580

Moreover, I am changing the hec/opt.py file so that first it looks in grains,get for splunk config ( and then fallback to config.get ),

