### PR TITLE
`log = logging.getLogger(__name__)`

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -637,7 +637,9 @@ good-names=i,
            k,
            ex,
            Run,
-           _
+           _,
+           log
+
 
 # Include a hint for the correct naming format with invalid-name
 include-naming-hint=no


### PR DESCRIPTION
I know all the globals should be allcaps, but as long as I've been writing programs, allcaps has meant "constant" not "global".

I've seen `log = logging.getLogger(__name__)` as a global a billion times. I've never seen it as `LOG`. I think that's just a side effect of the pylint defaults.

I'm wondering if there's other things we should consider changing in the pylintrc.