### PR TITLE
Changing permissions for hubble config in windows + other changes in 3.0 branch

### DIFF
--- a/pkg/windows/dockerfile
+++ b/pkg/windows/dockerfile
@@ -4,7 +4,7 @@
 #                    2. docker build -t <image_name> .
 # The resulting image is ready to run the pyinstaller on container start and drop hubble<version>.exe
 # in a local directory. Mount c:\data volume into a directory on the host to access the package.
-# To run the container:  
+# To run the container:
 #                    3. Copy over any other items you want to include with hubble and place them in <host folder>/opt
 #                    4. docker run -it --rm -v <host folder>:c:\data <image_name>
 #build docker image from windowscore
@@ -31,7 +31,9 @@ VOLUME C:/data
 COPY pyinstaller-requirements.txt c:/temp/
 COPY hubble.conf C:/temp/
 #install Chocolatey, then git and osquery
-RUN powershell.exe -Command Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString("$env:CHOCO_URL"))
+RUN powershell.exe -Command Set-ExecutionPolicy Bypass -Scope Process -Force; \
+ [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]'Tls,Tls11,Tls12'; \
+ iex ((New-Object System.Net.WebClient).DownloadString("$env:CHOCO_URL"));
 RUN powershell.exe -Command choco install git nssm -y;
 RUN powershell.exe -Command choco install osquery --version 3.4.0 -y;
 
@@ -52,10 +54,10 @@ RUN powershell.exe -Command git clone "$env:HUBBLE_GIT_URL"; \
   Push-Location hubble; \
   git checkout "$env:HUBBLE_CHECKOUT"; \
   pop-location;
-  
+
 #Use pip to install hubble dependencies
 RUN powershell.exe -Command pip install -r pyinstaller-requirements.txt;
-  
+
 # Modify gitfs fix for incorrect path variables until fix has been upstreamed
 RUN powershell.exe -Command If (!(Test-Path C:/Python27/Lib/site-packages/salt)) {Copy-Item C:/temp/salt/salt -Destination C:/Python27/Lib/site-packages/ -Recurse -Force}; \
   $gitfsFile = Get-Content C:\Python27\Lib\site-packages\salt\utils\gitfs.py; \
@@ -63,7 +65,7 @@ RUN powershell.exe -Command If (!(Test-Path C:/Python27/Lib/site-packages/salt))
   Set-Content -Path C:\Python27\Lib\site-packages\salt\utils\gitfs.py -Value $gitfsFile -Force
 #Get vcredist prereq for hubble
 RUN powershell.exe -Command \
-  $ProgressPreference = 'SilentlyContinue'; \ 
+  $ProgressPreference = 'SilentlyContinue'; \
   Invoke-WebRequest -Uri 'http://repo.saltstack.com/windows/dependencies/64/vcredist_x64_2008_mfc.exe' -OutFile "C:/temp/hubble/pkg/windows/vcredist.exe"
 #Create pyionstaller spec and edit it to work with windows
 CMD powershell.exe -Command Push-Location C:/temp/hubble; \
@@ -85,11 +87,11 @@ CMD powershell.exe -Command Push-Location C:/temp/hubble; \
   If (Test-Path C:/data/hubble.conf) {Copy-Item  C:/data/hubble.conf -Destination ./hubble/dist/hubble/etc/hubble/ -Force}; \
   If (Test-Path C:/data/opt) {Copy-Item  C:/data/opt -Destination './hubble/dist/hubble/' -Recurse -Force}; \
   Move-Item 'C:/temp/hubble/pkg/windows/osqueryd_safe_permissions.ps1' -Destination './hubble/dist/hubble/' -Force; \
