### PR TITLE
add logging for invalid/expired splunk tokens

### DIFF
--- a/hubblestack/hec/obj.py
+++ b/hubblestack/hec/obj.py
@@ -427,6 +427,9 @@ class HEC(object):
                 possible_queue = True
                 # If Splunk said it doesn't want this message, increment the opinion counter
                 meta_data['bad_request'] += 1
+            elif r.status == 403:
+                log.error('invalid or expired token (%d %s)', r.status, r.reason)
+                possible_queue = True
 
         # if we get here and something above thinks a queue is a good idea
         # then queue it! \o/


### PR DESCRIPTION
When hubble receives 403 from Splunk HEC the issue is hard to discover through the logs (debug level).
According to the docs, that would be an expired/invalid token and needs appropriate logging.
https://docs.splunk.com/Documentation/Splunk/latest/Data/TroubleshootHTTPEventCollector#Possible_error_codes