### PR TITLE
adding support for IMDSv2 for aws

### DIFF
--- a/hubblestack/extmods/grains/cloud_details.py
+++ b/hubblestack/extmods/grains/cloud_details.py
@@ -36,8 +36,13 @@ def _get_aws_details():
     proxies = { 'http': None }
 
     try:
+        ttl_header = {'X-aws-ec2-metadata-token-ttl-seconds': '300'}
+        token_url = 'http://169.254.169.254/latest/api/token'
+        token_request = requests.put(token_url, headers=ttl_header, timeout=3, proxies=proxies)
+        token = token_request.text
+        aws_token_header = {'X-aws-ec2-metadata-token': token}
         res = requests.get('http://169.254.169.254/latest/dynamic/instance-identity/document',
-                            timeout=3, proxies=proxies).json()
+                            headers=aws_token_header, timeout=3, proxies=proxies).json()
         aws['cloud_account_id'] = res.get('accountId', 'unknown')
 
         # AWS account id is always an integer number
@@ -46,7 +51,7 @@ def _get_aws_details():
         int(aws['cloud_account_id'])
 
         aws['cloud_instance_id'] = requests.get('http://169.254.169.254/latest/meta-data/instance-id',
-                                                timeout=3, proxies=proxies).text
+                                                headers=aws_token_header, timeout=3, proxies=proxies).text
     except (requests.exceptions.RequestException, ValueError):
         # Not on an AWS box
         aws = None
@@ -57,13 +62,13 @@ def _get_aws_details():
             aws_extra['cloud_availability_zone'] = res.get('availabilityZone')
             aws_extra['cloud_ami_id'] = res.get('imageId')
             aws_extra['cloud_region'] = res.get('region')
-            r = requests.get('http://169.254.169.254/latest/meta-data/public-hostname', timeout=3, proxies=proxies)
+            r = requests.get('http://169.254.169.254/latest/meta-data/public-hostname', headers=aws_token_header, timeout=3, proxies=proxies)
             if r.status_code == requests.codes.ok:
                 aws_extra['cloud_public_hostname'] = r.text
-            r = requests.get('http://169.254.169.254/latest/meta-data/public-ipv4', timeout=3, proxies=proxies)
+            r = requests.get('http://169.254.169.254/latest/meta-data/public-ipv4', headers=aws_token_header, timeout=3, proxies=proxies)
             if r.status_code == requests.codes.ok:
                 aws_extra['cloud_public_ipv4'] = r.text
-            r = requests.get('http://169.254.169.254/latest/meta-data/local-hostname', timeout=3, proxies=proxies)
+            r = requests.get('http://169.254.169.254/latest/meta-data/local-hostname', headers=aws_token_header, timeout=3, proxies=proxies)
             if r.status_code == requests.codes.ok:
                 aws_extra['cloud_private_hostname'] = r.text
             for key in aws_extra.keys():


### PR DESCRIPTION
IMDSv2 requires a session-based token to authenticate to the metadata service. Hubble will now generate a token and use it to fetch metadata values.