### PR TITLE
variadic args fixes

### DIFF
--- a/hubblestack/extmods/fdg/grep.py
+++ b/hubblestack/extmods/fdg/grep.py
@@ -38,7 +38,7 @@ def file(path, pattern, grep_args=None, format_chained=True, chained=None, chain
         path = path.format(chained)
     if grep_args is None:
         grep_args = []
-    ret = _grep(pattern=pattern, path=path, *grep_args)
+    ret = _grep(pattern, path=path, args=grep_args)
     status = bool(ret)
 
     return status, ret
@@ -73,16 +73,13 @@ def stdin(pattern, starting_string=None, grep_args=None,
 
     if grep_args is None:
         grep_args = []
-    ret = _grep(pattern=pattern, string=chained, *grep_args)
+    ret = _grep(pattern, string=chained, args=grep_args)
     status = bool(ret)
 
     return status, ret
 
 
-def _grep(pattern,
-          path=None,
-          string=None,
-          *args):
+def _grep(pattern, path=None, string=None, args=None):
     """
     Grep for a string in the specified file or string
 
@@ -105,7 +102,7 @@ def _grep(pattern,
         String to search
 
     args
-        Additional command-line flags to pass to the grep command. For example:
+        Optionally pass a list of flags to pass to the grep command. For example:
         ``-v`` or ``-i`` or ``-B2``
 .. note::
             The options should come after a double-dash (as shown in the
@@ -117,9 +114,9 @@ def _grep(pattern,
     .. code-block:: bash
 
         salt '*' file.grep /etc/passwd nobody
-        salt '*' file.grep /etc/sysconfig/network-scripts/ifcfg-eth0 ipaddr -- -i
-        salt '*' file.grep /etc/sysconfig/network-scripts/ifcfg-eth0 ipaddr -- -i -B2
-        salt '*' file.grep "/etc/sysconfig/network-scripts/*" ipaddr -- -i -l
+        salt '*' file.grep /etc/sysconfig/network-scripts/ifcfg-eth0 ipaddr '[-i, -B2]'
+        salt '*' file.grep /etc/sysconfig/network-scripts/ifcfg-eth0 ipaddr '[-i, -B2]'
+        salt '*' file.grep "/etc/sysconfig/network-scripts/*" ipaddr '[-i, -B2]'
     """
     if path:
         path = os.path.expanduser(path)

--- a/hubblestack/extmods/fdg/osquery.py
+++ b/hubblestack/extmods/fdg/osquery.py
@@ -53,10 +53,10 @@ def query(query_sql, osquery_args=None, osquery_path=None,
     if osquery_args is None:
         osquery_args = []
 
-    return _osquery(query_sql, *osquery_args, osquery_path=osquery_path)
+    return _osquery(query_sql, args=osquery_args, osquery_path=osquery_path)
 
 
-def _osquery(query_sql, osquery_path=None, *args):
+def _osquery(query_sql, osquery_path=None, args=None):
     """
     Format the osquery command and run it
 
@@ -82,7 +82,8 @@ def _osquery(query_sql, osquery_path=None, *args):
             LOG.error('osquery binary not found: %s', osquery_path)
             return False, ''
         cmd = [osquery_path, '--read_max', max_file_size, '--json', query_sql]
-    cmd.extend(args)
+    if isinstance(args, (list,tuple)):
+        cmd.extend(args)
 
     # Run the command
     res = __salt__['cmd.run_all'](cmd, timeout=10000, python_shell=False)


### PR DESCRIPTION
py2 was particularly bad with args, kwargs and *args (particularly mixtures of them). They mostly fixed that in 3.0, but for now, It's best to just remove the variadic args to keep from confusing the args population.

* fixed in fdg/grep.py
* fixed in fdg/osquery.py