### PR TITLE
wrong path hacking in test files

### DIFF
--- a/tests/unittests/test_grep_nova.py
+++ b/tests/unittests/test_grep_nova.py
@@ -1,7 +1,4 @@
-import sys
 import os
-myPath = os.path.abspath(os.getcwd())
-sys.path.insert(0, myPath)
 import hubblestack.files.hubblestack_nova.grep
 
 

--- a/tests/unittests/test_nebula_osquery.py
+++ b/tests/unittests/test_nebula_osquery.py
@@ -1,10 +1,6 @@
-import sys
 import os
 import json
 import pytest
-
-myPath = os.path.abspath(os.getcwd())
-sys.path.insert(0, myPath)
 
 __salt__ = None
 

--- a/tests/unittests/test_pkg_nova.py
+++ b/tests/unittests/test_pkg_nova.py
@@ -1,7 +1,4 @@
-import sys
 import os
-myPath = os.path.abspath(os.getcwd())
-sys.path.insert(0, myPath)
 import hubblestack.files.hubblestack_nova.pkg
 
 

--- a/tests/unittests/test_process.py
+++ b/tests/unittests/test_process.py
@@ -1,12 +1,8 @@
 from __future__ import absolute_import
 
 import os
-import sys
 import pytest
 from collections import defaultdict
-
-myPath = os.path.abspath(os.getcwd())
-sys.path.insert(0, myPath)
 
 from salt.exceptions import ArgumentValueError
 import hubblestack.extmods.fdg.process

--- a/tests/unittests/test_process_status.py
+++ b/tests/unittests/test_process_status.py
@@ -2,10 +2,6 @@ from __future__ import absolute_import
 
 import mock
 import os
-import sys
-
-myPath = os.path.abspath(os.getcwd())
-sys.path.insert(0, myPath)
 
 import hubblestack.extmods.fdg.process_status
 

--- a/tests/unittests/test_pulsar.py
+++ b/tests/unittests/test_pulsar.py
@@ -1,7 +1,4 @@
-import sys
 import os
-myPath = os.path.abspath(os.getcwd())
-sys.path.insert(0, myPath)
 import hubblestack.extmods.modules.pulsar as pulsar
 from salt.exceptions import CommandExecutionError
 

--- a/tests/unittests/test_readfile.py
+++ b/tests/unittests/test_readfile.py
@@ -2,12 +2,9 @@ from __future__ import absolute_import
 
 import json
 import os
-import sys
 import yaml
 import pytest
 
-myPath = os.path.abspath(os.getcwd())
-sys.path.insert(0, myPath)
 import hubblestack.extmods.fdg.readfile
 
 

--- a/tests/unittests/test_ssl_certificate.py
+++ b/tests/unittests/test_ssl_certificate.py
@@ -1,10 +1,7 @@
 # coding: utf-8
-import sys
 import os
 import ssl
 import mock
-myPath = os.path.abspath(os.getcwd())
-sys.path.insert(0, myPath)
 import hubblestack.extmods.fdg.ssl_certificate
 
 

--- a/tests/unittests/test_stat_nova.py
+++ b/tests/unittests/test_stat_nova.py
@@ -1,7 +1,4 @@
-import sys
 import os
-myPath = os.path.abspath(os.getcwd())
-sys.path.insert(0, myPath)
 import hubblestack.files.hubblestack_nova.stat_nova
 
 

--- a/tests/unittests/test_time_sync.py
+++ b/tests/unittests/test_time_sync.py
@@ -2,10 +2,6 @@ from __future__ import absolute_import
 
 import mock
 import os
-import sys
-
-myPath = os.path.abspath(os.getcwd())
-sys.path.insert(0, myPath)
 import hubblestack.extmods.fdg.time_sync
 
 class TestTimesync():


### PR DESCRIPTION
First of all, you're not supposed to modify the path in your tests. There's a discussion on the pytest site about it... https://docs.pytest.org/en/latest/pythonpath.html#invoking-pytest-versus-python-m-pytest

Second, we do this in conftest anyway (even though we really shouldn't):

https://github.com/hubblestack/hubble/blob/develop/tests/unittests/conftest.py#L21

Lastly, if you really don't want to have to tyep `python  -m pytest tests/unittests` or whatever, you can use pytest-pythonpath (see comment in pytest.ini 

We should really remove the sys.path hackery from confest too, but ... this small step is just the right thing to do