### PR TITLE
fix: sourcetype = 'hubble_fdg_' + fdg_file

### DIFF
--- a/hubblestack/extmods/returners/splunk_fdg_return.py
+++ b/hubblestack/extmods/returners/splunk_fdg_return.py
@@ -43,7 +43,7 @@ gateway is not defined.
               - product_group
 """
 import socket
-
+import re
 import json
 import logging
 from hubblestack.hec import http_event_collector, get_splunk_options, make_hec_args
@@ -186,7 +186,15 @@ def _generate_payload(args, fdg_args, cloud_details, opts, index_extracted_field
     fdg_file = fdg_file.lower().replace(' ', '_')
     payload = {'host': args['fqdn'], 'index': opts['index']}
     if opts['add_query_to_sourcetype']:
-        payload.update({'sourcetype': "%s_%s" % (opts['sourcetype'], fdg_file)})
+        extended_sourcetype = fdg_file
+        if extended_sourcetype.startswith('salt://'):
+            extended_sourcetype = extended_sourcetype[6:]
+        if extended_sourcetype.startswith('/fdg/'):
+            extended_sourcetype = extended_sourcetype[5:]
+        if extended_sourcetype.endswith('.fdg'):
+            extended_sourcetype = extended_sourcetype[:-4]
+        extended_sourcetype = re.sub(r'[^\w\d]+', '_', extended_sourcetype)
+        payload.update({'sourcetype': "%s_%s" % (opts['sourcetype'], extended_sourcetype)})
     else:
         payload.update({'sourcetype': opts['sourcetype']})
 

--- a/hubblestack/extmods/returners/splunk_fdg_return.py
+++ b/hubblestack/extmods/returners/splunk_fdg_return.py
@@ -188,6 +188,8 @@ def _file_url_to_sourcetype(filename, base='hubble_fdg'):
     """
     if re.search(r'^\w+://', filename):
         filename = filename.split('://', 1)[1]
+    if base.endswith('_fdg') and filename.startswith('fdg/'):
+        filename = filename[4:]
     if re.search(r'\.fdg$', filename):
         filename = filename[:-4]
     def _no_dups(x):

--- a/hubblestack/extmods/returners/splunk_fdg_return.py
+++ b/hubblestack/extmods/returners/splunk_fdg_return.py
@@ -192,14 +192,10 @@ def _file_url_to_sourcetype(filename, base='hubble_fdg'):
         filename = filename[:-4]
     def _no_dups(x):
         sf = re.split(r'[^a-zA-Z0-9]+', x)
-        last = None
         for item in sf:
-            if item == last:
-                continue
             if not item:
                 continue
             yield item
-            last = item
     return '_'.join( _no_dups(base + '_' + filename) )
 
 def _generate_payload(args, fdg_args, cloud_details, opts, index_extracted_fields):

--- a/hubblestack/extmods/returners/splunk_fdg_return.py
+++ b/hubblestack/extmods/returners/splunk_fdg_return.py
@@ -177,6 +177,14 @@ def _build_args(ret):
 
     return args
 
+def _file_url_to_sourcetype_tag(filename):
+    if filename.startswith('salt://'):
+        filename = filename[7:]
+    if filename.startswith('fdg/'):
+        filename = filename[4:]
+    if filename.endswith('.fdg'):
+        filename = filename[:-4]
+    return re.sub(r'[^\w\d]+', '_', filename)
 
 def _generate_payload(args, fdg_args, cloud_details, opts, index_extracted_fields):
     """
@@ -186,15 +194,10 @@ def _generate_payload(args, fdg_args, cloud_details, opts, index_extracted_field
     fdg_file = fdg_file.lower().replace(' ', '_')
     payload = {'host': args['fqdn'], 'index': opts['index']}
     if opts['add_query_to_sourcetype']:
-        extended_sourcetype = fdg_file
-        if extended_sourcetype.startswith('salt://'):
-            extended_sourcetype = extended_sourcetype[6:]
-        if extended_sourcetype.startswith('/fdg/'):
-            extended_sourcetype = extended_sourcetype[5:]
-        if extended_sourcetype.endswith('.fdg'):
-            extended_sourcetype = extended_sourcetype[:-4]
-        extended_sourcetype = re.sub(r'[^\w\d]+', '_', extended_sourcetype)
-        payload.update({'sourcetype': "%s_%s" % (opts['sourcetype'], extended_sourcetype)})
+
+        payload.update({'sourcetype': "{sourcetype}_{extension}".format(
+            sourcetype=opts['sourcetype'],
+            extension=_file_url_to_sourcetype_tag(fdg_file))})
     else:
         payload.update({'sourcetype': opts['sourcetype']})
 

--- a/hubblestack/extmods/returners/splunk_fdg_return.py
+++ b/hubblestack/extmods/returners/splunk_fdg_return.py
@@ -182,7 +182,7 @@ def _file_url_to_sourcetype(filename, base='hubble_fdg'):
         e.g.:
         'salt://fdg/interesting.operation.fdg'
         becomes
-        'interesting_operation'
+        base + '_' + 'interesting_operation'
         (intended for internal use by _generate_payload() to append to the
         default sourcetype)
     """

