### PR TITLE
Automatically populate the splunkindex grain

### DIFF
--- a/conf/hubble
+++ b/conf/hubble
@@ -146,9 +146,6 @@ fileserver_backend:
 #splunklogging: True
 #splunk_index_extracted_fields: []
 
-#config_to_grains:
-#  - splunkindex: "hubblestack:returner:splunk:0:index"
-
 #Set log level
 log_level: info
 

--- a/hubblestack/extmods/grains/splunkconfig.py
+++ b/hubblestack/extmods/grains/splunkconfig.py
@@ -9,10 +9,10 @@ import yaml
 
 
 def splunkconfig():
-    '''
+    """
     Walk the hubble.d/ directory and read in any .conf files using YAML. If
     splunk config is found, place it in grains and return.
-    '''
+    """
     configdir = os.path.join(os.path.dirname(__opts__['configfile']), 'hubble.d')
     ret = {}
     if not os.path.isdir(configdir):
@@ -31,4 +31,43 @@ def splunkconfig():
                         pass
     except:
         pass
+    ret = _splunkindex(ret)
     return ret
+
+
+def _splunkindex(grains=None):
+    """
+    If splunk config is found, set the ``index`` to the ``splunkindex`` grain.
+
+    Search grains (passed in), then config.
+    """
+    if grains is None:
+        grains = {}
+
+    # Grains, old-style config
+    try:
+        grains['splunkindex'] = grains['hubblestack']['returner']['splunk']['index']
+        return grains
+    except Exception:
+        pass
+
+    # Grains, new-style config
+    try:
+        grains['splunkindex'] = grains['hubblestack']['returner']['splunk'][0]['index']
+        return grains
+    except Exception:
+        pass
+
+    # Opts, old-style config
+    try:
+        grains['splunkindex'] = opts['hubblestack']['returner']['splunk']['index']
+        return grains
+    except Exception:
+        pass
+
+    # Opts, new-style config
+    try:
+        grains['splunkindex'] = opts['hubblestack']['returner']['splunk'][0]['index']
+        return grains
+    except Exception:
+        pass

--- a/hubblestack/extmods/grains/splunkconfig.py
+++ b/hubblestack/extmods/grains/splunkconfig.py
@@ -16,6 +16,7 @@ def splunkconfig():
     configdir = os.path.join(os.path.dirname(__opts__['configfile']), 'hubble.d')
     ret = {}
     if not os.path.isdir(configdir):
+        ret = _splunkindex(ret)
         return ret
     try:
         for root, dirs, files in os.walk(configdir):
@@ -42,8 +43,8 @@ def _splunkindex(grains=None):
     Grains take priority over opts.
 
     If the grains and opts splunk index differ, set ``splunk_grains_fallback``
-    grain so that we know that splunk config has changed (via grains) since
-    hubble startup.
+    grain (with the old index) so that we know that splunk config has changed
+    (via grains) since hubble startup.
     """
     if grains is None:
         grains = {}
@@ -79,5 +80,5 @@ def _splunkindex(grains=None):
         grains['splunkindex'] = index
         # Check if grains differ from opts, and note if that's the case
         if opts_index != index:
-            grains['splunk_grains_fallback'] = True
+            grains['splunk_grains_fallback'] = opts_index
     return grains

--- a/hubblestack/extmods/grains/splunkconfig.py
+++ b/hubblestack/extmods/grains/splunkconfig.py
@@ -52,13 +52,13 @@ def _splunkindex(grains=None):
 
     # Opts, new-style config
     try:
-        index = opts['hubblestack']['returner']['splunk'][0]['index']
+        index = __opts__['hubblestack']['returner']['splunk'][0]['index']
     except Exception:
         pass
 
     # Opts, old-style config
     try:
-        index = opts['hubblestack']['returner']['splunk']['index']
+        index = __opts__['hubblestack']['returner']['splunk']['index']
     except Exception:
         pass
 


### PR DESCRIPTION
Some users were still on the old-style splunk returner config
and were missing this grain. We can fix that in the config, but we
decided we wanted to make sure this grain was bulletproof. If the config
exists, we populate the grain.