### PR TITLE
instruct pyinstaller to include encoding utils

### DIFF
--- a/pkg/hook-hubblestack.py
+++ b/pkg/hook-hubblestack.py
@@ -34,6 +34,11 @@ HIDDEN_IMPORTS = [
     'azure.storage.blob',
     'croniter',
     'vulners',
+
+    # fdg readfile.json tries to absolute import a module during lazy load. Too
+    # late for the packer to notice it should be packed in the binary.
+    # marking it here for "hidden import"
+    'hubblestack.utils.encoding',
 ]
 DATAS = []
 binaries = []


### PR DESCRIPTION
pyinstaller only installs package deps for items that are imported at initial runtime

The workaround is to specify packages for "hidden import"; they get packed into the binary so later when `fdg/readfile.py` is lazy loaded, it can still absolute import `hubblestack.utils.encoding`

I tested this by building my own el7 rpm without the hidden import (readfile.json crashes) and with the hidden import (readfile.json functions).