### PR TITLE
New audit.py module to replace nova (hubble.py)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ tests/unittests/*cache*
 tests/unittests/*log*
 tests/unittests/output
 relevant-files.txt
+
+# PyCharm project
+.idea/

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -582,6 +582,9 @@ def load_config():
     fdg_dirs = __opts__.get('fdg_dirs', [])
     fdg_dirs.append(os.path.join(os.path.dirname(__file__), 'extmods', 'fdg'))
     __opts__['fdg_dirs'] = fdg_dirs
+    audit_dirs = __opts__.get('audit_dirs', [])
+    audit_dirs.append(os.path.join(os.path.dirname(__file__), 'extmods', 'audit'))
+    __opts__['audit_dirs'] = audit_dirs
     __opts__['file_roots']['base'].insert(0, os.path.join(os.path.dirname(__file__), 'files'))
     if 'roots' not in __opts__['fileserver_backend']:
         __opts__['fileserver_backend'].append('roots')

--- a/hubblestack/extmods/audit/grep.py
+++ b/hubblestack/extmods/audit/grep.py
@@ -1,0 +1,160 @@
+# -*- encoding: utf-8 -*-
+"""
+Audit module for using grep to verify settings in files.
+
+Sample YAML data:
+
+.. code-block:: yaml
+
+    CIS-6.2.4:
+      grep.file:
+        args:
+          - /etc/group
+        kwargs:
+          pattern: '^+:'
+          fail_on_match: True
+        description: Ensure no legacy "+" entries exist in /etc/group
+
+Required args/kwargs:
+
+    path
+        The absolute path of the file to match against
+    pattern
+        The pattern to use with the ``grep`` command.
+
+Optional kwargs:
+
+    grep_args
+        A list of args to pass to the ``grep`` command
+    fail_on_match
+        Defaults to False. If set to True, then if a match is found it will
+        count as a failure.
+    success_on_file_missing
+        Defaults to False. If set to True, then if a file is missing this check
+        will be marked as a success.
+    match_output
+        String to check for in the output of the grep command. If not provided,
+        any grep output will be considered a match.
+    match_output_regex
+        True/False. Whether to use regex when matching output. Defaults to
+        False.
+    match_output_multiline
+        True/False. Whether to use multiline flag for regex matching with
+        match_output_regex set to True. Defaults to True.
+"""
+from __future__ import absolute_import
+
+import logging
+import os
+import re
+
+from salt.exceptions import CommandExecutionError
+
+LOG = logging.getLogger(__name__)
+
+
+def grep(path,
+         pattern,
+         grep_args=None,
+         fail_on_match=False,
+         success_on_file_missing=False,
+         match_output=None,
+         match_output_regex=False,
+         match_output_multiline=True):
+    """
+    Use grep to match against the contents of a file.
+
+    :param path:
+        See module-level documentation
+    :param pattern:
+        See module-level documentation
+    :param grep_args:
+        See module-level documentation
+    :param fail_on_match:
+        See module-level documentation
+    :param success_on_file_missing:
+        See module-level documentation
+    :param match_output:
+        See module-level documentation
+    :param match_output_regex:
+        See module-level documentation
+    :param match_output_multiline:
+        See module-level documentation
+    :return:
+        Returns a tuple (success, {'grep_output': output}) where ``success``
+        is True or False based on the success of the check, and ``output`` is
+        the output of the ``grep`` command, for documentation purposes.
+    """
+    if not os.path.isfile(path):
+        if success_on_file_missing:
+            return True, {}
+
+    if not grep_args:
+        grep_args = []
+
+    output = _grep(path, pattern, *grep_args)
+
+    if not output:
+        # No output found
+        if fail_on_match:
+            return True, {'grep_output': output}
+        else:
+            return False, {'grep_output': output}
+
+    # We default to ``success = True`` because there was grep output. Now we'll
+    # check against the various match_output settings to see if we need to
+    # reverse that decision
+    success = True
+    if match_output:
+        if match_output_regex:
+            if match_output_multiline:
+                if not re.search(match_output, output, re.MULTILINE):
+                    success = False
+            else:
+                if not re.search(match_output, output):
+                    success = False
+        else:
+            if match_output not in output:
+                success = False
+
+    # Reverse our success if ``fail_on_match = True``
+    if fail_on_match:
+        success = not success
+
+    if success:
+        return True, {'grep_output': output}
+    else:
+        return False, {'grep_output': output}
+
+
+def _grep(path,
+          pattern,
+          *args):
+    """
+    Grep for a string in the specified file
+
+    :param path:
+        Path to the file to be searched
+    :param pattern:
+        Pattern to match. For example: ``test``, or ``a[0-5]``
+    :param args:
+        Additional command-line flags to pass to the grep command. For example:
+        ``-v``, or ``-i -B2``
+    :return:
+    """
+    path = os.path.expanduser(path)
+
+    if args:
+        options = ' '.join(args)
+    else:
+        options = ''
+    cmd = r'grep {options} {pattern} {path}'.format(options=options,
+                                                    pattern=pattern,
+                                                    path=path)
+
+    try:
+        ret = __salt__['cmd.run'](cmd, python_shell=False, ignore_retcode=True)
+    except (IOError, OSError) as exc:
+        raise CommandExecutionError(exc.strerror)
+
+    return ret

--- a/hubblestack/extmods/audit/grep.py
+++ b/hubblestack/extmods/audit/grep.py
@@ -87,7 +87,9 @@ def grep(path,
     """
     if not os.path.isfile(path):
         if success_on_file_missing:
-            return True, {}
+            return True, {'reason': 'File missing'}
+        else:
+            return False, {'reason': 'File missing'}
 
     if not grep_args:
         grep_args = []

--- a/hubblestack/extmods/audit/grep.py
+++ b/hubblestack/extmods/audit/grep.py
@@ -7,7 +7,7 @@ Sample YAML data:
 .. code-block:: yaml
 
     CIS-6.2.4:
-      grep.file:
+      grep.grep:
         args:
           - /etc/group
         kwargs:
@@ -47,7 +47,6 @@ from __future__ import absolute_import
 import logging
 import os
 import re
-import salt.modules.cmdmod
 
 from salt.exceptions import CommandExecutionError
 
@@ -154,7 +153,7 @@ def _grep(path,
                                                     path=path)
 
     try:
-        ret = salt.modules.cmdmod.run(cmd, python_shell=False, ignore_retcode=True)
+        ret = __salt__['cmd.run'](cmd, python_shell=False, ignore_retcode=True)
     except (IOError, OSError) as exc:
         raise CommandExecutionError(exc.strerror)
 

--- a/hubblestack/extmods/audit/grep.py
+++ b/hubblestack/extmods/audit/grep.py
@@ -47,6 +47,7 @@ from __future__ import absolute_import
 import logging
 import os
 import re
+import salt.modules.cmdmod
 
 from salt.exceptions import CommandExecutionError
 
@@ -153,7 +154,7 @@ def _grep(path,
                                                     path=path)
 
     try:
-        ret = __salt__['cmd.run'](cmd, python_shell=False, ignore_retcode=True)
+        ret = salt.modules.cmdmod.run(cmd, python_shell=False, ignore_retcode=True)
     except (IOError, OSError) as exc:
         raise CommandExecutionError(exc.strerror)
 

--- a/hubblestack/extmods/modules/audit.py
+++ b/hubblestack/extmods/modules/audit.py
@@ -234,17 +234,16 @@ def _get_top_data(topfile):
         raise CommandExecutionError('Could not load topfile: {0}'.format(e))
 
     if not isinstance(topdata, dict) or 'audit' not in topdata or \
-            not isinstance(topdata['audit'], list):
+            not isinstance(topdata['audit'], dict):
         raise CommandExecutionError('Audit topfile not formatted correctly.')
 
     topdata = topdata['audit']
 
     ret = []
 
-    for topmatch in topdata:
-        for match, data in topmatch.iteritems():
-            if __salt__['match.compound'](match):
-                ret.extend(data)
+    for match, data in topdata.iteritems():
+        if __salt__['match.compound'](match):
+            ret.extend(data)
 
     return ret
 

--- a/hubblestack/extmods/modules/audit.py
+++ b/hubblestack/extmods/modules/audit.py
@@ -99,7 +99,6 @@ import salt.loader
 import salt.utils
 import yaml
 
-import hubblestack.extmods.audit.grep
 from distutils.version import StrictVersion
 from hubblestack.status import HubbleStatus
 from salt.exceptions import CommandExecutionError

--- a/hubblestack/extmods/modules/audit.py
+++ b/hubblestack/extmods/modules/audit.py
@@ -212,9 +212,6 @@ def top(topfile=None,
     """
     audit_files = _get_top_data(topfile)
 
-    audit_files = ['salt://hubblestack_audit/' + audit_file.replace('.', '/') + '.yaml'
-                   for audit_file in audit_files]
-
     return audit(audit_files,
                  tags=tags,
                  labels=labels,

--- a/hubblestack/extmods/modules/audit.py
+++ b/hubblestack/extmods/modules/audit.py
@@ -121,13 +121,13 @@ def audit(audit_files=None,
     Execute one or more audit files, and return the cumulative results.
 
     :param audit_files:
-        Which audit files to execute. Can be formed as a string (single file) or
-        as a list (one or more files).
+        Which audit files to execute. Can contain multiple files (list or
+        comma-separated).
     :param tags:
         Can be used to target a subset of tags via glob targeting.
     :param labels:
-        Only run the checks with the given label(s). Can be formed as a string
-        (single label) or a list (one or more labels).
+        Only run the checks with the given label(s). Can contain multiple
+        labels (comma-separated).
     :param verbose:
         True by default. If set to False, results will be trimmed to just tags
         and descriptions.
@@ -145,7 +145,7 @@ def audit(audit_files=None,
         return ret
 
     if not isinstance(audit_files, list):
-        audit_files = [audit_files]
+        audit_files = audit_files.split(',')
 
     audit_files = ['salt://hubblestack_audit/' + audit_file.replace('.', '/') + '.yaml'
                    for audit_file in audit_files]
@@ -153,7 +153,7 @@ def audit(audit_files=None,
     if labels is None:
         labels = []
     if not isinstance(labels, list):
-        labels = [labels]
+        labels = labels.split(',')
 
     for audit_file in audit_files:
         # Cache audit file
@@ -180,15 +180,17 @@ def audit(audit_files=None,
         ret = _run_audit(ret, audit_data, tags, labels, audit_file)
 
     # If verbose=False, reduce each check to a dictionary with {tag: description}
-    if not verbose:
+    if not verbose or verbose == 'False':
         succinct_ret = {'Success': [],
                         'Failure': []}
         for success_type, checks in ret.iteritems():
             for check in checks:
                 succinct_ret[success_type].append({check['tag']: check.get('description', '<no description>')})
 
+        ret = succinct_ret
+
     # Remove successes if show_success is False
-    if not show_success:
+    if not show_success or show_success == 'False':
         ret.pop('Success')
 
     return ret

--- a/hubblestack/extmods/modules/audit.py
+++ b/hubblestack/extmods/modules/audit.py
@@ -412,6 +412,8 @@ def _run_audit(ret, audit_data, tags, labels, audit_file):
 
         if data_dict and isinstance(data_dict, dict):
             data_dict.update(data)
+        else:
+            data_dict = data
 
         if success:
             ret['Success'].append({audit_id: data_dict})

--- a/hubblestack/extmods/modules/audit.py
+++ b/hubblestack/extmods/modules/audit.py
@@ -178,7 +178,7 @@ def audit(audit_files=None,
 
 
 @hubble_status.watch
-def top(topfile=None,
+def top(topfile='salt://hubblestack_audit/top.audit',
         tags='*',
         labels=None,
         verbose=True,

--- a/hubblestack/extmods/modules/audit.py
+++ b/hubblestack/extmods/modules/audit.py
@@ -131,6 +131,8 @@ def audit(audit_files=None,
     audit_files = ['salt://hubblestack_audit/' + audit_file.replace('.', '/') + '.yaml'
                    for audit_file in audit_files]
 
+    if labels is None:
+        labels = []
     if not isinstance(labels, list):
         labels = [labels]
 

--- a/hubblestack/extmods/modules/audit.py
+++ b/hubblestack/extmods/modules/audit.py
@@ -128,13 +128,14 @@ def audit(audit_files=None,
     if not isinstance(audit_files, list):
         audit_files = [audit_files]
 
+    audit_files = ['salt://hubblestack_audit/' + audit_file.replace('.', '/') + '.yaml'
+                   for audit_file in audit_files]
+
     if not isinstance(labels, list):
         labels = [labels]
 
     for audit_file in audit_files:
         # Cache audit file
-        if not audit_file.startswith('salt://'):
-            audit_file = 'salt://' + audit_file
         path = __salt__['cp.cache_file'](audit_file)
 
         # Fileserver will return False if the file is not found

--- a/hubblestack/extmods/modules/audit.py
+++ b/hubblestack/extmods/modules/audit.py
@@ -35,7 +35,6 @@ tag if a tag is not explicitly provided.
         description: <description>
         tag: <tag>  # Uses <id> if not defined
         target: <target>
-        control: <reason>
         labels:
           - <label>
 
@@ -111,15 +110,13 @@ def audit(audit_files=None,
         True by default. If set to False, results will be trimmed to just tags
         and descriptions.
     :param show_success:
-        Whether to show successes and controlled checks, or just failures.
-        Defaults to True
+        Whether to show successes or just failures. Defaults to True
     :return:
-        Returns dictionary with Success, Failure, and Controlled keys and the
-        results of the checks
+        Returns dictionary with Success and Failure keys and the results of the
+        checks
     """
     ret = {'Success': [],
-           'Failure': [],
-           'Control': []}
+           'Failure': []}
 
     if not audit_files:
         LOG.warning('audit.audit called without any audit_files')
@@ -163,16 +160,14 @@ def audit(audit_files=None,
     # If verbose=False, reduce each check to a dictionary with {tag: description}
     if not verbose:
         succinct_ret = {'Success': [],
-                        'Failure': [],
-                        'Control': []}
+                        'Failure': []}
         for success_type, checks in ret.iteritems():
             for check in checks:
                 succinct_ret[success_type].append({check['tag']: check.get('description', '<no description>')})
 
-    # Remove successes and controlled checks if show_success is False
+    # Remove successes if show_success is False
     if not show_success:
         ret.pop('Success')
-        ret.pop('Control')
 
     return ret
 
@@ -207,8 +202,8 @@ def top(topfile='salt://hubblestack_audit/top.audit',
     :param show_success:
         See audit()
     :return:
-        Returns dictionary with Success, Failure, and Controlled keys and the
-        results of the checks
+        Returns dictionary with Success and Failure keys and the results of the
+        checks
     """
     audit_files = _get_top_data(topfile)
 
@@ -308,13 +303,6 @@ def _run_audit(ret, audit_data, tags, labels, audit_file):
         target = data.get('target', '*')
         if not __salt__['match.compound'](target):
             LOG.debug('Skipping audit {0} due to target mismatch: {1}'.format(target))
-            continue
-
-        # Check for control
-        if 'control' in data:
-            LOG.debug('Skipping audit {0} due to control being set with reason {1}'
-                      .format(audit_id, data['control']))
-            ret['Control'].append({audit_id: data})
             continue
 
         args = data.get('args', [])

--- a/hubblestack/extmods/modules/audit.py
+++ b/hubblestack/extmods/modules/audit.py
@@ -1,0 +1,343 @@
+# -*- encoding: utf-8 -*-
+"""
+Audit
+
+This module provides access to an easy format for writing audit checks in
+Hubble.
+
+Audit checks target a specific audit module, such as ``grep`` or ``fdg``. They
+are formed via YAML files in your hubblestack_data source:
+
+.. code-block:: yaml
+
+    CIS-6.2.4:
+      grep.file:
+        args:
+          - /etc/group
+        kwargs:
+          pattern: '^+:'
+          fail_on_match: True
+        description: Ensure no legacy "+" entries exist in /etc/group
+
+All audit checks have a few things in common. They have an ``id``, a ``tag``, a
+``description``, and a ``module.function`` (usually with arguments). The ``id`` will be used as the
+tag if a tag is not explicitly provided.
+
+.. code-block:: yaml
+
+    <id>
+      <module.function>:
+        args:
+          - arg1
+          - arg2
+        kwargs:
+          foo: bar
+        description: <description>
+        tag: <tag>  # Uses <id> if not defined
+        target: <target>
+        control: <reason>
+        labels:
+          - <label>
+
+You may have noticed there are a few more features shown in the example above.
+Here's how they work:
+
+target:
+    Allows you to use a Salt-style compound match to target this check to
+    specific hosts. If a host doesn't match the target, it won't execute the
+    check.
+
+labels:
+    Allows labels to be applied to a check. Labels will be reported in the
+    results, and can also be targeted by audit runs so only checks with a given
+    label will be executed.
+
+Like many pieces of Hubble, you can utilize topfiles to target files with one
+or more audit check to specific sets of hosts. Targeting is done via Salt-style
+compound matching:
+
+.. code-block:: yaml
+
+    audit:
+      '*':
+        - cis.linux
+        - adobebaseline
+      'G@os:CoreOS':
+        - coreos_additional_checks
+
+Audit modules take arbitrary args and kwargs and return a tuple
+``(success, data_dict)`` where ``success`` is a boolean True/False on whether
+it was a success or a failure, and ``data_dict`` is a dictionary of any
+information that should be added to the check's data dictionary in the return.
+"""
+from __future__ import absolute_import
+
+import fnmatch
+import logging
+import os
+import yaml
+
+import hubblestack.extmods.audit.grep
+from hubblestack.status import HubbleStatus
+from salt.exceptions import CommandExecutionError
+
+LOG = logging.getLogger(__name__)
+
+hubble_status = HubbleStatus(__name__, 'top', 'audit')
+
+audit_modules = {
+    'grep.file': hubblestack.extmods.audit.grep.grep
+}
+
+
+@hubble_status.watch
+def audit(audit_files=None,
+          tags='*',
+          labels=None,
+          verbose=True,
+          show_success=True):
+    """
+    Execute one or more audit files, and return the cumulative results.
+
+    :param audit_files:
+        Which audit files to execute. Can be formed as a string (single file) or
+        as a list (one or more files).
+    :param tags:
+        Can be used to target a subset of tags via glob targeting.
+    :param labels:
+        Only run the checks with the given label(s). Can be formed as a string
+        (single label) or a list (one or more labels).
+    :param verbose:
+        True by default. If set to False, results will be trimmed to just tags
+        and descriptions.
+    :param show_success:
+        Whether to show successes and controlled checks, or just failures.
+        Defaults to True
+    :return:
+        Returns dictionary with Success, Failure, and Controlled keys and the
+        results of the checks
+    """
+    ret = {'Success': [],
+           'Failure': [],
+           'Control': []}
+
+    if not audit_files:
+        LOG.warning('audit.audit called without any audit_files')
+        return ret
+
+    if not isinstance(audit_files, list):
+        audit_files = [audit_files]
+
+    if not isinstance(labels, list):
+        labels = [labels]
+
+    for audit_file in audit_files:
+        # Cache audit file
+        if not audit_file.startswith('salt://'):
+            audit_file = 'salt://' + audit_file
+        path = __salt__['cp.cache_file'](audit_file)
+
+        # Fileserver will return False if the file is not found
+        if not path:
+            LOG.error('Could not find audit file {0}'.format(audit_file))
+            continue
+
+        # Load current audit file
+        audit_data = None
+        if os.path.isfile(path):
+            try:
+                with open(path, 'r') as fh:
+                    audit_data = yaml.safe_load(fh)
+            except Exception as e:
+                LOG.exception('Error loading audit file {0}: {1}'.format(audit_file, e))
+                continue
+        if not audit_data or not isinstance(audit_data, dict):
+            LOG.error('audit data from {0} was not formed as a dict'.format(audit_file))
+            continue
+
+        ret = _run_audit(ret, audit_data, tags, labels, audit_file)
+
+    # If verbose=False, reduce each check to a dictionary with {tag: description}
+    if not verbose:
+        succinct_ret = {'Success': [],
+                        'Failure': [],
+                        'Control': []}
+        for success_type, checks in ret.iteritems():
+            for check in checks:
+                succinct_ret[success_type].append({check['tag']: check.get('description', '<no description>')})
+
+    # Remove successes and controlled checks if show_success is False
+    if not show_success:
+        ret.pop('Success')
+        ret.pop('Control')
+
+    return ret
+
+
+@hubble_status.watch
+def top(topfile=None,
+        tags='*',
+        labels=None,
+        verbose=True,
+        show_success=True):
+    """
+    Given a topfile with a series of compound targets, compile a list of audit
+    files for this host and execute and return the results of those audit files.
+
+    .. code-block:: yaml
+
+        audit:
+          '*':
+            - cis.linux
+            - adobebaseline
+          'G@os:CoreOS':
+            - coreos_additional_checks
+
+    :param topfile:
+        Topfile to process for targeted audit files to execute.
+    :param tags:
+        See audit()
+    :param labels:
+        See audit()
+    :param verbose:
+        See audit()
+    :param show_success:
+        See audit()
+    :return:
+        Returns dictionary with Success, Failure, and Controlled keys and the
+        results of the checks
+    """
+    audit_files = _get_top_data(topfile)
+
+    audit_files = ['salt://hubblestack_audit/' + audit_file.replace('.', '/') + '.yaml'
+                   for audit_file in audit_files]
+
+    return audit(audit_files,
+                 tags=tags,
+                 labels=labels,
+                 verbose=verbose,
+                 show_success=show_success,
+                 )
+
+
+def _get_top_data(topfile):
+
+    topfile = __salt__['cp.cache_file'](topfile)
+
+    if not topfile:
+        raise CommandExecutionError('Topfile not found.')
+
+    try:
+        with open(topfile) as handle:
+            topdata = yaml.safe_load(handle)
+    except Exception as e:
+        raise CommandExecutionError('Could not load topfile: {0}'.format(e))
+
+    if not isinstance(topdata, dict) or 'audit' not in topdata or \
+            not isinstance(topdata['audit'], list):
+        raise CommandExecutionError('Audit topfile not formatted correctly.')
+
+    topdata = topdata['audit']
+
+    ret = []
+
+    for topmatch in topdata:
+        for match, data in topmatch.iteritems():
+            if __salt__['match.compound'](match):
+                ret.extend(data)
+
+    return ret
+
+
+def _run_audit(ret, audit_data, tags, labels, audit_file):
+    """
+
+    :param ret:
+        The dictionary of return data from audit()
+    :param audit_data:
+        The audit checks to be run
+    :param tags:
+        See audit()
+    :param labels:
+        See audit()
+    :return:
+        Returns the updated ``ret`` object
+    """
+    for audit_id, data in audit_data.iteritems():
+        LOG.debug('Executing audit id {0} in audit file {1}'.format(audit_id, audit_file))
+        try:
+            module = data.keys()[0]
+            data = data[module]
+            if not isinstance(data, dict):
+                LOG.error('Audit data with id {0} from file {1} not formatted '
+                          'correctly'.format(audit_id, audit_file))
+                continue
+        except (IndexError, NameError) as e:
+            LOG.exception('Audit data with id {0} from file {1} not formatted '
+                          'correctly'.format(audit_id, audit_file))
+            continue
+
+        if module not in audit_modules:
+            LOG.error('Audit module {0} not found'.format(module))
+            continue
+
+        tag = data.get('tag', audit_id)
+        data['tag'] = tag
+        data['id'] = audit_id
+        data['file'] = audit_file
+        label_list = data.get('labels', [])
+
+        # Process tags via globbing
+        if not fnmatch.fnmatch(tag, tags):
+            LOG.debug('Skipping audit {0} due to tag {1} not matching tags {2}'
+                      .format(audit_id, tag, tags))
+            continue
+
+        # Process labels
+        matching_label = False
+        if not labels:
+            matching_label = True
+        for label in labels:
+            if label in label_list:
+                matching_label = True
+        if not matching_label:
+            LOG.debug('Skipping audit {0} due to no matching labels {1} in label list {2}'
+                      .format(audit_id, labels, label_list))
+            continue
+
+        # Process target
+        target = data.get(target, '*')
+        if not __salt__['match.compound'](target):
+            LOG.debug('Skipping audit {0} due to target mismatch: {1}'.format(target))
+            continue
+
+        # Check for control
+        if 'control' in data:
+            LOG.debug('Skipping audit {0} due to control being set with reason {1}'
+                      .format(audit_id, data['control']))
+            ret['Control'].append({audit_id: data})
+            continue
+
+        args = data.get('args', [])
+        kwargs = data.get('kwargs', {})
+
+        # Run the audit
+        try:
+            success, data_dict = audit_modules[module](*args, **kwargs)
+        except Exception as e:
+            LOG.error('Audit {0} from file {1} failed with exception {2}'
+                      .format(audit_id, audit_file, e))
+            data['reason'] = 'exception'
+            data['exception'] = str(e)
+            ret['Failure'].append({audit_id: data})
+            continue
+
+        if data_dict and isinstance(data_dict, dict):
+            data_dict.update(data)
+
+        if success:
+            ret['Success'].append({audit_id: data_dict})
+        else:
+            ret['Failure'].append({audit_id: data_dict})
+
+    return ret

--- a/hubblestack/extmods/modules/audit.py
+++ b/hubblestack/extmods/modules/audit.py
@@ -306,7 +306,7 @@ def _run_audit(ret, audit_data, tags, labels, audit_file):
             continue
 
         # Process target
-        target = data.get(target, '*')
+        target = data.get('target', '*')
         if not __salt__['match.compound'](target):
             LOG.debug('Skipping audit {0} due to target mismatch: {1}'.format(target))
             continue

--- a/hubblestack/extmods/modules/audit.py
+++ b/hubblestack/extmods/modules/audit.py
@@ -130,7 +130,8 @@ def audit(audit_files=None,
         Can be used to target a subset of tags via glob targeting.
     :param labels:
         Only run the checks with the given label(s). Can contain multiple
-        labels (comma-separated).
+        labels (comma-separated). If multiple labels are provided, a check
+        with any label in the list will be run.
     :param verbose:
         True by default. If set to False, results will be trimmed to just tags
         and descriptions.


### PR DESCRIPTION
The new audit module shares a lot with the previous generation (nova). I cut out a few things that I don't think were getting much use (like controlled checks and compliance % calculations). If we decide we have uses for them, they would be pretty trivially easy to add to the new module.

I also added a couple of new features, `target` and `version`. Check out the docs in audit.py to get a feel for how they work, and keep me posted if you have any questions.

So far I have only ported a single module to the new system, grep.py. As you can see, the actual audit modules themselves are *vastly* simplified compared to nova. Porting the rest of them should be pretty trivial.

***

Two other missing pieces:

* Code to convert the old profiles to the new format. This code will be module-specific (grep checks will need different logic thank pkg checks, for example). I'm hopeful I can write something for grep next week.
* New audit returner. Honestly this should be pretty easy to whip up so I figured spending time on it in my remaining days was low priority. I think @Tenebriso or @jettero could whip this up in no time.

***

You may notice the lack of `nova_loader.py`. For this initial pass I decided to try it out without dynamic loading. Thus the manual process of registering audit functions in the global `audit_modules` dictionary. This has some drawbacks, like the lack of `__salt__` and `__grains__` in the underlying modules. However, without having to dynamically load the yaml files, I could probably follow the pattern I used in FDG to load these modules dynamically with an unmodified loader. I may do that this afternoon, but wanted to get this up for review now.

Edit: Turns out adding the loader was super easy. See new commit for the difference.