### PR TITLE
Filter bad host values on queue log messages

### DIFF
--- a/hubblestack/utils/stdrec.py
+++ b/hubblestack/utils/stdrec.py
@@ -97,6 +97,8 @@ def update_payload(payload):
         payload['event'] = dict()
     if isinstance(payload['event'], dict):
         payload['event'].update(std_info())
+    if not payload.get('host'):
+        payload['host'] = get_fqdn()
     fields = index_extracted(payload)
     if fields:
         payload['fields'] = fields


### PR DESCRIPTION
Found a hubble_log message that was setting a bad value in the `host` field. This should fix that. Can we make sure this is merged into 4.0/develop?