### PR TITLE
S3 fix limit

### DIFF
--- a/hubblestack/extmods/fileserver/s3fs.py
+++ b/hubblestack/extmods/fileserver/s3fs.py
@@ -356,10 +356,10 @@ def _init():
     """
     cache_file = _get_buckets_cache_filename()
     s3_key_kwargs = _get_s3_key()
-    cache_expire_time = s3_key_kwargs['cache_expire'] if s3_key_kwargs.get('cache_expire', None) else S3_CACHE_EXPIRE
-    exp = time.time() - float(cache_expire_time)
+    cache_expire_time = float(s3_key_kwargs['cache_expire'] if s3_key_kwargs.get('cache_expire', None) else S3_CACHE_EXPIRE)
+    exp = time.time() - cache_expire_time
 
-    log.info('S3 cache expire time is {}s'.format(cache_expire_time))
+    log.info('S3 cache expire time is %ds', cache_expire_time)
     # check mtime of the buckets files cache
     metadata = None
     try:
@@ -445,7 +445,7 @@ def _refresh_buckets_cache_file(cache_file):
                                         https_enable=s3_key_kwargs['https_enable'],
                                         params={'marker': marker})
             if not tmp:
-                return
+                return None
 
             headers = []
             for header in tmp:

--- a/hubblestack/extmods/fileserver/s3fs.py
+++ b/hubblestack/extmods/fileserver/s3fs.py
@@ -349,6 +349,7 @@ def _get_s3_key():
 
     return ret
 
+
 def _init():
     """
     Connect to S3 and download the metadata for each file in all buckets
@@ -359,7 +360,7 @@ def _init():
     cache_expire_time = float(s3_key_kwargs['cache_expire'] if s3_key_kwargs.get('cache_expire', None) else S3_CACHE_EXPIRE)
     exp = time.time() - cache_expire_time
 
-    log.info('S3 cache expire time is %ds', cache_expire_time)
+    log.debug('S3 cache expire time is %ds', cache_expire_time)
     # check mtime of the buckets files cache
     metadata = None
     try:

--- a/hubblestack/extmods/fileserver/s3fs.py
+++ b/hubblestack/extmods/fileserver/s3fs.py
@@ -103,7 +103,7 @@ from salt.ext.six.moves.urllib.parse import quote as _quote
 
 log = logging.getLogger(__name__)
 
-S3_CACHE_EXPIRE = 30  # cache for 30 seconds
+S3_CACHE_EXPIRE = 3600  # cache for 30 minutes
 S3_SYNC_ON_UPDATE = True  # sync cache on update rather than jit
 
 
@@ -333,6 +333,7 @@ def _get_s3_key():
         'service_url': None,
         'keyid': None,
         'key': None,
+        'cache_expire': None
     }
 
     ret = dict()
@@ -354,8 +355,11 @@ def _init():
     specified and cache the data to disk.
     """
     cache_file = _get_buckets_cache_filename()
-    exp = time.time() - S3_CACHE_EXPIRE
+    s3_key_kwargs = _get_s3_key()
+    cache_expire_time = s3_key_kwargs['cache_expire'] if s3_key_kwargs.get('cache_expire', None) else S3_CACHE_EXPIRE
+    exp = time.time() - float(cache_expire_time)
 
+    log.info('S3 cache expire time is {}s'.format(cache_expire_time))
     # check mtime of the buckets files cache
     metadata = None
     try:
@@ -440,6 +444,9 @@ def _refresh_buckets_cache_file(cache_file):
                                         path_style=s3_key_kwargs['path_style'],
                                         https_enable=s3_key_kwargs['https_enable'],
                                         params={'marker': marker})
+            if not tmp:
+                return
+
             headers = []
             for header in tmp:
                 if 'Key' in header:

--- a/hubblestack/extmods/fileserver/s3fs.py
+++ b/hubblestack/extmods/fileserver/s3fs.py
@@ -356,8 +356,7 @@ def _init():
     specified and cache the data to disk.
     """
     cache_file = _get_buckets_cache_filename()
-    s3_key_kwargs = _get_s3_key()
-    cache_expire_time = float(s3_key_kwargs['cache_expire'] if s3_key_kwargs.get('cache_expire', None) else S3_CACHE_EXPIRE)
+    cache_expire_time = float(_get_s3_key().get('cache_expire', S3_CACHE_EXPIRE))
     exp = time.time() - cache_expire_time
 
     log.debug('S3 cache expire time is %ds', cache_expire_time)

--- a/hubblestack/extmods/fileserver/s3fs.py
+++ b/hubblestack/extmods/fileserver/s3fs.py
@@ -103,7 +103,7 @@ from salt.ext.six.moves.urllib.parse import quote as _quote
 
 log = logging.getLogger(__name__)
 
-S3_CACHE_EXPIRE = 3600  # cache for 30 minutes
+S3_CACHE_EXPIRE = 1800  # cache for 30 minutes
 S3_SYNC_ON_UPDATE = True  # sync cache on update rather than jit
 
 

