### PR TITLE
CPU improvements in diskqueue pop()/get()/put()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,7 @@ relevant-files.txt
 
 # PyCharm project
 .idea/
+
+# sometimes when I stop docker with a sigquit, hubble drops core (??)
+core
+core.*

--- a/hubblestack/hec/dq.py
+++ b/hubblestack/hec/dq.py
@@ -212,9 +212,11 @@ class DiskQueue(OKTypesMixin):
     def pop(self):
         """ remove the next item from the queue (do not return it); useful with .peek() """
         for fname in self.files:
+            sz = os.stat(fname).st_size
             self.unlink_(fname)
+            self.cn -= 1
+            self.sz -= sz
             break
-        self._count()
 
     @property
     def files(self):

--- a/hubblestack/hec/dq.py
+++ b/hubblestack/hec/dq.py
@@ -128,11 +128,13 @@ class DiskQueue(OKTypesMixin):
         f = os.path.join(d, remainder)
         with open(f, 'wb') as fh:
             log.debug('writing item to disk cache')
-            fh.write(self.compress(item))
+            bstr = self.compress(item)
+            fh.write(bstr)
         if meta:
             with open(f + '.meta', 'w') as fh:
                 json.dump(meta, fh)
-        self._count()
+        self.cn += 1
+        self.sz += len(bstr)
 
     def read_meta(self, fname):
         try:

--- a/hubblestack/hec/dq.py
+++ b/hubblestack/hec/dq.py
@@ -162,8 +162,10 @@ class DiskQueue(OKTypesMixin):
             with open(fname, 'rb') as fh:
                 ret = self.decompress(fh.read())
             ret = ret, self.read_meta(fname)
+            sz = os.stat(fname).st_size
             self.unlink_(fname)
-            self._count()
+            self.cn -= 1
+            self.sz -= sz
             return ret
 
     def getz(self, sz=SPLUNK_MAX_MSG):

--- a/hubblestack/hec/dq.py
+++ b/hubblestack/hec/dq.py
@@ -123,14 +123,14 @@ class DiskQueue(OKTypesMixin):
             if given, it will write to a meta data file describing the entry.
         """
         self.check_type(item)
-        if not self.accept(item):
+        bstr = self.compress(item)
+        if not self.accept(bstr):
             raise QueueCapacityError('refusing to accept item due to size')
         fanout, remainder = self._fanout('{0}.{1}'.format(int(time.time()), self.cn))
         d = self._mkdir(fanout)
         f = os.path.join(d, remainder)
         with open(f, 'wb') as fh:
             log.debug('writing item to disk cache')
-            bstr = self.compress(item)
             fh.write(bstr)
         if meta:
             with open(f + '.meta', 'w') as fh:

--- a/tests/unittests/test_hec_dq.py
+++ b/tests/unittests/test_hec_dq.py
@@ -46,3 +46,14 @@ def _test_pop(samp,q):
 
 def test_dq_pop(samp,dq):
     _test_pop(samp,dq)
+
+def test_disk_queue_put_estimator():
+    dq = DiskQueue(TEST_DQ_DIR, fresh=True)
+    for item in ['hi-there-{}'.format(x) for x in range(20)]:
+        pre = dq.cn, dq.sz
+        dq.put(item)
+        post = dq.cn, dq.sz
+        assert (pre[0]+1, pre[1]+len(item)) == post
+        dq._count()
+        more = dq.cn, dq.sz
+        assert post == more


### PR DESCRIPTION
I was experimenting with semi-large queues and discovered that the O(n²) operation of counting the disk usage on every `pop()` is (gasp) expensive. Probably estimating the disk queue size on a `pop()` will rarely ever matter, and probably saves us a ton of CPU time.

In fact, we can do roughly the same thing to `get()` and `put()`.

We leave counting disk space completely to `__init__()` and `getz()` — `getz()` gets as many messages as will fit in the splunk max message size.