### PR TITLE
Enabling hubble service post install on systemd init

### DIFF
--- a/conf/afterinstall-systemd.sh
+++ b/conf/afterinstall-systemd.sh
@@ -1,2 +1,3 @@
 systemctl daemon-reload
+systemctl enable hubble
 service hubble start

--- a/conf/afterupgrade-systemd.sh
+++ b/conf/afterupgrade-systemd.sh
@@ -1,2 +1,3 @@
 systemctl daemon-reload
+systemctl enable hubble
 service hubble restart


### PR DESCRIPTION
Hubble service is disabled on few operating systems post install. If instances restart, then user needs to explicitly start the Hubble service.