--- a/hubblestack/extmods/fileserver/s3fs.py
+++ b/hubblestack/extmods/fileserver/s3fs.py
@@ -333,7 +333,7 @@ def _get_s3_key():
         'service_url': None,
         'keyid': None,
         'key': None,
-        'cache_expire': None
+        'cache_expire': S3_CACHE_EXPIRE,
     }
 
     ret = dict()
@@ -356,7 +356,7 @@ def _init():
     specified and cache the data to disk.
     """
     cache_file = _get_buckets_cache_filename()
-    cache_expire_time = float(_get_s3_key().get('cache_expire', S3_CACHE_EXPIRE))
+    cache_expire_time = float(_get_s3_key().get('cache_expire'))
     exp = time.time() - cache_expire_time
 
     log.debug('S3 cache expire time is %ds', cache_expire_time)

--- a/hubblestack/extmods/utils/s3.py
+++ b/hubblestack/extmods/utils/s3.py
@@ -250,6 +250,9 @@ def query(key, keyid, method='GET', params=None, headers=None,
         return 'Saved to local file: {0}'.format(local_file)
 
     if result.status_code < 200 or result.status_code >= 300:
+        if err_code == 'SlowDown':
+            log.warning('{}, {}'.format(err_code, err_msg))
+            return
         raise CommandExecutionError(
             'Failed s3 operation. {0}: {1}'.format(err_code, err_msg))
 

--- a/hubblestack/extmods/utils/s3.py
+++ b/hubblestack/extmods/utils/s3.py
@@ -17,6 +17,7 @@ except ImportError:
     HAS_REQUESTS = False  # pylint: disable=W0612
 
 # Import Salt libs
+import os
 import salt.utils.aws
 import salt.utils.files
 import salt.utils.hashutils
@@ -202,6 +203,11 @@ def query(key, keyid, method='GET', params=None, headers=None,
             )
             err_code = 'http-{0}'.format(result.status_code)
             err_msg = err_text
+
+    if os.environ.get('MOCK_SLOW_DOWN'):
+        result.status_code = 503
+        err_code = 'SlowDown'
+        err_msg = 'slow down you jerks'
 
     log.debug('S3 Response Status Code: %s', result.status_code)
 

--- a/hubblestack/extmods/utils/s3.py
+++ b/hubblestack/extmods/utils/s3.py
@@ -219,7 +219,7 @@ def query(key, keyid, method='GET', params=None, headers=None,
             log.debug('Uploaded from %s to %s', local_file, path)
         else:
             log.debug('Created bucket %s', bucket)
-        return
+        return None
 
     if method == 'DELETE':
         if not six.text_type(result.status_code).startswith('2'):
@@ -235,7 +235,7 @@ def query(key, keyid, method='GET', params=None, headers=None,
             log.debug('Deleted %s from bucket %s', path, bucket)
         else:
             log.debug('Deleted bucket %s', bucket)
-        return
+        return None
 
     # This can be used to save a binary object to disk
     if local_file and method == 'GET':
@@ -251,8 +251,8 @@ def query(key, keyid, method='GET', params=None, headers=None,
 
     if result.status_code < 200 or result.status_code >= 300:
         if err_code == 'SlowDown':
-            log.warning('{}, {}'.format(err_code, err_msg))
-            return
+            log.warning('%s, %s', err_code, err_msg)
+            return None
         raise CommandExecutionError(
             'Failed s3 operation. {0}: {1}'.format(err_code, err_msg))
 
@@ -271,7 +271,7 @@ def query(key, keyid, method='GET', params=None, headers=None,
             return ret, requesturl
     else:
         if result.status_code != requests.codes.ok:
-            return
+            return None
         ret = {'headers': []}
         if full_headers:
             ret['headers'] = dict(result.headers)

--- a/hubblestack/extmods/utils/s3.py
+++ b/hubblestack/extmods/utils/s3.py
@@ -250,8 +250,9 @@ def query(key, keyid, method='GET', params=None, headers=None,
         return 'Saved to local file: {0}'.format(local_file)
 
     if result.status_code < 200 or result.status_code >= 300:
-        if err_code == 'SlowDown':
-            log.warning('%s, %s', err_code, err_msg)
+        if err_code in ['SlowDown', 'ServiceUnavailable', 'RequestTimeTooSkewed',
+                        'RequestTimeout', 'OperationAborted', 'InternalError']:
+            log.error('Failed s3 operation: %s, %s', err_code, err_msg)
             return None
         raise CommandExecutionError(
             'Failed s3 operation. {0}: {1}'.format(err_code, err_msg))


### PR DESCRIPTION
S3 cache expire can now be configured through the hubble stack config('s3.cache_expire'). Default cache expire time increased from 30 seconds to 1800 seconds(30 minutes). Also handles s3.query return DELETE request properly.