### PR TITLE
Remove returner_retry functionality

### DIFF
--- a/conf/hubble
+++ b/conf/hubble
@@ -48,14 +48,12 @@ fileserver_backend:
 #    kwargs:
 #      verbose: True
 #    returner: splunk_nova_return
-#    returner_retry: True # only works on splunk returners for now
 #    run_on_start: False
 #  fdg_top:
 #    function: fdg.top
 #    seconds: 86400
 #    splay: 3600
 #    returner: splunk_fdg_return
-#    returner_retry: True
 #    run_on_start: True
 #  nebula_fifteen_min:
 #    function: nebula.queries
@@ -80,7 +78,6 @@ fileserver_backend:
 #    args:
 #      - day
 #    returner: splunk_nebula_return
-#    returner_retry: True # only works on splunk returners for now
 #    run_on_start: False
 #  nebula_osqueryd_monitor:
 #    function: nebula.osqueryd_monitor

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -345,7 +345,6 @@ def schedule():
         returners = jobdata.get('returner', [])
         if not isinstance(returners, list):
             returners = [returners]
-        returner_retry = jobdata.get('returner_retry', False)
 
         # Actually process the job
         run = False
@@ -395,8 +394,7 @@ def schedule():
                                 'jid': salt.utils.jid.gen_jid(__opts__),
                                 'fun': func,
                                 'fun_args': args + ([kwargs] if kwargs else []),
-                                'return': ret,
-                                'retry': returner_retry}
+                                'return': ret}
                 __returners__[returner](returner_ret)
     return sf_count
 
@@ -435,10 +433,7 @@ def run_function():
                             'jid': salt.utils.jid.gen_jid(__opts__),
                             'fun': __opts__['function'],
                             'fun_args': args + ([kwargs] if kwargs else []),
-                            'return': ret,
-                            'retry': False}
-            if __opts__.get('returner_retry', False):
-                returner_ret['retry'] = True
+                            'return': ret}
             __returners__[returner](returner_ret)
 
     # TODO instantiate the salt outputter system?
@@ -867,9 +862,6 @@ def parse_args():
     parser.add_argument('--ignore_running',
                         action='store_true',
                         help='Ignore any running hubble processes. This disables the pidfile.')
-    parser.add_argument('--returner_retry',
-                        action='store_true',
-                        help='Enable retry on the returner for one-off jobs')
     return vars(parser.parse_args())
 
 def check_pidfile(kill_other=False, scan_proc=True):

--- a/hubblestack/extmods/modules/fdg.py
+++ b/hubblestack/extmods/modules/fdg.py
@@ -299,7 +299,7 @@ def _pipe(chained, chained_status, block_data, block_id, returner=None):
     return ret
 
 
-def _return(data, returner, returner_retry=None):
+def _return(data, returner):
     """
     Return data using the returner system
     """
@@ -307,8 +307,6 @@ def _return(data, returner, returner_retry=None):
     global __returners__
     if not __returners__:
         __returners__ = salt.loader.returners(__opts__, __salt__)
-    if returner_retry is None:
-        returner_retry = __opts__.get(returner_retry, False)
 
     returner += '.returner'
     if returner not in __returners__:
@@ -320,8 +318,7 @@ def _return(data, returner, returner_retry=None):
                     'fun': 'fdg.fdg',
                     'fun_args': [],
                     'return': data[0],
-                    'return_status': data[1],
-                    'retry': returner_retry}
+                    'return_status': data[1]}
     __returners__[returner](returner_ret)
     return True
 

--- a/hubblestack/extmods/returners/splunk_fdg_return.py
+++ b/hubblestack/extmods/returners/splunk_fdg_return.py
@@ -55,7 +55,6 @@ import logging
 
 _max_content_bytes = 100000
 http_event_collector_debug = False
-RETRY = False
 
 log = logging.getLogger(__name__)
 
@@ -84,8 +83,6 @@ def returner(ret):
             minion_id = ret['id']
             jid = ret['jid']
             fun = ret['fun']
-            global RETRY
-            RETRY = ret['retry']
             fqdn = __grains__['fqdn']
             # Sometimes fqdn is blank. If it is, replace it with minion_id
             fqdn = fqdn if fqdn else minion_id

--- a/hubblestack/extmods/returners/splunk_nebula_return.py
+++ b/hubblestack/extmods/returners/splunk_nebula_return.py
@@ -51,7 +51,6 @@ import logging
 
 _max_content_bytes = 100000
 http_event_collector_debug = False
-RETRY = False
 
 log = logging.getLogger(__name__)
 
@@ -81,8 +80,6 @@ def returner(ret):
             data = ret['return']
             minion_id = ret['id']
             jid = ret['jid']
-            global RETRY
-            RETRY = ret['retry']
             fqdn = __grains__['fqdn']
             # Sometimes fqdn is blank. If it is, replace it with minion_id
             fqdn = fqdn if fqdn else minion_id

--- a/hubblestack/extmods/returners/splunk_nova_return.py
+++ b/hubblestack/extmods/returners/splunk_nova_return.py
@@ -48,8 +48,6 @@ import logging
 
 from hubblestack.hec import http_event_collector, get_splunk_options, make_hec_args
 
-RETRY = False
-
 log = logging.getLogger(__name__)
 
 
@@ -78,8 +76,6 @@ def returner(ret):
             data = ret['return']
             minion_id = ret['id']
             jid = ret['jid']
-            global RETRY
-            RETRY = ret['retry']
             fqdn = __grains__['fqdn']
             # Sometimes fqdn is blank. If it is, replace it with minion_id
             fqdn = fqdn if fqdn else minion_id

--- a/hubblestack/extmods/returners/splunk_osqueryd_return.py
+++ b/hubblestack/extmods/returners/splunk_osqueryd_return.py
@@ -52,7 +52,6 @@ import logging
 
 _max_content_bytes = 100000
 http_event_collector_debug = False
-RETRY = False
 
 log = logging.getLogger(__name__)
 
@@ -81,8 +80,6 @@ def returner(ret):
             data = ret['return']
             minion_id = ret['id']
             jid = ret['jid']
-            global RETRY
-            RETRY = ret['retry']
             fqdn = __grains__['fqdn']
             # Sometimes fqdn is blank. If it is, replace it with minion_id
             fqdn = fqdn if fqdn else minion_id

--- a/hubblestack/extmods/returners/splunk_pulsar_return.py
+++ b/hubblestack/extmods/returners/splunk_pulsar_return.py
@@ -50,8 +50,6 @@ from hubblestack.hec import http_event_collector, get_splunk_options, make_hec_a
 
 import logging
 
-RETRY = False
-
 log = logging.getLogger(__name__)
 
 def returner(ret):
@@ -88,8 +86,6 @@ def returner(ret):
             data = _dedupList(data)
             minion_id = __opts__['id']
             jid = ret['jid']
-            global RETRY
-            RETRY = ret['retry']
             fqdn = __grains__['fqdn']
             # Sometimes fqdn is blank. If it is, replace it with minion_id
             fqdn = fqdn if fqdn else minion_id


### PR DESCRIPTION
It was broken in the splunk returner consolidation, and the need for
this retry system has been eliminated by the disk queueing system
anyway.