### PR TITLE
Adding support for overriding splunk configuration via global parameters

### DIFF
--- a/conf/hubble
+++ b/conf/hubble
@@ -132,6 +132,13 @@ fileserver_backend:
 ## In order for the sample scheduler config to work, you must configure the
 ## returners which are being used. In the case of the Splunk returners, you
 ## must add index, token, and endpoint information
+## this can be specified in the hubblestack:returner:splunk space or can be overridden
+## overriding can be done using the 'splunk_index', 'splunk_token' and 'splunk_port' as shown below
+## whenever overriding make sure that both index and token are specified or not specified at all
+
+#splunk_token: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+#splunk_index: hubble
+#splunk_port: 8088
 
 #hubblestack:
 #  returner:

--- a/hubblestack/hec/opt.py
+++ b/hubblestack/hec/opt.py
@@ -84,9 +84,8 @@ def _get_splunk_options(space, modality, **kw):
                 if j in final_opts:
                     # if j is one of the args that can be overridden and has been provided then do not update it
                     if j in {'token', 'index', 'port'}:
-                        if not bool(confg("splunk_" + j, None)):
+                        if not confg("splunk_" + j, None):
                             final_opts[j] = opt[k]
-                            # print final_opts
                     else:
                         final_opts[j] = opt[k]
 
@@ -139,17 +138,16 @@ def get_splunk_options(*spaces, **kw):
        get_splunk_options(sourcetype_nebula='blah', _nick={'sourcetype_nebula': 'sourcetype'})
        [ { ... 'sourcetype': 'hubble_osquery' ... } ]
     """
-    ret = []
     if not spaces:
         spaces = ['hubblestack:returner:splunk']
 
     for space in spaces:
         for modality in MODALITIES:
             ret = _get_splunk_options(space, modality, **copy.deepcopy(kw))
-            # if ret:
-            #     return ret
+            if ret:
+                return ret
 
-    return ret
+    return []
 
 def make_hec_args(opts):
     if isinstance(opts, (tuple,list)):

--- a/hubblestack/hec/opt.py
+++ b/hubblestack/hec/opt.py
@@ -83,7 +83,7 @@ def _get_splunk_options(space, modality, **kw):
                 j = nicknames.get(k, k)
                 if j in final_opts:
                     # if j is one of the args that can be overridden and has been provided then do not update it
-                    if j in {'token', 'index', 'port'}:
+                    if j in options_for_grains_config:
                         if not confg("splunk_" + j, None):
                             final_opts[j] = opt[k]
                     else:

--- a/hubblestack/hec/opt.py
+++ b/hubblestack/hec/opt.py
@@ -40,7 +40,7 @@ def _get_splunk_options(space, modality, **kw):
     # both index and token must be specified if at all overriding in /etc/hubble/hubble
     # is taking place using the variables splunk_token and splunk_index
 
-    if bool(confg('splunk_token', None)) != bool(confg('splunk_index', None)):
+    if bool(confg('splunk_token', "").strip()) != bool(confg('splunk_index', "").strip()):
         raise Exception('Both index and token must be specified together or not '
                         'specified at all in case of overriding')
 
@@ -84,7 +84,7 @@ def _get_splunk_options(space, modality, **kw):
                 if j in final_opts:
                     # if j is one of the args that can be overridden and has been provided then do not update it
                     if j in options_for_grains_config:
-                        if not confg("splunk_" + j, None):
+                        if not confg("splunk_" + j, "").strip():
                             final_opts[j] = opt[k]
                     else:
                         final_opts[j] = opt[k]

--- a/hubblestack/hec/opt.py
+++ b/hubblestack/hec/opt.py
@@ -40,9 +40,18 @@ def _get_splunk_options(space, modality, **kw):
     # both index and token must be specified if at all overriding in /etc/hubble/hubble
     # is taking place using the variables splunk_token and splunk_index
 
-    if bool(confg('splunk_token', "").strip()) != bool(confg('splunk_index', "").strip()):
+    if bool(confg('splunk_token', None)) != bool(confg('splunk_index', None)):
         raise Exception('Both index and token must be specified together or not '
                         'specified at all in case of overriding')
+
+    if confg('splunk_token', None) and not str(confg('splunk_token', None)).strip():
+        raise Exception('splunk_token cannot be an empty field')
+
+    if confg('splunk_index', None) and not str(confg('splunk_index', None)).strip():
+        raise Exception('splunk_index cannot be an empty field')
+
+    if confg('splunk_port', None) and not str(confg('splunk_port', None)).strip():
+        raise Exception('splunk_port cannot be an empty field')
 
     # additionally overriding can be carried out using 'splunk_index', 'splunk_token' and 'splunk_port'
     # in the /etc/hubble/hubble file
@@ -84,7 +93,7 @@ def _get_splunk_options(space, modality, **kw):
                 if j in final_opts:
                     # if j is one of the args that can be overridden and has been provided then do not update it
                     if j in options_for_grains_config:
-                        if not confg("splunk_" + j, "").strip():
+                        if not confg("splunk_" + j, None):
                             final_opts[j] = opt[k]
                     else:
                         final_opts[j] = opt[k]

--- a/hubblestack/log.py
+++ b/hubblestack/log.py
@@ -12,7 +12,7 @@ import copy
 import hubblestack.splunklogging
 
 # These patterns will not be logged by "conf_publisher" and "emit_to_splunk"
-PATTERNS_TO_FILTER = ["password", "token", "passphrase", "privkey", "keyid", "s3.key"]
+PATTERNS_TO_FILTER = ["password", "token", "passphrase", "privkey", "keyid", "s3.key", "splunk_token"]
 
 # While hubble doesn't use these, salt modules can, so let's define them anyway
 SPLUNK = logging.SPLUNK = 25


### PR DESCRIPTION
Initially the user had to provide the whole block of parameters in /etc/hubble/hubble.d/user.config with a format similar to the default config block in /etc/hubble/hubble. Now the user can specify only the index, token and port in /etc/hubble/hubble using the global parameters splunk_token, splunk_index and splunk_port. These options will be given priority over the hubblestack:returner:splunk block. Index and token must be specified together or not at all.