### PR TITLE
Avoiding splunk token from getting logged among grains 

### DIFF
--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -698,7 +698,7 @@ def load_config():
 
     if __salt__['config.get']('splunklogging', False):
         hubblestack.log.setup_splunk_logger()
-        hubblestack.log.emit_to_splunk(__grains__, 'INFO', 'hubblestack.grains_report')
+        hubblestack.log.emit_to_splunk(__grains__, 'INFO', 'hubblestack.grains_report', filter_logs=True)
 
 # 600s is a long time to get stuck loading grains and *not* be doing things
 # like nova/pulsar. The SIGALRM will get caught by salt.loader.raw_mod as an
@@ -795,7 +795,7 @@ def refresh_grains(initial=False):
     hubble_status.start_sigusr1_signal_handler()
 
     if not initial and __salt__['config.get']('splunklogging', False):
-        hubblestack.log.emit_to_splunk(__grains__, 'INFO', 'hubblestack.grains_report')
+        hubblestack.log.emit_to_splunk(__grains__, 'INFO', 'hubblestack.grains_report', filter_logs=True)
 
 def emit_to_syslog(grains_to_emit):
     '''

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -698,7 +698,7 @@ def load_config():
 
     if __salt__['config.get']('splunklogging', False):
         hubblestack.log.setup_splunk_logger()
-        hubblestack.log.emit_to_splunk(__grains__, 'INFO', 'hubblestack.grains_report', filter_logs=True)
+        hubblestack.log.emit_to_splunk(__grains__, 'INFO', 'hubblestack.grains_report', remove_sensitive_logs=True)
 
 # 600s is a long time to get stuck loading grains and *not* be doing things
 # like nova/pulsar. The SIGALRM will get caught by salt.loader.raw_mod as an
@@ -795,7 +795,7 @@ def refresh_grains(initial=False):
     hubble_status.start_sigusr1_signal_handler()
 
     if not initial and __salt__['config.get']('splunklogging', False):
-        hubblestack.log.emit_to_splunk(__grains__, 'INFO', 'hubblestack.grains_report', filter_logs=True)
+        hubblestack.log.emit_to_splunk(__grains__, 'INFO', 'hubblestack.grains_report', remove_sensitive_logs=True)
 
 def emit_to_syslog(grains_to_emit):
     '''

--- a/hubblestack/log.py
+++ b/hubblestack/log.py
@@ -7,8 +7,12 @@ from __future__ import print_function
 
 import logging
 import time
+import copy
 
 import hubblestack.splunklogging
+
+# These patterns will not be logged by "conf_publisher" module and emit_to_splunk
+PATTERNS_TO_FILTER = ["password", "token", "passphrase", "privkey", "keyid", "s3.key"]
 
 # While hubble doesn't use these, salt modules can, so let's define them anyway
 SPLUNK = logging.SPLUNK = 25
@@ -154,10 +158,17 @@ def setup_splunk_logger():
     SPLUNK_HANDLER = handler
 
 
-def emit_to_splunk(message, level, name):
+def emit_to_splunk(message, level, name, filter_logs=False):
     '''
     Emit a single message to splunk
     '''
+
+    if filter_logs:
+        # copying the original message so that it does not
+        # get modified while filtering
+        copy_of_message = copy.deepcopy(message)
+        message = filter_logs(copy_of_message, remove_dots=True)
+
     if SPLUNK_HANDLER is None:
         return False
     handler = SPLUNK_HANDLER
@@ -177,3 +188,31 @@ def workaround_salt_log_handler_queues():
     sls.LOGGING_NULL_HANDLER.sync_with_handlers([flh])
     # if flh.count > 0:
     #     log.info("pretended to handle %d logging record(s) for salt.log.setup.LOGGING_*_HANDLER", flh.count)
+
+def filter_logs(opts_to_log, remove_dots=True):
+    '''
+    Filters out keys containing certain patterns to avoid sensitive information being sent to logs
+    Works on dictionaries and lists
+    This function was located at extmods/modules/conf_publisher.py previously
+    '''
+    filtered_conf = _remove_sensitive_info(opts_to_log, PATTERNS_TO_FILTER)
+    if remove_dots:
+        for key in filtered_conf.keys():
+            if '.' in key:
+                filtered_conf[key.replace('.', '_')] = filtered_conf.pop(key)
+    return filtered_conf
+
+
+def _remove_sensitive_info(obj, patterns_to_filter):
+    '''
+    Filter known sensitive info
+    '''
+    if isinstance(obj, dict):
+         obj = {
+             key: _remove_sensitive_info(value, patterns_to_filter)
+             for key, value in obj.iteritems()
+             if not any(patt in key for patt in patterns_to_filter)}
+    elif isinstance(obj, list):
+         obj = [_remove_sensitive_info(item, patterns_to_filter)
+                    for item in obj]
+    return obj

--- a/hubblestack/log.py
+++ b/hubblestack/log.py
@@ -11,7 +11,7 @@ import copy
 
 import hubblestack.splunklogging
 
-# These patterns will not be logged by "conf_publisher" module and emit_to_splunk
+# These patterns will not be logged by "conf_publisher" and "emit_to_splunk"
 PATTERNS_TO_FILTER = ["password", "token", "passphrase", "privkey", "keyid", "s3.key"]
 
 # While hubble doesn't use these, salt modules can, so let's define them anyway
@@ -158,12 +158,12 @@ def setup_splunk_logger():
     SPLUNK_HANDLER = handler
 
 
-def emit_to_splunk(message, level, name, filter_logs=False):
+def emit_to_splunk(message, level, name, remove_sensitive_logs=False):
     '''
     Emit a single message to splunk
     '''
 
-    if filter_logs:
+    if remove_sensitive_logs:
         # copying the original message so that it does not
         # get modified while filtering
         copy_of_message = copy.deepcopy(message)

--- a/hubblestack/log.py
+++ b/hubblestack/log.py
@@ -164,7 +164,7 @@ def emit_to_splunk(message, level, name, remove_sensitive_logs=False):
     '''
 
     if isinstance(message, (list, dict)):
-        message = filter_logs(copy_of_message, remove_dots=False)
+        message = filter_logs(message, remove_dots=False)
 
     if SPLUNK_HANDLER is None:
         return False

--- a/hubblestack/log.py
+++ b/hubblestack/log.py
@@ -163,11 +163,8 @@ def emit_to_splunk(message, level, name, remove_sensitive_logs=False):
     Emit a single message to splunk
     '''
 
-    if remove_sensitive_logs:
-        # copying the original message so that it does not
-        # get modified while filtering
-        copy_of_message = copy.deepcopy(message)
-        message = filter_logs(copy_of_message, remove_dots=True)
+    if isinstance(message, (list, dict)):
+        message = filter_logs(copy_of_message, remove_dots=False)
 
     if SPLUNK_HANDLER is None:
         return False


### PR DESCRIPTION
After this PR : https://github.com/hubblestack/hubble/pull/679 , splunk config loaded via hubble.d/*.conf will become a part of __grains__.

As a result, splunk related details will be published on spunk, including the token.
So I am trying to omit token ( and other such sensitive details ) from splunk logs.

Instead of writing completely new logic, I am reusing some functions which were present in extmods/modules/conf_publisher.py 

I have made more comments in the PR for explanation.