### PR TITLE
from hubblestack.extmods.fdg.process import encode_base64 issues …

### DIFF
--- a/hubblestack/extmods/fdg/process.py
+++ b/hubblestack/extmods/fdg/process.py
@@ -8,11 +8,10 @@ the data outputted by a module to serve it to another module.
 """
 from __future__ import absolute_import
 
-import base64
 import logging
 import re
 
-import salt.ext.six as six
+from hubblestack.utils.encoding import encode_base64 as utils_encode_base64
 from salt.exceptions import ArgumentValueError
 
 LOG = logging.getLogger(__name__)
@@ -643,21 +642,5 @@ def encode_base64(starting_string, format_chained=True, chained=None, chained_st
 
     The first return value (status) will be False only if an error will occur.
     """
-    if format_chained:
-        try:
-            starting_string = starting_string.format(chained)
-        except AttributeError:
-            LOG.error("Invalid type for starting_string - has to be string.", exc_info=True)
-            return False, None
-    if not isinstance(starting_string, str):
-        LOG.error('Invalid arguments - starting_string should be a string')
-        return False, None
-    # compatbility with python2 & 3
-    if six.PY3:
-        ret = base64.b64encode(bytes(starting_string, 'utf-8'))
-        # convert from bytes to str
-        ret = ret.decode('ascii')
-    else:
-        ret = base64.b64encode(starting_string)
-
-    return bool(ret), ret
+    return utils_encode_base64(starting_string, format_chained=format_chained,
+        chained=chained, chained_status=chained_status)

--- a/hubblestack/extmods/fdg/readfile.py
+++ b/hubblestack/extmods/fdg/readfile.py
@@ -14,7 +14,7 @@ import re
 
 import yaml as _yaml
 
-from hubblestack.extmods.fdg.process import encode_base64
+from . process import encode_base64
 
 LOG = logging.getLogger(__name__)
 

--- a/hubblestack/extmods/fdg/readfile.py
+++ b/hubblestack/extmods/fdg/readfile.py
@@ -14,7 +14,7 @@ import re
 
 import yaml as _yaml
 
-from . process import encode_base64
+from hubblestack.utils.encoding import encode_base64
 
 LOG = logging.getLogger(__name__)
 

--- a/hubblestack/utils/encoding.py
+++ b/hubblestack/utils/encoding.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import base64
+import salt.ext.six as six
+
+def encode_base64(starting_string, format_chained=True, chained=None, chained_status=None):
+    """
+    Given a string, base64 encode it and return it.
+
+    By default, ``starting_string`` will have ``.format()`` called on it
+    with ``chained`` as the only argument. (So, use ``{0}`` in your pattern to
+    substitute the chained value.) If you want to avoid having to escape curly braces,
+    set ``format_chained=False``.
+
+    chained_status
+        Status returned by the chained method.
+
+    The first return value (status) will be False only if an error will occur.
+    """
+    if format_chained:
+        try:
+            starting_string = starting_string.format(chained)
+        except AttributeError:
+            LOG.error("Invalid type for starting_string - has to be string.", exc_info=True)
+            return False, None
+    if not isinstance(starting_string, str):
+        LOG.error('Invalid arguments - starting_string should be a string')
+        return False, None
+    # compatbility with python2 & 3
+    if six.PY3:
+        ret = base64.b64encode(bytes(starting_string, 'utf-8'))
+        # convert from bytes to str
+        ret = ret.decode('ascii')
+    else:
+        ret = base64.b64encode(starting_string)
+
+    return bool(ret), ret

--- a/hubblestack/utils/encoding.py
+++ b/hubblestack/utils/encoding.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
 # coding: utf-8
 
+import logging
 import base64
 import salt.ext.six as six
+
+log = logging.getLogger(__name__)
 
 def encode_base64(starting_string, format_chained=True, chained=None, chained_status=None):
     """
@@ -22,10 +25,10 @@ def encode_base64(starting_string, format_chained=True, chained=None, chained_st
         try:
             starting_string = starting_string.format(chained)
         except AttributeError:
-            LOG.error("Invalid type for starting_string - has to be string.", exc_info=True)
+            log.error("Invalid type for starting_string - has to be string.", exc_info=True)
             return False, None
     if not isinstance(starting_string, str):
-        LOG.error('Invalid arguments - starting_string should be a string')
+        log.error('Invalid arguments - starting_string should be a string')
         return False, None
     # compatbility with python2 & 3
     if six.PY3:


### PR DESCRIPTION
from hubblestack.extmods.fdg.process import encode_base64 is fine if you're
running a source install but if the live readfile.py is in /var/cache, this
causes an import problem.

Let's try using local import from process (which should be near to readfile.py
either in /var/cache or in $LIBDIR/hubblestack/extmods/fdg