### PR TITLE
platform.linux_distribution() & platform.dist() replaced with distro.linux_distribution()

### DIFF
--- a/hubblestack/files/hubblestack_nova/grep.py
+++ b/hubblestack/files/hubblestack_nova/grep.py
@@ -175,7 +175,7 @@ def audit(data_list, tags, labels, debug=False, **kwargs):
                 if not os.path.exists(name) and 'match_on_file_missing' in tag_data:
                     if tag_data['match_on_file_missing']:
                         found = True
-                        failure_reason = "Found the file '{0}'. This blaclisted file " \
+                        failure_reason = "Found the file '{0}'. This blacklisted file " \
                                          "should not exist.".format(name)
                     else:
                         found = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 ntplib
+distro
 pyinstaller==3.3.1
 Crypto
 pyopenssl>=16.2.0

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,14 @@ distro, version, _ = platform.dist()
 if not distro:
     distro, version, _ = platform.linux_distribution(supported_dists=['system'])
 
-# Default to cent7
+    if not distro:
+        try:
+            import distro
+            distro, version, _ = distro.linux_distribution(full_distribution_name=False)
+        except ModuleNotFoundError:
+            distro = version = ''
+
+# Default to CentOS7
 data_files = [('/usr/lib/systemd/system', ['pkg/source/hubble.service']),
               ('/etc/hubble', ['conf/hubble']), ]
 

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,11 @@
 from setuptools import setup, find_packages
-import platform
 import re
 
-distro, version, _ = platform.dist()
-if not distro:
-    distro, version, _ = platform.linux_distribution(supported_dists=['system'])
-
-    if not distro:
-        try:
-            import distro
-            distro, version, _ = distro.linux_distribution(full_distribution_name=False)
-        except ModuleNotFoundError:
-            distro = version = ''
+try:
+    import distro
+    distro, version, _ = distro.linux_distribution(full_distribution_name=False)
+except ModuleNotFoundError:
+    distro = version = ''
 
 # Default to CentOS7
 data_files = [('/usr/lib/systemd/system', ['pkg/source/hubble.service']),


### PR DESCRIPTION
Python 3.5 deprecated platform.linux_distribution() and the distro package is the recommended replacement. Its predecessor function platform.dist() was already deprecated since Python 2.6 and both will be removed in Python 3.8. More information can be found [here](https://bugs.python.org/issue1322)