--- a/hubblestack/extmods/returners/splunk_fdg_return.py
+++ b/hubblestack/extmods/returners/splunk_fdg_return.py
@@ -178,6 +178,14 @@ def _build_args(ret):
     return args
 
 def _file_url_to_sourcetype_tag(filename):
+    """ attempt to turn a file URL into a sourcetype extension description
+        e.g.:
+        'salt://fdg/interesting.operation.fdg'
+        becomes
+        'interesting_operation'
+        (intended for internal use by _generate_payload() to append to the
+        default sourcetype)
+    """
     if filename.startswith('salt://'):
         filename = filename[7:]
     if filename.startswith('fdg/'):

--- a/tests/unittests/test_fdg_sourcetypes.py
+++ b/tests/unittests/test_fdg_sourcetypes.py
@@ -9,7 +9,7 @@ def test01():
         https://github.com/hubblestack/hubble/pull/738
     Here are the discussed items:
     """
-    assert sfr._file_url_to_sourcetype('salt://fdg/test.fdg') == 'hubble_fdg_test'
-    assert sfr._file_url_to_sourcetype('salt://////fdg///////test.fdg') == 'hubble_fdg_test'
+    assert sfr._file_url_to_sourcetype('salt://fdg/test.fdg') == 'hubble_fdg_fdg_test'
+    assert sfr._file_url_to_sourcetype('salt://////fdg///////test.fdg') == 'hubble_fdg_fdg_test'
     assert sfr._file_url_to_sourcetype('/tmp/file/a/b/c/test.fdg') == 'hubble_fdg_tmp_file_a_b_c_test'
     assert sfr._file_url_to_sourcetype('/opt/tmpfdg_test/2fdg_cert_test.fdg') == 'hubble_fdg_opt_tmpfdg_test_2fdg_cert_test'

--- a/tests/unittests/test_fdg_sourcetypes.py
+++ b/tests/unittests/test_fdg_sourcetypes.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import hubblestack.extmods.returners.splunk_fdg_return as sfr
+
+def test01():
+    """
+    Exactly how to resolve these sourcetypes caused some discussion:
+        https://github.com/hubblestack/hubble/pull/738
+    Here are the discussed items:
+    """
+    assert sfr._file_url_to_sourcetype('salt://fdg/test.fdg') == 'hubble_fdg_test'
+    assert sfr._file_url_to_sourcetype('salt://////fdg///////test.fdg') == 'hubble_fdg_test'
+    assert sfr._file_url_to_sourcetype('/tmp/file/a/b/c/test.fdg') == 'hubble_fdg_tmp_file_a_b_c_test'
+    assert sfr._file_url_to_sourcetype('/opt/tmpfdg_test/2fdg_cert_test.fdg') == 'hubble_fdg_opt_tmpfdg_test_2fdg_cert_test'

--- a/tests/unittests/test_fdg_sourcetypes.py
+++ b/tests/unittests/test_fdg_sourcetypes.py
@@ -9,7 +9,7 @@ def test01():
         https://github.com/hubblestack/hubble/pull/738
     Here are the discussed items:
     """
-    assert sfr._file_url_to_sourcetype('salt://fdg/test.fdg') == 'hubble_fdg_fdg_test'
+    assert sfr._file_url_to_sourcetype('salt://fdg/test.fdg') == 'hubble_fdg_test'
     assert sfr._file_url_to_sourcetype('salt://////fdg///////test.fdg') == 'hubble_fdg_fdg_test'
     assert sfr._file_url_to_sourcetype('/tmp/file/a/b/c/test.fdg') == 'hubble_fdg_tmp_file_a_b_c_test'
     assert sfr._file_url_to_sourcetype('/opt/tmpfdg_test/2fdg_cert_test.fdg') == 'hubble_fdg_opt_tmpfdg_test_2fdg_cert_test'


### PR DESCRIPTION
Apparently we do want to extend the sourcetype name from `hubble_fdg` to `hubble_fdg_filename` but let's choose to do that without the `salt://` protocol and without the `.fdg` file extension; while we're at it, make sure to replace all non alphanumerics with an underscore.