### PR TITLE
Fim single file

### DIFF
--- a/hubblestack/extmods/modules/pulsar.py
+++ b/hubblestack/extmods/modules/pulsar.py
@@ -837,7 +837,6 @@ def process(configfile='salt://hubblestack_pulsar/hubblestack_pulsar_config.yaml
         dt.mark('update_watches')
         log.debug("update watches")
         # Update existing watches and add new ones
-        # TODO: make the config handle more options
         for path in config:
             excludes = lambda x: False
             if path in ['return', 'checksum', 'stats', 'batch', 'verbose',

--- a/hubblestack/extmods/modules/pulsar.py
+++ b/hubblestack/extmods/modules/pulsar.py
@@ -32,7 +32,8 @@ import salt.utils.platform
 try:
     import pyinotify
     HAS_PYINOTIFY = True
-    DEFAULT_MASK = pyinotify.IN_CREATE | pyinotify.IN_DELETE | pyinotify.IN_MODIFY
+    DEFAULT_MASK = pyinotify.IN_CREATE | pyinotify.IN_DELETE | pyinotify.IN_DELETE_SELF | pyinotify.IN_MODIFY
+    RM_WATCH_MASK = pyinotify.IN_DELETE | pyinotify.IN_DELETE_SELF | pyinotify.IN_IGNORED
     MASKS = {}
     for var in dir(pyinotify):
         if var.startswith('IN_'):
@@ -72,6 +73,18 @@ def _enqueue(revent):
     Enqueue the event
     """
     __context__['pulsar.queue'].append(revent)
+
+def _maskname_filter(name):
+    """ deleting a directly watched file produces IN_DELETE_SELF (not
+        IN_DELETE) and also kicks up a an IN_IGNORED (whether you mask for it
+        or not) to indicate the file is nolonger watched.
+
+        We avoid returning IN_IGNORED if we can... but IN_DELETE_SELF is
+        corrected to IN_DELETE
+    """
+    if name == 'IN_DELETE_SELF':
+        return 'IN_DELETE'
+    return name
 
 class ConfigManager(object):
     _config = {}
@@ -360,9 +373,9 @@ class PulsarWatchManager(pyinotify.WatchManager):
             kw['rec'] = kw.get('rec')
             if kw['rec'] is None:
                 kw['rec'] = pconf['recurse']
-            self.add_watch(path,mask,**kw)
-            log.debug('add-watch wd={0} path={1} watch_files={2} recurse={3}'.format(
-                self.watch_db.get(path), path, pconf['watch_files'], kw['rec']))
+            self.add_watch(path, mask, **kw)
+            log.debug('add-watch wd={0} path={1} watch_files={2} recurse={3} mask={4}'.format(
+                self.watch_db.get(path), path, pconf['watch_files'], kw['rec'], mask))
 
         if new_file: # process() says this is a new file
             self._add_recursed_file_watch(path)
@@ -770,10 +783,11 @@ def process(configfile='salt://hubblestack_pulsar/hubblestack_pulsar_config.yaml
 
             excludes = _preprocess_excludes( config[cpath].get('exclude') )
             _append = not excludes(pathname)
+
             if _append:
                 config_path = config['paths'][0]
                 pulsar_config = config_path[config_path.rfind('/') + 1:len(config_path)]
-                sub = { 'change': event.maskname,
+                sub = { 'change': _maskname_filter(event.maskname),
                         'path': abspath,  # goes to object_path in splunk
                         'tag':  dirname,  # goes to file_path in splunk
                         'name': basename, # goes to file_name in splunk
@@ -814,9 +828,8 @@ def process(configfile='salt://hubblestack_pulsar/hubblestack_pulsar_config.yaml
                     if os.path.isfile(pathname):
                         sub['size'] = os.path.getsize(pathname)
 
-
-
-                ret.append(sub)
+                if event.mask != pyinotify.IN_IGNORED:
+                    ret.append(sub)
 
                 if not event.mask & pyinotify.IN_ISDIR:
                     if event.mask & pyinotify.IN_CREATE:
@@ -824,10 +837,10 @@ def process(configfile='salt://hubblestack_pulsar/hubblestack_pulsar_config.yaml
                             or config[cpath].get('watch_files', False)
                         if watch_this:
                             if not excludes(pathname):
-                                log.debug("add file-watch path={0}".format(pathname))
+                                log.debug("add file-watch path={0} mask={1}".format(pathname,
+                                    pyinotify.IN_MODIFY))
                                 wm.watch(pathname, pyinotify.IN_MODIFY, new_file=True)
-
-                    elif event.mask & pyinotify.IN_DELETE:
+                    elif event.mask & RM_WATCH_MASK:
                         wm.rm_watch(pathname)
             else:
                 log.debug('Excluding {0} from event for {1}'.format(pathname, cpath))
@@ -845,22 +858,18 @@ def process(configfile='salt://hubblestack_pulsar/hubblestack_pulsar_config.yaml
                 continue
             if isinstance(config[path], dict):
                 mask = config[path].get('mask', DEFAULT_MASK)
-             ## commented out on 2019-08-05
-             #  watch_files = config[path].get('watch_files', DEFAULT_MASK)
-             ## note: it seems like the below was commented out because the above seems to be bugged
-             ## clearly watch_files should default to False, not DEFAULT_MASK
-             ## (aka true); that probably seemd like spurious watches from ##
-             ## duplications or whatever caused the below to be commented out.
-             ## Regardless, the above is probably wrong *and* seems unused.
-             ## commented out previous to 2019-08-05
-             #  if watch_files:
-             #      # we're going to get dup modify events if watch_files is set
-             #      # and we still monitor modify for the dir
-             #      a = mask & pyinotify.IN_MODIFY
-             #      if a:
-             #          log.debug("mask={0} -= mask & pyinotify.IN_MODIFY={1} ==> {2}".format(
-             #              mask, a, mask-a))
-             #          mask -= mask & pyinotify.IN_MODIFY
+                watch_files = config[path].get('watch_files', False)
+                if watch_files:
+                    # we're going to get dup modify events if watch_files is set
+                    # and we still monitor modify for the dir
+                    mask_and_modify = mask & pyinotify.IN_MODIFY
+                    if mask_and_modify:
+                        log.debug("mask={0} -= mask & pyinotify.IN_MODIFY={1}" \
+                            " ==> {2}".format(
+                                mask,
+                                mask_and_modify,
+                                mask-mask_and_modify))
+                        mask -= mask_and_modify
                 excludes = _preprocess_excludes( config[path].get('exclude') )
                 if isinstance(mask, list):
                     r_mask = 0
@@ -878,7 +887,32 @@ def process(configfile='salt://hubblestack_pulsar/hubblestack_pulsar_config.yaml
                 rec = False
                 auto_add = False
 
+            if os.path.isfile(path) and not wm.get_wd(path):
+                # We were not previously watching this file generate a fake
+                # IN_CREATE to announce this fact.  We'd like to only generate
+                # CREATE events when files are created, but we can't actually
+                # watch files that don't exist yet (not with inotify anyway).
+                # The kernel would rather be watching directories anyway.
+                #
+                # You might worry we'll get lots of spurious IN_CREATEs when
+                # the database is cleared or at startup or whatever.  We
+                # actually watch everyhthing from config at startup anyway; so
+                # we avoid these fake IN_CREATE events at startup. They only
+                # happen when we add a watch during update, which means the
+                # file really is new since the last time we thought about it
+                # (aka the last time we ran the process() function).
+                _, abspath, dirname, basename = cm.format_path(path)
+                config_path = config['paths'][0]
+                pulsar_config = config_path[config_path.rfind('/') + 1:len(config_path)]
+                fake_sub = { 'change': 'IN_CREATE',
+                        'path': abspath,  # goes to object_path in splunk
+                        'tag':  dirname,  # goes to file_path in splunk
+                        'name': basename, # goes to file_name in splunk
+                        'pulsar_config': pulsar_config}
+                ret.append(fake_sub)
+
             wm.watch(path, mask, rec=rec, auto_add=auto_add, exclude_filter=excludes)
+
         dt.fin()
         dt.mark('prune_watches')
         wm.prune()

--- a/tests/unittests/test_pulsar.py
+++ b/tests/unittests/test_pulsar.py
@@ -1,3 +1,7 @@
+"""
+Test the fim (pulsar) internals for various correctness
+"""
+
 import os
 import shutil
 import logging
@@ -8,14 +12,8 @@ import hubblestack.extmods.modules.pulsar as pulsar
 
 log = logging.getLogger(__name__)
 
-if os.environ.get('DEBUG_SHOW_PULSAR_LOGS'):
-    import logging
-    root_logger = logging.getLogger()
-    ch = logging.StreamHandler()
-    ch.setLevel(logging.DEBUG)
-    root_logger.addHandler(ch)
-
-class TestPulsar():
+class TestPulsar(object):
+    """ An older set of pulsar tests """
 
     def test_virtual(self):
         var = pulsar.__virtual__()
@@ -77,8 +75,10 @@ class TestPulsar():
         configfile = 'tests/unittests/resources/hubblestack_pulsar_config.yaml'
         verbose = False
 
-        def config_get(value, default):
+        def config_get(_, default):
+            ''' pretend salt[config.get] '''
             return default
+
         __salt__ = {}
         __salt__['config.get'] = config_get
         pulsar.__salt__ = __salt__
@@ -92,11 +92,14 @@ class TestPulsar():
     def test_top_result_for_list(self):
         topfile = 'tests/unittests/resources/top.pulsar'
 
-        def cp_cache_file(value):
+        def cp_cache_file(_):
+            ''' pretend salt[cp.cache_file] '''
             return 'tests/unittests/resources/top.pulsar'
 
         def match_compound(value):
+            ''' pretend match.compound '''
             return value
+
         __salt__ = {}
         __salt__['cp.cache_file'] = cp_cache_file
         __salt__['match.compound'] = match_compound
@@ -110,10 +113,13 @@ class TestPulsar():
         topfile = 'tests/unittests/resources/top.pulsar'
 
         def cp_cache_file(topfile):
+            ''' pretend salt[cp.cache_file] '''
             return topfile
 
         def match_compound(value):
+            ''' pretend match.compound '''
             return value
+
         __salt__ = {}
         __salt__['cp.cache_file'] = cp_cache_file
         __salt__['match.compound'] = match_compound
@@ -126,11 +132,14 @@ class TestPulsar():
     def test_get_top_data_for_CommandExecutionError(self):
         topfile = '/testfile'
 
-        def cp_cache_file(topfile):
+        def cp_cache_file(_):
+            ''' pretend salt[cp.cache_file] '''
             return '/testfile'
 
         def match_compound(value):
+            ''' pretend match.compound '''
             return value
+
         __salt__ = {}
         __salt__['cp.cache_file'] = cp_cache_file
         __salt__['match.compound'] = match_compound
@@ -141,14 +150,17 @@ class TestPulsar():
         except CommandExecutionError:
             pass
 
-class TestPulsar2():
+class TestPulsar2(object):
+    """ A slightly newer set of pulsar internals tets """
+
     tdir   = 'blah'
     tfile  = os.path.join(tdir, 'file')
     atdir  = os.path.abspath(tdir)
     atfile = os.path.abspath(tfile)
 
     def reset(self, **kwargs):
-        def config_get(value, default):
+        def config_get(_, default):
+            ''' pretend salt[config.get] '''
             return default
 
         if 'paths' not in kwargs:
@@ -158,18 +170,18 @@ class TestPulsar2():
         __salt__['config.get'] = config_get
         pulsar.__salt__ = __salt__
         pulsar.__opts__ = {'pulsar': kwargs}
-        pulsar.__context__ = c = {}
+        pulsar.__context__ = {}
         self.nuke_tdir()
 
         pulsar._get_notifier() # sets up the dequeue
 
         self.events = []
-        self.N = c['pulsar.notifier']
-        self.watch_manager = self.N._watch_manager
+        self.notifier = pulsar.__context__['pulsar.notifier']
+        self.watch_manager = self.notifier._watch_manager
         self.watch_manager.update_config()
 
     def process(self):
-        self.events.extend([ "{change}(path)".format(**x) for x in pulsar.process() ])
+        self.events.extend([ "{change}({path})".format(**x) for x in pulsar.process() ])
 
     def nuke_tdir(self):
         if os.path.isdir(self.tdir):
@@ -184,7 +196,7 @@ class TestPulsar2():
             fh.write(to_write)
 
     def mk_subdir_files(self, *files, **kwargs):
-        if len(files) == 1 and isinstance(files[0], (list,tuple)):
+        if len(files) == 1 and isinstance(files[0], (list, tuple)):
             files = files[0]
         for file in files:
             file = file if file.startswith(self.tdir + '/') else os.path.join(self.tdir, file)
@@ -193,7 +205,7 @@ class TestPulsar2():
                 output_fname = split_file.pop()
                 dir_to_make = ''
                 for i in split_file:
-                    dir_to_make = os.path.join(dir_to_make,i)
+                    dir_to_make = os.path.join(dir_to_make, i)
                     if not os.path.isdir(i):
                         os.mkdir(dir_to_make)
                 forms = ('{}_out', 'out_{}', '{}_to_write', 'to_write')
@@ -218,28 +230,33 @@ class TestPulsar2():
                 fh.write(to_write.format(count))
 
     def test_listify_anything(self):
-        la = pulsar.PulsarWatchManager._listify_anything
-        def lla(x,e):
-            assert len( la(x) ) == e
-        def sla(x,e):
-            assert str(sorted(la(x))) == str(sorted(e))
-        lla(None, 0)
-        lla([None], 0)
-        lla(set([None]), 0)
-        lla(set(), 0)
-        lla([], 0)
-        lla([[],[],(),{},None,[None]], 0)
+        listify_fn = pulsar.PulsarWatchManager._listify_anything
 
-        m = [[1],[2],(1,),(5),{2},None,[None],{'one':1}]
-        lla(m, 4)
-        sla(m, [1,2,5,'one'])
+        def assert_len_listify_is(list_arg, expected):
+            """ compact comparifier """
+            assert len( listify_fn(list_arg) ) == expected
+
+        def assert_str_listify_is(list_arg, expected):
+            """ compact comparifier """
+            assert str(sorted(listify_fn(list_arg))) == str(sorted(expected))
+
+        assert_len_listify_is(None, 0)
+        assert_len_listify_is([None], 0)
+        assert_len_listify_is(set([None]), 0)
+        assert_len_listify_is(set(), 0)
+        assert_len_listify_is([], 0)
+        assert_len_listify_is([[],[],(),{}, None,[None]], 0)
+
+        oogly_list = [[1],[2],(1,),(5),{2}, None,[None],{'one':1}]
+        assert_len_listify_is(oogly_list, 4)
+        assert_str_listify_is(oogly_list, [1,2,5,'one'])
 
     def test_add_watch(self, modality='add-watch'):
-        o = {}
-        kwargs = { self.atdir: o }
+        options = {}
+        kwargs = { self.atdir: options }
 
         if modality in ('watch_new_files', 'watch_files'):
-            o[modality] = True
+            options[modality] = True
 
         self.reset(**kwargs)
 
@@ -287,100 +304,153 @@ class TestPulsar2():
         self.test_add_watch(modality='watch_new_files')
 
     def test_recurse_without_watch_files(self):
-        c1 = {self.atdir: { 'recurse': False }}
-        c2 = {self.atdir: { 'recurse': True  }}
+        config1 = {self.atdir: { 'recurse': False }}
+        config2 = {self.atdir: { 'recurse': True  }}
 
-        self.reset(**c1)
+        self.reset(**config1)
         self.mk_subdir_files('blah1','a/b/c/blah2')
         self.watch_manager.watch(self.tdir)
         self.watch_manager.prune()
-        s1 = set(self.watch_manager.watch_db)
+        set1 = set(self.watch_manager.watch_db)
 
-        self.reset(**c2)
+        self.reset(**config2)
         self.mk_subdir_files('blah1','a/b/c/blah2')
         self.watch_manager.watch(self.tdir)
         self.watch_manager.prune()
-        s2 = set(self.watch_manager.watch_db)
+        set2 = set(self.watch_manager.watch_db)
 
-        s0a = set([self.atdir])
-        s0b = [self.atdir]
+        set0_a = set([self.atdir])
+        set0_b = [self.atdir]
         for i in 'abc':
-            s0b.append( os.path.join(s0b[-1], i) )
-        s0b = set(s0b)
+            set0_b.append( os.path.join(set0_b[-1], i) )
+        set0_b = set(set0_b)
 
-        assert s1 == s0a
-        assert s2 == s0b
+        assert set1 == set0_a
+        assert set2 == set0_b
 
     def config_make_files_watch_process_reconfig(self, config, reconfig=None, mk_files=0):
         """
             create a config (arg0),
             make tdir and tfile,
             watch the tdir,
-            store watch_db in s0,
+            store watch_db in set0,
             make additional files (default: 0),
             execute process(),
-            store watch_db in s1,
+            store watch_db in set1,
             reconfigure using reconfig param (named param or arg1) (default: None)
             execute process(),
-            store watch_db in s2
-            return s0, s1, s2 as a tuple
+            store watch_db in set2
+            return set0, set1, set2 as a tuple
         """
         self.reset(**config)
         self.mk_tdir_and_write_tfile()
         self.watch_manager.watch(self.tdir)
-        s0 = set(self.watch_manager.watch_db)
+        set0 = set(self.watch_manager.watch_db)
         if mk_files > 0:
             self.mk_more_files(count=mk_files)
         self.process()
-        s1 = set(self.watch_manager.watch_db)
+        set1 = set(self.watch_manager.watch_db)
         if reconfig is None:
             del self.watch_manager.cm.nc_config[ self.atdir ]
         else:
             self.watch_manager.cm.nc_config[ self.atdir ] = reconfig
         self.process()
-        s2 = set(self.watch_manager.watch_db)
-        return s0,s1,s2
+        set2 = set(self.watch_manager.watch_db)
+        return set0, set1, set2
 
     def test_pruning_watch_files_false(self):
-        s0,s1,s2 = self.config_make_files_watch_process_reconfig({self.atdir:{}}, None, mk_files=2)
-        assert s0 == set([self.atdir])
-        assert s1 == set([self.atdir])
-        assert s2 == set()
+        set0, set1, set2 = self.config_make_files_watch_process_reconfig({self.atdir:{}}, None, mk_files=2)
+        assert set0 == set([self.atdir])
+        assert set1 == set([self.atdir])
+        assert set2 == set()
 
     def test_pruning_watch_new_files_then_false(self):
-        c1 = {self.atdir: { 'watch_new_files': True }}
-        c2 = {self.atdir: { 'watch_new_files': False }}
-        s0,s1,s2 = self.config_make_files_watch_process_reconfig(c1,c2, mk_files=2)
-        f1 = self.more_fname(0, base=self.atfile)
-        f2 = self.more_fname(1, base=self.atfile)
-        assert s0 == set([self.atdir])
-        assert s1 == set([self.atdir, f1, f2])
-        assert s2 == set([self.atdir])
+        config1 = {self.atdir: { 'watch_new_files': True }}
+        config2 = {self.atdir: { 'watch_new_files': False }}
+        set0, set1, set2 = self.config_make_files_watch_process_reconfig(config1, config2, mk_files=2)
+        fname1 = self.more_fname(0, base=self.atfile)
+        fname2 = self.more_fname(1, base=self.atfile)
+        assert set0 == set([self.atdir])
+        assert set1 == set([self.atdir, fname1, fname2])
+        assert set2 == set([self.atdir])
 
     def test_pruning_watch_files_then_false(self):
-        c1 = {self.atdir: { 'watch_files': True }}
-        c2 = {self.atdir: { 'watch_files': False }}
-        s0,s1,s2 = self.config_make_files_watch_process_reconfig(c1,c2, mk_files=2)
-        f1 = self.more_fname(0, base=self.atfile)
-        f2 = self.more_fname(1, base=self.atfile)
-        assert s0 == set([self.atdir, self.atfile])
-        assert s1 == set([self.atdir, self.atfile, f1, f2])
-        assert s2 == set([self.atdir])
+        config1 = {self.atdir: { 'watch_files': True }}
+        config2 = {self.atdir: { 'watch_files': False }}
+        set0, set1, set2 = self.config_make_files_watch_process_reconfig(config1, config2, mk_files=2)
+        fname1 = self.more_fname(0, base=self.atfile)
+        fname2 = self.more_fname(1, base=self.atfile)
+        assert set0 == set([self.atdir, self.atfile])
+        assert set1 == set([self.atdir, self.atfile, fname1, fname2])
+        assert set2 == set([self.atdir])
 
     def test_pruning_watch_new_files_then_nothing(self):
-        c1 = {self.atdir: { 'watch_new_files': True }}
-        s0,s1,s2 = self.config_make_files_watch_process_reconfig(c1,None, mk_files=2)
-        f1 = self.more_fname(0, base=self.atfile)
-        f2 = self.more_fname(1, base=self.atfile)
-        assert s0 == set([self.atdir])
-        assert s1 == set([self.atdir, f1, f2])
-        assert s2 == set()
+        config1 = {self.atdir: { 'watch_new_files': True }}
+        set0, set1, set2 = self.config_make_files_watch_process_reconfig(config1, None, mk_files=2)
+        fname1 = self.more_fname(0, base=self.atfile)
+        fname2 = self.more_fname(1, base=self.atfile)
+        assert set0 == set([self.atdir])
+        assert set1 == set([self.atdir, fname1, fname2])
+        assert set2 == set()
 
     def test_pruning_watch_files_then_nothing(self):
-        c1 = {self.atdir: { 'watch_files': True }}
-        s0,s1,s2 = self.config_make_files_watch_process_reconfig(c1,None, mk_files=2)
-        f1 = self.more_fname(0, base=self.atfile)
-        f2 = self.more_fname(1, base=self.atfile)
-        assert s0 == set([self.atdir, self.atfile])
-        assert s1 == set([self.atdir, f1, f2, self.atfile])
-        assert s2 == set()
+        config1 = {self.atdir: { 'watch_files': True }}
+        set0, set1, set2 = self.config_make_files_watch_process_reconfig(config1, None, mk_files=2)
+        fname1 = self.more_fname(0, base=self.atfile)
+        fname2 = self.more_fname(1, base=self.atfile)
+        assert set0 == set([self.atdir, self.atfile])
+        assert set1 == set([self.atdir, fname1, fname2, self.atfile])
+        assert set2 == set()
+
+    def test_fim_single_file(self):
+        config = {self.atfile: {}}
+        self.reset(**config)
+        self.mk_tdir_and_write_tfile()
+        self.watch_manager.watch(self.tfile)
+
+        set0 = set(self.watch_manager.watch_db)
+        levents0 = len(self.events)
+        # we should be watching 1 file, no events
+
+        self.process()
+        set1 = set(self.watch_manager.watch_db)
+        levents1 = len(self.events)
+        # we should be watching 1 file, no events
+
+        with open(self.atfile, 'a') as fh:
+            fh.write('supz\n')
+
+        self.process()
+        set2 = set(self.watch_manager.watch_db)
+        levents2 = len(self.events)
+        # we should still be watching 1 file, 1 event
+
+        os.unlink(self.atfile)
+
+        self.process()
+        set3 = set(self.watch_manager.watch_db)
+        levents3 = len(self.events)
+        # we should now be watching 0 files, 2 events
+
+        assert levents0 == 0
+        assert levents1 == 0
+        assert levents2 == 1
+        assert levents3 == 2
+        assert set0 == set([self.atfile])
+        assert set1 == set([self.atfile])
+        assert set2 == set([self.atfile])
+        assert set3 == set()
+        ### BASELINE ###
+
+        # the relevant connundrum: if we put the file back, this config should
+        # somehow know to re-watch the atfile
+        # at the time of this writing, this test fails
+        with open(self.atfile, 'a') as fh:
+            fh.write('supz\n')
+
+        self.process()
+        set4 = set(self.watch_manager.watch_db)
+        levents4 = len(self.events)
+
+        assert set4 == set([self.atfile])
+        assert levents4 == 3 # XXX: 4? CREATE? CREATE_MODIFY? CREATE+MODIFY??


### PR DESCRIPTION
If we watch a single file with pulsar ... we may forget to watch it again later... we may miss events relating to the file...

This attempts to address all those problems.

Note that in any case it's impossible to watch a file that's not there using inotify (kernel stuff). So if we're not watching a file, we have to notice on the next `process()` pass and the best we can do is generate a pretend IN_CREATE event.