+  Move-Item 'C:/temp/hubble/pkg/windows/hubble_config_permissions.ps1' -Destination './hubble/dist/hubble/' -Force; \
   Move-Item 'C:/temp/hubble/pkg/windows/prerequisites.ps1' -Destination './hubble/dist/hubble/' -Force; \
 #Build the installer
   Push-Location 'C:/Program Files (x86)/NSIS'; \
   ./makensis.exe /DHubbleVersion="$env:HUBBLE_CHECKOUT" 'C:/temp/hubble/pkg/windows/hubble-Setup.nsi'; \
   Get-FileHash -Path C:/temp/hubble/pkg/windows/Hubble*exe -Algorithm SHA256 ^| Out-File C:/temp/hubble/pkg/windows/hubble_windows.sha256; \
   Copy-Item C:/temp/hubble/pkg/windows/Hubble*exe -Destination C:/data/; \
-  Copy-Item C:/temp/hubble/pkg/windows/hubble_windows.sha256 -Destination C:/data/; 
-  
+  Copy-Item C:/temp/hubble/pkg/windows/hubble_windows.sha256 -Destination C:/data/;

--- a/pkg/windows/hubble-Setup.nsi
+++ b/pkg/windows/hubble-Setup.nsi
@@ -46,15 +46,15 @@
   ;Name and File
   Name "${PRODUCT_NAME} ${PRODUCT_VERSION}"
   OutFile "Hubble-${PRODUCT_VERSION}-Setup.exe"
-  
+
   ;Default Installation folder
   InstallDir "C:\${PFILES}\Hubble"
-  
+
   ;Get installation folder from registry if available
   InstallDirRegKey HKLM "${PRODUCT_DIR_REGKEY}" ""
   ShowInstDetails show
   ShowUnInstDetails show
-  
+
   ;Request application privileges for Windows Vista
   RequestExecutionLevel highest
 
@@ -136,7 +136,7 @@
 
     ${NSD_CreateText} 0 43u 100% 12u $IndexName_State
     Pop $IndexName
-	
+
     ${NSD_CreateLabel} 0 60u 100% 12u "Indexer:"
     Pop $Label
 
@@ -146,7 +146,7 @@
     nsDialogs::Show
 
   FunctionEnd
-  
+
   Function pageHubbleConfig_Leave
 
     ${NSD_GetText} $HECToken $HECToken_State
@@ -172,7 +172,7 @@
     SetCtlColors $CheckBox_Hubble_Start "" "ffffff"
     # This command required to bring the checkbox to the front
     System::Call "User32::SetWindowPos(i, i, i, i, i, i, i) b ($CheckBox_Hubble_Start, ${HWND_TOP}, 0, 0, 0, 0, ${SWP_NOSIZE}|${SWP_NOMOVE})"
-	
+
 	# Create Start Hubble Delayed Checkbox
 	${NSD_CreateCheckbox} 130u 102u 100% 12u "&Delayed Start"
     Pop $CheckBox_Hubble_Start_Delayed
@@ -241,13 +241,13 @@
   Section "MainSection" SEC01
 
     SetOutPath "$INSTDIR\"
-    SetOverwrite ifdiff 
+    SetOverwrite ifdiff
 	CreateDirectory $INSTDIR\var
     CreateDirectory $INSTDIR\etc\hubble\hubble.d
     File /r "..\..\dist\hubble\"
 
   SectionEnd
-  
+
   Section -Post
 
     WriteUninstaller "$INSTDIR\uninst.exe"
@@ -287,20 +287,21 @@
 
     ExecWait 'powershell -ExecutionPolicy Bypass -WindowStyle Hidden -File .\prerequisites.ps1 "$INSTDIR" -FFFeatureOff'
     ExecWait 'powershell -ExecutionPolicy Bypass -WindowStyle Hidden -File .\osqueryd_safe_permissions.ps1 "$INSTDIR" -FFFeatureOff'
+    ExecWait 'powershell -ExecutionPolicy Bypass -WindowStyle Hidden -File .\hubble_config_permissions.ps1 "$INSTDIR" -FFFeatureOff'
     RMDir /R "$INSTDIR\var\cache" ; removing cache from old version
 
     ${if} $HECToken_State != "xxxxx-xxx-xxx-xxx-xxxxxx"
 	${AndIf} $HECToken_State != ""
         Call makeUserConfig
     ${endif}
