### PR TITLE
build id changes for conflict

### DIFF
--- a/pkg/centos8/Dockerfile
+++ b/pkg/centos8/Dockerfile
@@ -208,6 +208,7 @@ CMD [ "if [ -f /data/hubble_buildinfo ] ; then echo \"\" >> /hubble_build/hubble
        --url ${HUBBLE_URL} \
        --description \"${HUBBLE_DESCRIPTION}\" \
        --rpm-summary \"${HUBBLE_SUMMARY}\" \
+       --rpm-rpmbuild-define "_build_id_links none" \
        --after-install /hubble_build/conf/afterinstall-systemd.sh \
        --after-upgrade /hubble_build/conf/afterupgrade-systemd.sh \
        --before-remove /hubble_build/conf/beforeremove.sh \

--- a/pkg/dev/centos8/Dockerfile
+++ b/pkg/dev/centos8/Dockerfile
@@ -210,6 +210,7 @@ CMD [ "if [ -f /data/hubble_buildinfo ] ; then echo \"\" >> /hubble_build/hubble
        --url ${HUBBLE_URL} \
        --description \"${HUBBLE_DESCRIPTION}\" \
        --rpm-summary \"${HUBBLE_SUMMARY}\" \
+       --rpm-rpmbuild-define "_build_id_links none" \
        --after-install /hubble_build/conf/afterinstall-systemd.sh \
        --after-upgrade /hubble_build/conf/afterupgrade-systemd.sh \
        --before-remove /hubble_build/conf/beforeremove.sh \


### PR DESCRIPTION
While installing build on centos-8, it shows conflict errors for some libraries. It got installed using --force flag. But, it is not a good practice.
There is a command change in building the rpm for centos-8 (fpm command) which resolves this issue.