### PR TITLE
4.0 azure py3 fix and forward port of PR811

### DIFF
--- a/hubblestack/extmods/fileserver/azurefs.py
+++ b/hubblestack/extmods/fileserver/azurefs.py
@@ -252,7 +252,8 @@ def update():
             if os.path.exists(fname):
                 # File exists, check the hashes
                 source_md5 = blob.properties.content_settings.content_md5
-                local_md5 = base64.b64encode(salt.utils.hashutils.get_hash(fname, 'md5').decode('hex'))
+                local_md5_hex = salt.utils.hashutils.get_hash(fname, 'md5')
+                local_md5 = base64.b64encode(bytes.fromhex(local_md5_hex))
                 if local_md5 != source_md5:
                     update = True
             else:

--- a/hubblestack/utils/stdrec.py
+++ b/hubblestack/utils/stdrec.py
@@ -116,6 +116,8 @@ def update_payload(payload):
         payload['event'] = dict()
     if isinstance(payload['event'], dict):
         payload['event'].update(std_info())
+    if not payload.get('host'):
+        payload['host'] = get_fqdn()
     fields = index_extracted(payload)
     if fields:
         payload['fields'] = fields


### PR DESCRIPTION
'1a1b1c'.decode('hex') is now bytes.fromhex('1a1b1c'); conveniently, already bytes for b64encode()