-	
+
     Push "C:\${PFILES}\Hubble"
     Call AddToPath
 
     Delete "$INSTDIR\vcredist.exe"
 
   SectionEnd
-  
+
   Section Uninstall
 
     Call un.uninstallHubble
@@ -387,7 +388,7 @@
         "$(^Name) was successfully removed from your computer." \
         /SD IDOK
   FunctionEnd
-  
+
 
 ;--------------------------------
 ;functions
@@ -446,7 +447,7 @@
     skipUninstall:
 
   FunctionEnd
-  
+
   Function .onInstSuccess
 
     ; If StartHubbleDelayed is 1, then set the service to start delayed
@@ -460,7 +461,7 @@
     ${EndIf}
 
   FunctionEnd
-  
+
 ;--------------------------------
 ;Helper Functions Section
 
@@ -706,11 +707,11 @@
   !macroend
   !insertmacro RemoveFromPath ""
   !insertmacro RemoveFromPath "un."
-  
+
 ;--------------------------------
 ;Specialty Fuctions
   Function makeUserConfig
-  
+
     confFind:
 	IfFileExists "$INSTDIR\etc\hubble\hubble.d\user.conf" confFound confNotFound
 
@@ -725,7 +726,7 @@
         goto confFind
 
     confLoop:
-    
+
         FileWrite $9 "hubblestack:$\r$\n"
         FileWrite $9 "  returner:$\r$\n"
         FileWrite $9 "    splunk:$\r$\n"
@@ -789,7 +790,7 @@ Function parseCommandLineSwitches
     ${ElseIf} $IndexName_State == ""
         StrCpy $IndexName_State "index"
     ${EndIf}
-	
+
 	# Hubble Config: Indexer
     ${GetOptions} $R0 "/indexer=" $R1
     ${IfNot} $R1 == ""

--- a/pkg/windows/hubble_config_permissions.ps1
+++ b/pkg/windows/hubble_config_permissions.ps1
@@ -1,0 +1,35 @@
+$hubble_path = $args[0]
+$hubble_conf_path = $hubble_path + "\etc\hubble\"
+Write-Host $hubble_conf_path
+$acl = Get-Acl $hubble_conf_path
+
+$acl.SetAccessRuleProtection($true, $false)
+foreach ($access in $acl.Access) {
+  $acl.RemoveAccessRule($access)
+}
+Set-Acl $hubble_conf_path $acl
+Write-Host "Succesfully removed all permissions from file"
+
+$acl = Get-Acl $hubble_conf_path
+$inheritanceFlag = [System.Security.AccessControl.InheritanceFlags]::ContainerInherit -bor [System.Security.AccessControl.InheritanceFlags]::ObjectInherit
+$propagationFlag = [System.Security.AccessControl.PropagationFlags]::None
+$permType = [System.Security.AccessControl.AccessControlType]::Allow
+$grantedPerm = 'FullControl'
+
+$systemSid = New-Object System.Security.Principal.SecurityIdentifier('S-1-5-18')
+$systemUser = $systemSid.Translate([System.Security.Principal.NTAccount])
+Write-Host $systemUser
+
+$adminsSid = New-Object System.Security.Principal.SecurityIdentifier('S-1-5-32-544')
+$adminsGroup = $adminsSid.Translate([System.Security.Principal.NTAccount])
+Write-Host $adminsGroup
+
+$permGroups = @($systemUser, $adminsGroup)
+foreach ($accnt in $permGroups) {
+  $permission = $accnt.Value, $grantedPerm, $inheritanceFlag, $propagationFlag, $permType
+  $accessRule = New-Object System.Security.AccessControl.FileSystemAccessRule $permission
+  Write-Host $accessRule
+  $acl.SetAccessRule($accessRule)
+    }
+$acl.SetOwner($adminsGroup)
+Set-Acl $hubble_conf_path $acl


### PR DESCRIPTION
- Added support for TLS, TLS11, TLS12 for downloading from chocolatey URL.
- Added a new script 'hubble_config_permissions.ps1' for restricting permissions of '\etc\hubble' folder in windows. Only system and admin users are allowed full control.