### PR TITLE
osquery dockerfiles and augeas folder fix

### DIFF
--- a/hubblestack/extmods/modules/nebula_osquery.py
+++ b/hubblestack/extmods/modules/nebula_osquery.py
@@ -192,10 +192,12 @@ def _run_osqueryi_query(query, query_sql, timing, verbose):
     Run the osqueryi query in query_sql and return the result
     """
     max_file_size = 104857600
+    augeas_lenses = '/opt/osquery/lenses'
     query_ret = {'result': True}
 
     # Run the osqueryi query
-    cmd = [__grains__['osquerybinpath'], '--read_max', max_file_size, '--json', query_sql]
+    cmd = [__grains__['osquerybinpath'], '--read_max', max_file_size, '--json',
+          '--augeas_lenses', augeas_lenses, query_sql]
 
     time_start = time.time()
     res = __salt__['cmd.run_all'](cmd, timeout=10000)

--- a/pkg/amazonlinux2016.09/Dockerfile
+++ b/pkg/amazonlinux2016.09/Dockerfile
@@ -1,81 +1,35 @@
-# This Dockerfile aims to make building Hubble v2 packages easier.
-# To build an image: 1. copy pkg/scripts/pyinstaller-requirements.txt to directory with this Dockerfile
-#                    2. docker build -t <image_name> .
-# The resulting image is ready to run the pyinstaller on container start and drop hubble<version>-coreos.tar.gz
-# in the /data directory. Mount /data volume into a directory on the host to access the package.
+# This Dockerfile aims to make building Hubble v4 packages easier.
+# Starting with version 4 building osquery is removed from individual Dockerfiles to its own.
+# osquery needs to be built once. Resulting tar file can be used in hubblev4 Dockerfiles.
+# Before building hubble, build osquery using a Dockerfile in pkg/osquery/ directory.
+# To build this image: 1. copy previously built osquery_4hubble.tar to directory with this Dockerfile
+#                      2. docker build -t <image_name> --build-arg=HUBBLE_CHECKOUT=<tag or commit> .
+# The resulting image is ready to build and run pyinstaller on container start that should 
+# create hubble<version>-al.tar.gz in the /data directory inside the container.
+# Mount /data volume into a directory on the host to access the package.
 # To run the container:  docker run -it --rm -v `pwd`:/data <image_name>
-# Requires docker 17.05 or higher
 
-# Set this argument to "local" if you want to build osquery for local code.
-# In that case, osquery folder must exist besides Dockerfile
-ARG OSQUERY_BUILD_ENV=remote
-
-#--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
-FROM alpine as osquery_local
-ONBUILD COPY osquery /osquery
-ONBUILD RUN echo "Copying osquery from local folder"
-
-
-
-#--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
-FROM alpine/git as osquery_remote
-#to pin osquery to a different version change the following envirnment variable
-ENV OSQUERY_SRC_VERSION=3.3.2
-ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
-ONBUILD RUN cd / \
- && git clone "$OSQUERY_GIT_URL" \
- && cd osquery/ \
- && git checkout "$OSQUERY_SRC_VERSION" \
- && echo "Fetching osquery from git"
-
-
-#--------------- TEMP CONTAINER FOR OSQUERY ( BASED ON ARGUMENT ) ---------------
-FROM osquery_"$OSQUERY_BUILD_ENV" as osquery_image
-
-
-#--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM amazonlinux:2016.09
 
 RUN yum makecache fast && yum -y update
 
 #paths that hubble or hubble parts need in the package
 RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osquery/backuplogs
-#osquery build start
-#osquery should be built first since requirements for other packages can interfere with osquery dependencies
-#to build, osquery scripts want sudo and a user to sudo with.
-ENV OSQUERY_BUILD_USER=osquerybuilder
-RUN yum -y install git make python ruby sudo which
-RUN useradd --shell /bin/bash --create-home --user-group --groups wheel "$OSQUERY_BUILD_USER" \
- && sed -i '0,/^#\ %wheel/s/^#\ %wheel.*/%wheel\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
-COPY --from=osquery_image /osquery /home/"$OSQUERY_BUILD_USER"/osquery
-RUN mkdir -p /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
-USER $OSQUERY_BUILD_USER
-ENV SKIP_TESTS=1
-RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
- && make sysprep \
-#have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
- && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \
- && make deps \
- && make \
- && make strip
-USER root
-RUN cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery \
- && cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd \
- && chown -R root. /opt/osquery \
- && chmod -R 500 /opt/osquery/* \
-#put augeas lenses into the default directory that we changed earlier
- && mkdir -p /opt/osquery/lenses \
- && cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses \
- && chmod -R 400 /opt/osquery/lenses/*
-RUN ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version
+
+#copy in and process osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg
+ARG OSQUERY_TAR_FILENAME=osquery_4hubble.tar
+COPY ${OSQUERY_TAR_FILENAME} /opt/osquery/${OSQUERY_TAR_FILENAME}
+RUN cd /opt/osquery \
+ && tar xf "$OSQUERY_TAR_FILENAME" \
+ && rm -f "$OSQUERY_TAR_FILENAME" \
+ && cd / \
+ && /opt/osquery/osqueryi --version
 
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
-RUN yum -y install  \
-               libffi-devel openssl-devel libffi libssh2-devel autoconf automake libtool \
-               libxml2-devel libxslt-devel libjpeg-devel zlib-devel \
-               make cmake gcc python-devel python-setuptools wget openssl
+RUN yum -y install git \
+    libffi-devel openssl-devel libffi libssh2-devel autoconf automake libtool \
+    libxml2-devel libxslt-devel libjpeg-devel zlib-devel \
+    make cmake gcc python-devel python-setuptools wget openssl
 
 #libcurl install start
 #install libcurl to avoid depending on host version

--- a/pkg/amazonlinux2016.09/Dockerfile
+++ b/pkg/amazonlinux2016.09/Dockerfile
@@ -16,11 +16,6 @@ RUN yum makecache fast && yum -y update
 #paths that hubble or hubble parts need in the package
 RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osquery/backuplogs
 
-#extract osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg
-ARG OSQUERY_TAR_FILENAME=osquery_4hubble.tar
-ADD ${OSQUERY_TAR_FILENAME} /opt/osquery/
-RUN /opt/osquery/osqueryi --version
-
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
 RUN yum -y install git \
     libffi-devel openssl-devel libffi libssh2-devel autoconf automake libtool \
@@ -107,6 +102,11 @@ RUN umask 022 \
 
 RUN eval "$(pyenv init -)" \
  && pip -v install --upgrade pip
+
+#extract osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg
+ARG OSQUERY_TAR_FILENAME=osquery_4hubble.tar
+ADD ${OSQUERY_TAR_FILENAME} /opt/osquery/
+RUN /opt/osquery/osqueryi --version
 
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built

--- a/pkg/amazonlinux2016.09/Dockerfile
+++ b/pkg/amazonlinux2016.09/Dockerfile
@@ -16,14 +16,10 @@ RUN yum makecache fast && yum -y update
 #paths that hubble or hubble parts need in the package
 RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osquery/backuplogs
 
-#copy in and process osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg
+#extract osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg
 ARG OSQUERY_TAR_FILENAME=osquery_4hubble.tar
-COPY ${OSQUERY_TAR_FILENAME} /opt/osquery/${OSQUERY_TAR_FILENAME}
-RUN cd /opt/osquery \
- && tar xf "$OSQUERY_TAR_FILENAME" \
- && rm -f "$OSQUERY_TAR_FILENAME" \
- && cd / \
- && /opt/osquery/osqueryi --version
+ADD ${OSQUERY_TAR_FILENAME} /opt/osquery/
+RUN /opt/osquery/osqueryi --version
 
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
 RUN yum -y install git \

--- a/pkg/centos6/Dockerfile
+++ b/pkg/centos6/Dockerfile
@@ -16,11 +16,6 @@ RUN yum makecache fast && yum -y update
 #paths that hubble or hubble parts need in the package
 RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osquery/backuplogs
 
-#extract osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg
-ARG OSQUERY_TAR_FILENAME=osquery_4hubble.tar
-ADD ${OSQUERY_TAR_FILENAME} /opt/osquery/
-RUN /opt/osquery/osqueryi --version
-
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
 RUN yum -y install git \
     libffi-devel openssl-devel libxml2-devel libxslt-devel libffi \
@@ -108,6 +103,11 @@ RUN umask 022 \
 
 RUN eval "$(pyenv init -)" \
  && pip -v install --upgrade pip
+
+#extract osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg
+ARG OSQUERY_TAR_FILENAME=osquery_4hubble.tar
+ADD ${OSQUERY_TAR_FILENAME} /opt/osquery/
+RUN /opt/osquery/osqueryi --version
 
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built

--- a/pkg/centos6/Dockerfile
+++ b/pkg/centos6/Dockerfile
@@ -16,14 +16,10 @@ RUN yum makecache fast && yum -y update
 #paths that hubble or hubble parts need in the package
 RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osquery/backuplogs
 
-#copy in and process osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg
+#extract osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg
 ARG OSQUERY_TAR_FILENAME=osquery_4hubble.tar
-COPY ${OSQUERY_TAR_FILENAME} /opt/osquery/${OSQUERY_TAR_FILENAME}
-RUN cd /opt/osquery \
- && tar xf "$OSQUERY_TAR_FILENAME" \
- && rm -f "$OSQUERY_TAR_FILENAME" \
- && cd / \
- && /opt/osquery/osqueryi --version
+ADD ${OSQUERY_TAR_FILENAME} /opt/osquery/
+RUN /opt/osquery/osqueryi --version
 
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
 RUN yum -y install git \

--- a/pkg/centos6/Dockerfile
+++ b/pkg/centos6/Dockerfile
@@ -1,82 +1,36 @@
-# This Dockerfile aims to make building Hubble v2 packages easier.
-# To build an image: 1. copy pkg/scripts/pyinstaller-requirements.txt to directory with this Dockerfile
-#                    2. docker build -t <image_name> .
-# The resulting image is ready to run the pyinstaller on container start and drop hubble<version>-coreos.tar.gz
-# in the /data directory. Mount /data volume into a directory on the host to access the package.
+# This Dockerfile aims to make building Hubble v4 packages easier.
+# Starting with version 4 building osquery is removed from individual Dockerfiles to its own.
+# osquery needs to be built once. Resulting tar file can be used in hubblev4 Dockerfiles.
+# Before building hubble, build osquery using a Dockerfile in pkg/osquery/ directory.
+# To build this image: 1. copy previously built osquery_4hubble.tar to directory with this Dockerfile
+#                      2. docker build -t <image_name> --build-arg=HUBBLE_CHECKOUT=<tag or commit> .
+# The resulting image is ready to build and run pyinstaller on container start that should 
+# create hubble<version>-centos6.tar.gz in the /data directory inside the container.
+# Mount /data volume into a directory on the host to access the package.
 # To run the container:  docker run -it --rm -v `pwd`:/data <image_name>
-# Requires docker 17.05 or higher
 
-# Set this argument to "local" if you want to build osquery for local code.
-# In that case, osquery folder must exist besides Dockerfile
-ARG OSQUERY_BUILD_ENV=remote
-
-#--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
-FROM alpine as osquery_local
-ONBUILD COPY osquery /osquery
-ONBUILD RUN echo "Copying osquery from local folder"
-
-
-
-#--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
-FROM alpine/git as osquery_remote
-#to pin osquery to a different version change the following envirnment variable
-ENV OSQUERY_SRC_VERSION=3.3.2
-ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
-ONBUILD RUN cd / \
- && git clone "$OSQUERY_GIT_URL" \
- && cd osquery/ \
- && git checkout "$OSQUERY_SRC_VERSION" \
- && echo "Fetching osquery from git"
-
-
-#--------------- TEMP CONTAINER FOR OSQUERY ( BASED ON ARGUMENT ) ---------------
-FROM osquery_"$OSQUERY_BUILD_ENV" as osquery_image
-
-
-#--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM centos:6
 
 RUN yum makecache fast && yum -y update
 
 #paths that hubble or hubble parts need in the package
 RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osquery/backuplogs
-#osquery build start
-#osquery should be built first since requirements for other packages can interfere with osquery dependencies
-#to build, osquery scripts want sudo and a user to sudo with.
-ENV OSQUERY_BUILD_USER=osquerybuilder
-RUN yum -y install xz git make ruby sudo which python-argparse
-RUN useradd --shell /bin/bash --create-home --user-group --groups wheel "$OSQUERY_BUILD_USER" \
- && sed -i '0,/^#\ %wheel/s/^#\ %wheel.*/%wheel\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
-COPY --from=osquery_image /osquery /home/"$OSQUERY_BUILD_USER"/osquery
-RUN mkdir -p /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
-USER $OSQUERY_BUILD_USER
-ENV SKIP_TESTS=1
-RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
- && make sysprep \
-#have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
- && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \
- && make deps \
- && make \
- && make strip
-USER root
-RUN cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery \
- && cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd \
- && chown -R root. /opt/osquery \
- && chmod -R 500 /opt/osquery/* \
-#put augeas lenses into the default directory that we changed earlier
- && mkdir -p /opt/osquery/lenses \
- && cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses \
- && chmod -R 400 /opt/osquery/lenses/*
-RUN ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version
+
+#copy in and process osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg
+ARG OSQUERY_TAR_FILENAME=osquery_4hubble.tar
+COPY ${OSQUERY_TAR_FILENAME} /opt/osquery/${OSQUERY_TAR_FILENAME}
+RUN cd /opt/osquery \
+ && tar xf "$OSQUERY_TAR_FILENAME" \
+ && rm -f "$OSQUERY_TAR_FILENAME" \
+ && cd / \
+ && /opt/osquery/osqueryi --version
 
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
-RUN yum -y install  \
+RUN yum -y install git \
     libffi-devel openssl-devel libxml2-devel libxslt-devel libffi \
     libssh2-devel autoconf automake libtool libjpeg-devel zlib-devel \
     make cmake gcc wget openssl
-
+    
 #libcurl install start
 #install libcurl to avoid depending on host version
 #requires autoconf libtool libssh2-devel zlib-devel autoconf

--- a/pkg/centos7/Dockerfile
+++ b/pkg/centos7/Dockerfile
@@ -16,11 +16,6 @@ RUN yum makecache fast && yum -y update
 #paths that hubble or hubble parts need in the package
 RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osquery/backuplogs
 
-#extract osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg
-ARG OSQUERY_TAR_FILENAME=osquery_4hubble.tar
-ADD ${OSQUERY_TAR_FILENAME} /opt/osquery/
-RUN /opt/osquery/osqueryi --version
-
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
 RUN yum -y install git \
     libffi-devel openssl-devel libffi libssh2-devel autoconf automake libtool \
@@ -107,6 +102,11 @@ RUN umask 022 \
 
 RUN eval "$(pyenv init -)" \
  && pip -v install --upgrade pip
+
+#extract osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg
+ARG OSQUERY_TAR_FILENAME=osquery_4hubble.tar
+ADD ${OSQUERY_TAR_FILENAME} /opt/osquery/
+RUN /opt/osquery/osqueryi --version
 
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built

--- a/pkg/centos7/Dockerfile
+++ b/pkg/centos7/Dockerfile
@@ -1,81 +1,35 @@
-# This Dockerfile aims to make building Hubble v2 packages easier.
-# To build an image: 1. copy pkg/scripts/pyinstaller-requirements.txt to directory with this Dockerfile
-#                    2. docker build -t <image_name> .
-# The resulting image is ready to run the pyinstaller on container start and drop hubble<version>-coreos.tar.gz
-# in the /data directory. Mount /data volume into a directory on the host to access the package.
+# This Dockerfile aims to make building Hubble v4 packages easier.
+# Starting with version 4 building osquery is removed from individual Dockerfiles to its own.
+# osquery needs to be built once. Resulting tar file can be used in hubblev4 Dockerfiles.
+# Before building hubble, build osquery using a Dockerfile in pkg/osquery/ directory.
+# To build this image: 1. copy previously built osquery_4hubble.tar to directory with this Dockerfile
+#                      2. docker build -t <image_name> --build-arg=HUBBLE_CHECKOUT=<tag or commit> .
+# The resulting image is ready to build and run pyinstaller on container start that should 
+# create hubble<version>-centos7.tar.gz in the /data directory inside the container.
+# Mount /data volume into a directory on the host to access the package.
 # To run the container:  docker run -it --rm -v `pwd`:/data <image_name>
-# Requires docker 17.05 or higher
 
-# Set this argument to "local" if you want to build osquery for local code.
-# In that case, osquery folder must exist besides Dockerfile
-ARG OSQUERY_BUILD_ENV=remote
-
-#--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
-FROM alpine as osquery_local
-ONBUILD COPY osquery /osquery
-ONBUILD RUN echo "Copying osquery from local folder"
-
-
-
-#--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
-FROM alpine/git as osquery_remote
-#to pin osquery to a different version change the following envirnment variable
-ENV OSQUERY_SRC_VERSION=3.3.2
-ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
-ONBUILD RUN cd / \
- && git clone "$OSQUERY_GIT_URL" \
- && cd osquery/ \
- && git checkout "$OSQUERY_SRC_VERSION" \
- && echo "Fetching osquery from git"
-
-
-#--------------- TEMP CONTAINER FOR OSQUERY ( BASED ON ARGUMENT ) ---------------
-FROM osquery_"$OSQUERY_BUILD_ENV" as osquery_image
-
-
-#--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM centos:7
 
 RUN yum makecache fast && yum -y update
 
 #paths that hubble or hubble parts need in the package
 RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osquery/backuplogs
-#osquery build start
-#osquery should be built first since requirements for other packages can interfere with osquery dependencies
-#to build, osquery scripts want sudo and a user to sudo with.
-ENV OSQUERY_BUILD_USER=osquerybuilder
-RUN yum -y install git make python ruby sudo which
-RUN useradd --shell /bin/bash --create-home --user-group --groups wheel "$OSQUERY_BUILD_USER" \
- && sed -i '0,/^#\ %wheel/s/^#\ %wheel.*/%wheel\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
-COPY --from=osquery_image /osquery /home/"$OSQUERY_BUILD_USER"/osquery
-RUN mkdir -p /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
-USER $OSQUERY_BUILD_USER
-ENV SKIP_TESTS=1
-RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
- && make sysprep \
-#have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
- && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \
- && make deps \
- && make \
- && make strip
-USER root
-RUN cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery \
- && cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd \
- && chown -R root. /opt/osquery \
- && chmod -R 500 /opt/osquery/* \
-#put augeas lenses into the default directory that we changed earlier
- && mkdir -p /opt/osquery/lenses \
- && cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses \
- && chmod -R 400 /opt/osquery/lenses/*
-RUN ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version
+
+#copy in and process osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg
+ARG OSQUERY_TAR_FILENAME=osquery_4hubble.tar
+COPY ${OSQUERY_TAR_FILENAME} /opt/osquery/${OSQUERY_TAR_FILENAME}
+RUN cd /opt/osquery \
+ && tar xf "$OSQUERY_TAR_FILENAME" \
+ && rm -f "$OSQUERY_TAR_FILENAME" \
+ && cd / \
+ && /opt/osquery/osqueryi --version
 
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
-RUN yum -y install  \
-               libffi-devel openssl-devel libffi libssh2-devel autoconf automake libtool \
-               libxml2-devel libxslt-devel libjpeg-devel zlib-devel \
-               make cmake gcc python-devel python-setuptools wget openssl
+RUN yum -y install git \
+    libffi-devel openssl-devel libffi libssh2-devel autoconf automake libtool \
+    libxml2-devel libxslt-devel libjpeg-devel zlib-devel \
+    make cmake gcc python-devel python-setuptools wget openssl
 
 #libcurl install start
 #install libcurl to avoid depending on host version

--- a/pkg/centos7/Dockerfile
+++ b/pkg/centos7/Dockerfile
@@ -16,14 +16,10 @@ RUN yum makecache fast && yum -y update
 #paths that hubble or hubble parts need in the package
 RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osquery/backuplogs
 
-#copy in and process osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg
+#extract osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg
 ARG OSQUERY_TAR_FILENAME=osquery_4hubble.tar
-COPY ${OSQUERY_TAR_FILENAME} /opt/osquery/${OSQUERY_TAR_FILENAME}
-RUN cd /opt/osquery \
- && tar xf "$OSQUERY_TAR_FILENAME" \
- && rm -f "$OSQUERY_TAR_FILENAME" \
- && cd / \
- && /opt/osquery/osqueryi --version
+ADD ${OSQUERY_TAR_FILENAME} /opt/osquery/
+RUN /opt/osquery/osqueryi --version
 
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
 RUN yum -y install git \

--- a/pkg/centos8/Dockerfile
+++ b/pkg/centos8/Dockerfile
@@ -16,14 +16,10 @@ RUN dnf -y update
 #paths that hubble or hubble parts need in the package
 RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osquery/backuplogs
 
-#copy in and process osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg
+#extract osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg
 ARG OSQUERY_TAR_FILENAME=osquery_4hubble.tar
-COPY ${OSQUERY_TAR_FILENAME} /opt/osquery/${OSQUERY_TAR_FILENAME}
-RUN cd /opt/osquery \
- && tar xf "$OSQUERY_TAR_FILENAME" \
- && rm -f "$OSQUERY_TAR_FILENAME" \
- && cd / 
-# && /opt/osquery/osqueryi --version
+ADD ${OSQUERY_TAR_FILENAME} /opt/osquery/
+RUN /opt/osquery/osqueryi --version
  
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
 RUN dnf -y install git \

--- a/pkg/centos8/Dockerfile
+++ b/pkg/centos8/Dockerfile
@@ -16,11 +16,6 @@ RUN dnf -y update
 #paths that hubble or hubble parts need in the package
 RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osquery/backuplogs
 
-#extract osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg
-ARG OSQUERY_TAR_FILENAME=osquery_4hubble.tar
-ADD ${OSQUERY_TAR_FILENAME} /opt/osquery/
-RUN /opt/osquery/osqueryi --version
- 
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
 RUN dnf -y install git \
     libffi-devel openssl-devel libffi libssh-devel autoconf automake libtool \
@@ -113,6 +108,11 @@ RUN umask 022 \
 
 RUN eval "$(pyenv init -)" \
  && pip -v install --upgrade pip
+
+#extract osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg
+ARG OSQUERY_TAR_FILENAME=osquery_4hubble.tar
+ADD ${OSQUERY_TAR_FILENAME} /opt/osquery/
+RUN /opt/osquery/osqueryi --version
 
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built

--- a/pkg/centos8/Dockerfile
+++ b/pkg/centos8/Dockerfile
@@ -1,84 +1,35 @@
-# This Dockerfile aims to make building Hubble v2 packages easier.
-# To build an image: 1. copy pkg/scripts/pyinstaller-requirements.txt to directory with this Dockerfile
-#                    2. docker build -t <image_name> .
-# The resulting image is ready to run the pyinstaller on container start and drop hubble<version>-coreos.tar.gz
-# in the /data directory. Mount /data volume into a directory on the host to access the package.
+# This Dockerfile aims to make building Hubble v4 packages easier.
+# Starting with version 4 building osquery is removed from individual Dockerfiles to its own.
+# osquery needs to be built once. Resulting tar file can be used in hubblev4 Dockerfiles.
+# Before building hubble, build osquery using a Dockerfile in pkg/osquery/ directory.
+# To build this image: 1. copy previously built osquery_4hubble.tar to directory with this Dockerfile
+#                      2. docker build -t <image_name> --build-arg=HUBBLE_CHECKOUT=<tag or commit> .
+# The resulting image is ready to build and run pyinstaller on container start that should 
+# create hubble<version>-centos8.tar.gz in the /data directory inside the container.
+# Mount /data volume into a directory on the host to access the package.
 # To run the container:  docker run -it --rm -v `pwd`:/data <image_name>
-# Requires docker 17.05 or higher
 
-# Set this argument to "local" if you want to build osquery for local code.
-# In that case, osquery folder must exist besides Dockerfile
-ARG OSQUERY_BUILD_ENV=remote
-
-#--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
-FROM alpine as osquery_local
-ONBUILD COPY osquery /osquery
-ONBUILD RUN echo "Copying osquery from local folder"
-
-
-
-#--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
-FROM alpine/git as osquery_remote
-#to pin osquery to a different version change the following envirnment variable
-ENV OSQUERY_SRC_VERSION=3.3.2
-ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
-ONBUILD RUN cd / \
- && git clone "$OSQUERY_GIT_URL" \
- && cd osquery/ \
- && git checkout "$OSQUERY_SRC_VERSION" \
- && echo "Fetching osquery from git"
-
-
-#--------------- TEMP CONTAINER FOR OSQUERY ( BASED ON ARGUMENT ) ---------------
-FROM osquery_"$OSQUERY_BUILD_ENV" as osquery_image
-
-
-#--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM centos:8
 
 RUN dnf -y update
 
 #paths that hubble or hubble parts need in the package
 RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osquery/backuplogs
-#osquery build start
-#osquery should be built first since requirements for other packages can interfere with osquery dependencies
-#to build, osquery scripts want sudo and a user to sudo with.
-ENV OSQUERY_BUILD_USER=osquerybuilder
-RUN dnf -y install dnf-plugins-core \
- && dnf config-manager --set-enabled PowerTools \
- && dnf -y install python3 git make ruby sudo which doxygen \
- && ln -svf python3 /usr/bin/python
-RUN useradd --shell /bin/bash --create-home --user-group --groups wheel "$OSQUERY_BUILD_USER" \
- && sed -i '0,/^#\ %wheel/s/^#\ %wheel.*/%wheel\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
-COPY --from=osquery_image /osquery /home/"$OSQUERY_BUILD_USER"/osquery
-RUN mkdir -p /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
-USER $OSQUERY_BUILD_USER
-ENV SKIP_TESTS=1
-RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
- && make sysprep \
-#have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
- && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \
- && make deps \
- && make \
- && make strip
-USER root
-RUN cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery \
- && cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd \
- && chown -R root. /opt/osquery \
- && chmod -R 500 /opt/osquery/* \
-#put augeas lenses into the default directory that we changed earlier
- && mkdir -p /opt/osquery/lenses \
- && cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses \
- && chmod -R 400 /opt/osquery/lenses/*
-RUN ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version
 
+#copy in and process osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg
+ARG OSQUERY_TAR_FILENAME=osquery_4hubble.tar
+COPY ${OSQUERY_TAR_FILENAME} /opt/osquery/${OSQUERY_TAR_FILENAME}
+RUN cd /opt/osquery \
+ && tar xf "$OSQUERY_TAR_FILENAME" \
+ && rm -f "$OSQUERY_TAR_FILENAME" \
+ && cd / 
+# && /opt/osquery/osqueryi --version
+ 
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
-RUN dnf -y install  \
-               libffi-devel openssl-devel libffi libssh-devel autoconf automake libtool \
-               libxml2-devel libxslt-devel libjpeg-devel zlib-devel \
-               make cmake gcc python3-devel wget openssl
+RUN dnf -y install git \
+    libffi-devel openssl-devel libffi libssh-devel autoconf automake libtool \
+    libxml2-devel libxslt-devel libjpeg-devel zlib-devel \
+    make cmake gcc python3-devel wget openssl
 
 #libcurl install start
 #install libcurl to avoid depending on host version

--- a/pkg/coreos/Dockerfile
+++ b/pkg/coreos/Dockerfile
@@ -1,39 +1,14 @@
-# This Dockerfile aims to make building Hubble v2 packages easier.
-# To build an image: 1. copy pkg/scripts/pyinstaller-requirements.txt to directory with this Dockerfile
-#                    2. docker build -t <image_name> .
-# The resulting image is ready to run the pyinstaller on container start and drop hubble<version>-coreos.tar.gz
-# in the /data directory. Mount /data volume into a directory on the host to access the package.
+# This Dockerfile aims to make building Hubble v4 packages easier.
+# Starting with version 4 building osquery is removed from individual Dockerfiles to its own.
+# osquery needs to be built once. Resulting tar file can be used in hubblev4 Dockerfiles.
+# Before building hubble, build osquery using a Dockerfile in pkg/osquery/ directory.
+# To build this image: 1. copy previously built osquery_4hubble.tar to directory with this Dockerfile
+#                      2. docker build -t <image_name> --build-arg=HUBBLE_CHECKOUT=<tag or commit> .
+# The resulting image is ready to build and run pyinstaller on container start that should 
+# create hubble<version>-coreos.tar.gz in the /data directory inside the container.
+# Mount /data volume into a directory on the host to access the package.
 # To run the container:  docker run -it --rm -v `pwd`:/data <image_name>
-# Requires docker 17.05 or higher
 
-# Set this argument to "local" if you want to build osquery for local code.
-# In that case, osquery folder must exist besides Dockerfile
-ARG OSQUERY_BUILD_ENV=remote
-
-#--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
-FROM alpine as osquery_local
-ONBUILD COPY osquery /osquery
-ONBUILD RUN echo "Copying osquery from local folder"
-
-
-
-#--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
-FROM alpine/git as osquery_remote
-#to pin osquery to a different version change the following envirnment variable
-ENV OSQUERY_SRC_VERSION=3.3.2
-ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
-ONBUILD RUN cd / \
- && git clone "$OSQUERY_GIT_URL" \
- && cd osquery/ \
- && git checkout "$OSQUERY_SRC_VERSION" \
- && echo "Fetching osquery from git"
-
-
-#--------------- TEMP CONTAINER FOR OSQUERY ( BASED ON ARGUMENT ) ---------------
-FROM osquery_"$OSQUERY_BUILD_ENV" as osquery_image
-
-
-#--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM debian:9
 
 RUN apt-get update \
@@ -42,58 +17,20 @@ RUN apt-get update \
 #paths that hubble or hubble parts need in the package
 RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osquery/backuplogs
 
-#patchelf build start
-#must precede osquery as at the moment, osquery won't build without patchelf
-ENV PATCHELF_GIT_URL=https://github.com/NixOS/patchelf.git
-ENV PATCHELF_TEMP=/tmp/patchelf
-RUN apt-get -y install autoconf git make g++
-RUN mkdir -p "$PATCHELF_TEMP" \
- && cd "$PATCHELF_TEMP" \
- && git clone "$PATCHELF_GIT_URL" \
- && cd patchelf \
- && sed -i 's/serial-tests/parallel-tests/' configure.ac \
- && ./bootstrap.sh \
- && ./configure \
- && make \
- && make install
-
-#osquery build start
-#osquery should be built first since requirements for other packages can interfere with osquery dependencies
-#to build, osquery scripts want sudo and a user to sudo with.
-ENV OSQUERY_BUILD_USER=osquerybuilder
-RUN apt-get -y install git make python ruby sudo curl
-RUN useradd --shell /bin/bash --create-home --user-group --groups sudo "$OSQUERY_BUILD_USER" \
- && sed -i 's/^%sudo.*/%sudo\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
-COPY --from=osquery_image /osquery /home/"$OSQUERY_BUILD_USER"/osquery
-RUN mkdir -p /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
-USER $OSQUERY_BUILD_USER
-ENV SKIP_TESTS=1
-RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
- && make sysprep \
-#have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
- && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \
- && make deps \
- && make \
- && make strip
-USER root
-RUN cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery \
- && cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd \
- && chown -R root. /opt/osquery \
- && chmod -R 500 /opt/osquery/* \
-#put augeas lenses into the default directory that we changed earlier
- && mkdir -p /opt/osquery/lenses \
- && cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses \
- && chmod -R 400 /opt/osquery/lenses/*
-RUN ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version
+#copy in and process osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg
+ARG OSQUERY_TAR_FILENAME=osquery_4hubble.tar
+COPY ${OSQUERY_TAR_FILENAME} /opt/osquery/${OSQUERY_TAR_FILENAME}
+RUN cd /opt/osquery \
+ && tar xf "$OSQUERY_TAR_FILENAME" \
+ && rm -f "$OSQUERY_TAR_FILENAME" \
+ && cd / \
+ && /opt/osquery/osqueryi --version
 
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
-RUN apt-get -y install  \
-               python-dev libffi-dev libssl-dev libyaml-dev libssh2-1 libssh2-1-dev autoconf automake libtool \
-               libxml2-dev libxslt1-dev python-cffi \
-               zlib1g-dev cmake python-setuptools  \
-               gcc wget python-pip openssl \
+RUN apt-get -y install git curl \
+    python-dev libffi-dev libssl-dev libyaml-dev libssh2-1 libssh2-1-dev autoconf automake libtool \
+    libxml2-dev libxslt1-dev python-cffi zlib1g-dev python-setuptools \
+    cmake gcc wget python-pip openssl \
  && apt-get clean
 
 #libcurl install start

--- a/pkg/coreos/Dockerfile
+++ b/pkg/coreos/Dockerfile
@@ -17,11 +17,6 @@ RUN apt-get update \
 #paths that hubble or hubble parts need in the package
 RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osquery/backuplogs
 
-#extract osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg
-ARG OSQUERY_TAR_FILENAME=osquery_4hubble.tar
-ADD ${OSQUERY_TAR_FILENAME} /opt/osquery/
-RUN /opt/osquery/osqueryi --version
-
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
 RUN apt-get -y install git curl \
     python-dev libffi-dev libssl-dev libyaml-dev libssh2-1 libssh2-1-dev autoconf automake libtool \
@@ -105,6 +100,11 @@ RUN umask 022 \
 
 RUN eval "$(pyenv init -)" \
  && pip -v install --upgrade pip
+
+#extract osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg
+ARG OSQUERY_TAR_FILENAME=osquery_4hubble.tar
+ADD ${OSQUERY_TAR_FILENAME} /opt/osquery/
+RUN /opt/osquery/osqueryi --version
 
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built

--- a/pkg/coreos/Dockerfile
+++ b/pkg/coreos/Dockerfile
@@ -17,14 +17,10 @@ RUN apt-get update \
 #paths that hubble or hubble parts need in the package
 RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osquery/backuplogs
 
-#copy in and process osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg
+#extract osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg
 ARG OSQUERY_TAR_FILENAME=osquery_4hubble.tar
-COPY ${OSQUERY_TAR_FILENAME} /opt/osquery/${OSQUERY_TAR_FILENAME}
-RUN cd /opt/osquery \
- && tar xf "$OSQUERY_TAR_FILENAME" \
- && rm -f "$OSQUERY_TAR_FILENAME" \
- && cd / \
- && /opt/osquery/osqueryi --version
+ADD ${OSQUERY_TAR_FILENAME} /opt/osquery/
+RUN /opt/osquery/osqueryi --version
 
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
 RUN apt-get -y install git curl \

--- a/pkg/debian10/Dockerfile
+++ b/pkg/debian10/Dockerfile
@@ -17,11 +17,6 @@ RUN apt-get update \
 #paths that hubble or hubble parts need in the package
 RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osquery/backuplogs
 
-#extract osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg
-ARG OSQUERY_TAR_FILENAME=osquery_4hubble.tar
-ADD ${OSQUERY_TAR_FILENAME} /opt/osquery/
-RUN /opt/osquery/osqueryi --version
-
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
 RUN apt-get -y install git curl \
     python-dev libffi-dev libssl-dev libyaml-dev libssh2-1 libssh2-1-dev autoconf automake libtool \
@@ -110,6 +105,11 @@ RUN umask 022 \
 
 RUN eval "$(pyenv init -)" \
  && pip -v install --upgrade pip
+
+#extract osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg
+ARG OSQUERY_TAR_FILENAME=osquery_4hubble.tar
+ADD ${OSQUERY_TAR_FILENAME} /opt/osquery/
+RUN /opt/osquery/osqueryi --version
 
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built

--- a/pkg/debian10/Dockerfile
+++ b/pkg/debian10/Dockerfile
@@ -1,39 +1,14 @@
-# This Dockerfile aims to make building Hubble v2 packages easier.
-# To build an image: 1. copy pkg/scripts/pyinstaller-requirements.txt to directory with this Dockerfile
-#                    2. docker build -t <image_name> .
-# The resulting image is ready to run the pyinstaller on container start and drop hubble<version>-coreos.tar.gz
-# in the /data directory. Mount /data volume into a directory on the host to access the package.
+# This Dockerfile aims to make building Hubble v4 packages easier.
+# Starting with version 4 building osquery is removed from individual Dockerfiles to its own.
+# osquery needs to be built once. Resulting tar file can be used in hubblev4 Dockerfiles.
+# Before building hubble, build osquery using a Dockerfile in pkg/osquery/ directory.
+# To build this image: 1. copy previously built osquery_4hubble.tar to directory with this Dockerfile
+#                      2. docker build -t <image_name> --build-arg=HUBBLE_CHECKOUT=<tag or commit> .
+# The resulting image is ready to build and run pyinstaller on container start that should 
+# create hubble<version>-debian.tar.gz in the /data directory inside the container.
+# Mount /data volume into a directory on the host to access the package.
 # To run the container:  docker run -it --rm -v `pwd`:/data <image_name>
-# Requires docker 17.05 or higher
 
-# Set this argument to "local" if you want to build osquery for local code.
-# In that case, osquery folder must exist besides Dockerfile
-ARG OSQUERY_BUILD_ENV=remote
-
-#--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
-FROM alpine as osquery_local
-ONBUILD COPY osquery /osquery
-ONBUILD RUN echo "Copying osquery from local folder"
-
-
-
-#--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
-FROM alpine/git as osquery_remote
-#to pin osquery to a different version change the following envirnment variable
-ENV OSQUERY_SRC_VERSION=3.3.2
-ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
-ONBUILD RUN cd / \
- && git clone "$OSQUERY_GIT_URL" \
- && cd osquery/ \
- && git checkout "$OSQUERY_SRC_VERSION" \
- && echo "Fetching osquery from git"
-
-
-#--------------- TEMP CONTAINER FOR OSQUERY ( BASED ON ARGUMENT ) ---------------
-FROM osquery_"$OSQUERY_BUILD_ENV" as osquery_image
-
-
-#--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM debian:10
 
 RUN apt-get update \
@@ -42,58 +17,21 @@ RUN apt-get update \
 #paths that hubble or hubble parts need in the package
 RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osquery/backuplogs
 
-#patchelf build start
-#must precede osquery as at the moment, osquery won't build without patchelf
-ENV PATCHELF_GIT_URL=https://github.com/NixOS/patchelf.git
-ENV PATCHELF_TEMP=/tmp/patchelf
-RUN apt-get -y install autoconf git make g++
-RUN mkdir -p "$PATCHELF_TEMP" \
- && cd "$PATCHELF_TEMP" \
- && git clone "$PATCHELF_GIT_URL" \
- && cd patchelf \
- && sed -i 's/serial-tests/parallel-tests/' configure.ac \
- && ./bootstrap.sh \
- && ./configure \
- && make \
- && make install
-
-#osquery build start
-#osquery should be built first since requirements for other packages can interfere with osquery dependencies
-#to build, osquery scripts want sudo and a user to sudo with.
-ENV OSQUERY_BUILD_USER=osquerybuilder
-RUN apt-get -y install git make python ruby sudo curl
-RUN useradd --shell /bin/bash --create-home --user-group --groups sudo "$OSQUERY_BUILD_USER" \
- && sed -i 's/^%sudo.*/%sudo\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
-COPY --from=osquery_image /osquery /home/"$OSQUERY_BUILD_USER"/osquery
-RUN mkdir -p /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
-USER $OSQUERY_BUILD_USER
-ENV SKIP_TESTS=1
-RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
- && make sysprep \
-#have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
- && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \
- && make deps \
- && make \
- && make strip
-USER root
-RUN cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery \
- && cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd \
- && chown -R root. /opt/osquery \
- && chmod -R 500 /opt/osquery/* \
-#put augeas lenses into the default directory that we changed earlier
- && mkdir -p /opt/osquery/lenses \
- && cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses \
- && chmod -R 400 /opt/osquery/lenses/*
-RUN ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version
+#copy in and process osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg
+ARG OSQUERY_TAR_FILENAME=osquery_4hubble.tar
+COPY ${OSQUERY_TAR_FILENAME} /opt/osquery/${OSQUERY_TAR_FILENAME}
+RUN cd /opt/osquery \
+ && tar xf "$OSQUERY_TAR_FILENAME" \
+ && rm -f "$OSQUERY_TAR_FILENAME" \
+ && cd / \
+ && /opt/osquery/osqueryi --version
 
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
-RUN apt-get -y install  \
-               python-dev libffi-dev libssl-dev libyaml-dev libssh2-1 libssh2-1-dev autoconf automake libtool \
-               libxml2-dev libxslt1-dev python-cffi \
-               zlib1g-dev cmake python-setuptools  \
-               gcc wget python-pip openssl \
+RUN apt-get -y install git curl \
+    python-dev libffi-dev libssl-dev libyaml-dev libssh2-1 libssh2-1-dev autoconf automake libtool \
+    libxml2-dev libxslt1-dev python-cffi \
+    zlib1g-dev cmake python-setuptools  \
+    gcc wget python-pip openssl \
  && apt-get clean
 
 #libcurl install start

--- a/pkg/debian10/Dockerfile
+++ b/pkg/debian10/Dockerfile
@@ -17,14 +17,10 @@ RUN apt-get update \
 #paths that hubble or hubble parts need in the package
 RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osquery/backuplogs
 
-#copy in and process osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg
+#extract osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg
 ARG OSQUERY_TAR_FILENAME=osquery_4hubble.tar
-COPY ${OSQUERY_TAR_FILENAME} /opt/osquery/${OSQUERY_TAR_FILENAME}
-RUN cd /opt/osquery \
- && tar xf "$OSQUERY_TAR_FILENAME" \
- && rm -f "$OSQUERY_TAR_FILENAME" \
- && cd / \
- && /opt/osquery/osqueryi --version
+ADD ${OSQUERY_TAR_FILENAME} /opt/osquery/
+RUN /opt/osquery/osqueryi --version
 
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
 RUN apt-get -y install git curl \

--- a/pkg/debian8/Dockerfile
+++ b/pkg/debian8/Dockerfile
@@ -1,39 +1,14 @@
-# This Dockerfile aims to make building Hubble v2 packages easier.
-# To build an image: 1. copy pkg/scripts/pyinstaller-requirements.txt to directory with this Dockerfile
-#                    2. docker build -t <image_name> .
-# The resulting image is ready to run the pyinstaller on container start and drop hubble<version>-coreos.tar.gz
-# in the /data directory. Mount /data volume into a directory on the host to access the package.
+# This Dockerfile aims to make building Hubble v4 packages easier.
+# Starting with version 4 building osquery is removed from individual Dockerfiles to its own.
+# osquery needs to be built once. Resulting tar file can be used in hubblev4 Dockerfiles.
+# Before building hubble, build osquery using a Dockerfile in pkg/osquery/ directory.
+# To build this image: 1. copy previously built osquery_4hubble.tar to directory with this Dockerfile
+#                      2. docker build -t <image_name> --build-arg=HUBBLE_CHECKOUT=<tag or commit> .
+# The resulting image is ready to build and run pyinstaller on container start that should 
+# create hubble<version>-debian.tar.gz in the /data directory inside the container.
+# Mount /data volume into a directory on the host to access the package.
 # To run the container:  docker run -it --rm -v `pwd`:/data <image_name>
-# Requires docker 17.05 or higher
 
-# Set this argument to "local" if you want to build osquery for local code.
-# In that case, osquery folder must exist besides Dockerfile
-ARG OSQUERY_BUILD_ENV=remote
-
-#--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
-FROM alpine as osquery_local
-ONBUILD COPY osquery /osquery
-ONBUILD RUN echo "Copying osquery from local folder"
-
-
-
-#--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
-FROM alpine/git as osquery_remote
-#to pin osquery to a different version change the following envirnment variable
-ENV OSQUERY_SRC_VERSION=3.3.2
-ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
-ONBUILD RUN cd / \
- && git clone "$OSQUERY_GIT_URL" \
- && cd osquery/ \
- && git checkout "$OSQUERY_SRC_VERSION" \
- && echo "Fetching osquery from git"
-
-
-#--------------- TEMP CONTAINER FOR OSQUERY ( BASED ON ARGUMENT ) ---------------
-FROM osquery_"$OSQUERY_BUILD_ENV" as osquery_image
-
-
-#--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM debian:8
 
 RUN apt-get update \
@@ -42,60 +17,20 @@ RUN apt-get update \
 #paths that hubble or hubble parts need in the package
 RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osquery/backuplogs
 
-#patchelf build start
-#must precede osquery as at the moment, osquery won't build without patchelf
-ENV PATCHELF_GIT_URL=https://github.com/NixOS/patchelf.git
-ENV PATCHELF_TEMP=/tmp/patchelf
-RUN apt-get -y install autoconf git make g++
-RUN mkdir -p "$PATCHELF_TEMP" \
- && cd "$PATCHELF_TEMP" \
- && git clone "$PATCHELF_GIT_URL" \
- && cd patchelf \
- && sed -i 's/serial-tests/parallel-tests/' configure.ac \
- && ./bootstrap.sh \
- && ./configure \
- && make \
- && make install
-
-#osquery build start
-#osquery should be built first since requirements for other packages can interfere with osquery dependencies
-#to build, osquery scripts want sudo and a user to sudo with.
-ENV OSQUERY_BUILD_USER=osquerybuilder
-RUN apt-get -y install git make python ruby sudo locales curl xz-utils
-RUN useradd --shell /bin/bash --create-home --user-group --groups sudo "$OSQUERY_BUILD_USER" \
- && sed -i 's/^%sudo.*/%sudo\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
-COPY --from=osquery_image /osquery /home/"$OSQUERY_BUILD_USER"/osquery
-RUN mkdir -p /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery \
- && echo "LC_ALL=en_US.UTF-8" >> /etc/default/locale \
- && sed -i '/en_US.UTF-8\ UTF-8/s/^#//' /etc/locale.gen \
- && locale-gen
-USER $OSQUERY_BUILD_USER
-ENV SKIP_TESTS=1
-RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
- && make sysprep \
-#have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
- && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \
- && make deps \
- && make \
- && make strip
-USER root
-RUN cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery \
- && cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd \
- && chown -R root. /opt/osquery \
- && chmod -R 500 /opt/osquery/* \
-#put augeas lenses into the default directory that we changed earlier
- && mkdir -p /opt/osquery/lenses \
- && cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses \
- && chmod -R 400 /opt/osquery/lenses/*
-RUN ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version
+#copy in and process osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg
+ARG OSQUERY_TAR_FILENAME=osquery_4hubble.tar
+COPY ${OSQUERY_TAR_FILENAME} /opt/osquery/${OSQUERY_TAR_FILENAME}
+RUN cd /opt/osquery \
+ && tar xf "$OSQUERY_TAR_FILENAME" \
+ && rm -f "$OSQUERY_TAR_FILENAME" \
+ && cd / \
+ && /opt/osquery/osqueryi --version
 
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
-RUN apt-get -y install  \
-               python-dev libffi-dev libssl-dev libyaml-dev libssh2-1 libssh2-1-dev autoconf automake libtool \
-               libxml2-dev libxslt1-dev zlib1g-dev cmake python-setuptools \
-               gcc wget openssl \
+RUN apt-get -y install git curl \
+    python-dev libffi-dev libssl-dev libyaml-dev libssh2-1 libssh2-1-dev autoconf automake libtool \
+    libxml2-dev libxslt1-dev zlib1g-dev cmake python-setuptools \
+    gcc wget openssl \
  && apt-get clean
 
 #libcurl install start

--- a/pkg/debian8/Dockerfile
+++ b/pkg/debian8/Dockerfile
@@ -17,14 +17,10 @@ RUN apt-get update \
 #paths that hubble or hubble parts need in the package
 RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osquery/backuplogs
 
-#copy in and process osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg
+#extract osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg
 ARG OSQUERY_TAR_FILENAME=osquery_4hubble.tar
-COPY ${OSQUERY_TAR_FILENAME} /opt/osquery/${OSQUERY_TAR_FILENAME}
-RUN cd /opt/osquery \
- && tar xf "$OSQUERY_TAR_FILENAME" \
- && rm -f "$OSQUERY_TAR_FILENAME" \
- && cd / \
- && /opt/osquery/osqueryi --version
+ADD ${OSQUERY_TAR_FILENAME} /opt/osquery/
+RUN /opt/osquery/osqueryi --version
 
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
 RUN apt-get -y install git curl \

--- a/pkg/debian8/Dockerfile
+++ b/pkg/debian8/Dockerfile
@@ -17,11 +17,6 @@ RUN apt-get update \
 #paths that hubble or hubble parts need in the package
 RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osquery/backuplogs
 
-#extract osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg
-ARG OSQUERY_TAR_FILENAME=osquery_4hubble.tar
-ADD ${OSQUERY_TAR_FILENAME} /opt/osquery/
-RUN /opt/osquery/osqueryi --version
-
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
 RUN apt-get -y install git curl \
     python-dev libffi-dev libssl-dev libyaml-dev libssh2-1 libssh2-1-dev autoconf automake libtool \
@@ -109,6 +104,11 @@ RUN umask 022 \
 
 RUN eval "$(pyenv init -)" \
  && pip -v install --upgrade pip
+
+#extract osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg
+ARG OSQUERY_TAR_FILENAME=osquery_4hubble.tar
+ADD ${OSQUERY_TAR_FILENAME} /opt/osquery/
+RUN /opt/osquery/osqueryi --version
 
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built

--- a/pkg/debian9/Dockerfile
+++ b/pkg/debian9/Dockerfile
@@ -17,11 +17,6 @@ RUN apt-get update \
 #paths that hubble or hubble parts need in the package
 RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osquery/backuplogs
 
-#extract osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg
-ARG OSQUERY_TAR_FILENAME=osquery_4hubble.tar
-ADD ${OSQUERY_TAR_FILENAME} /opt/osquery/
-RUN /opt/osquery/osqueryi --version
-
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
 RUN apt-get -y install git curl \
     python-dev libffi-dev libssl-dev libyaml-dev libssh2-1 libssh2-1-dev autoconf automake libtool \
@@ -110,6 +105,11 @@ RUN umask 022 \
 
 RUN eval "$(pyenv init -)" \
  && pip -v install --upgrade pip
+
+#extract osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg
+ARG OSQUERY_TAR_FILENAME=osquery_4hubble.tar
+ADD ${OSQUERY_TAR_FILENAME} /opt/osquery/
+RUN /opt/osquery/osqueryi --version
 
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built

--- a/pkg/debian9/Dockerfile
+++ b/pkg/debian9/Dockerfile
@@ -1,39 +1,14 @@
-# This Dockerfile aims to make building Hubble v2 packages easier.
-# To build an image: 1. copy pkg/scripts/pyinstaller-requirements.txt to directory with this Dockerfile
-#                    2. docker build -t <image_name> .
-# The resulting image is ready to run the pyinstaller on container start and drop hubble<version>-coreos.tar.gz
-# in the /data directory. Mount /data volume into a directory on the host to access the package.
+# This Dockerfile aims to make building Hubble v4 packages easier.
+# Starting with version 4 building osquery is removed from individual Dockerfiles to its own.
+# osquery needs to be built once. Resulting tar file can be used in hubblev4 Dockerfiles.
+# Before building hubble, build osquery using a Dockerfile in pkg/osquery/ directory.
+# To build this image: 1. copy previously built osquery_4hubble.tar to directory with this Dockerfile
+#                      2. docker build -t <image_name> --build-arg=HUBBLE_CHECKOUT=<tag or commit> .
+# The resulting image is ready to build and run pyinstaller on container start that should 
+# create hubble<version>-debian.tar.gz in the /data directory inside the container.
+# Mount /data volume into a directory on the host to access the package.
 # To run the container:  docker run -it --rm -v `pwd`:/data <image_name>
-# Requires docker 17.05 or higher
 
-# Set this argument to "local" if you want to build osquery for local code.
-# In that case, osquery folder must exist besides Dockerfile
-ARG OSQUERY_BUILD_ENV=remote
-
-#--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
-FROM alpine as osquery_local
-ONBUILD COPY osquery /osquery
-ONBUILD RUN echo "Copying osquery from local folder"
-
-
-
-#--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
-FROM alpine/git as osquery_remote
-#to pin osquery to a different version change the following envirnment variable
-ENV OSQUERY_SRC_VERSION=3.3.2
-ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
-ONBUILD RUN cd / \
- && git clone "$OSQUERY_GIT_URL" \
- && cd osquery/ \
- && git checkout "$OSQUERY_SRC_VERSION" \
- && echo "Fetching osquery from git"
-
-
-#--------------- TEMP CONTAINER FOR OSQUERY ( BASED ON ARGUMENT ) ---------------
-FROM osquery_"$OSQUERY_BUILD_ENV" as osquery_image
-
-
-#--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM debian:9
 
 RUN apt-get update \
@@ -42,58 +17,21 @@ RUN apt-get update \
 #paths that hubble or hubble parts need in the package
 RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osquery/backuplogs
 
-#patchelf build start
-#must precede osquery as at the moment, osquery won't build without patchelf
-ENV PATCHELF_GIT_URL=https://github.com/NixOS/patchelf.git
-ENV PATCHELF_TEMP=/tmp/patchelf
-RUN apt-get -y install autoconf git make g++
-RUN mkdir -p "$PATCHELF_TEMP" \
- && cd "$PATCHELF_TEMP" \
- && git clone "$PATCHELF_GIT_URL" \
- && cd patchelf \
- && sed -i 's/serial-tests/parallel-tests/' configure.ac \
- && ./bootstrap.sh \
- && ./configure \
- && make \
- && make install
-
-#osquery build start
-#osquery should be built first since requirements for other packages can interfere with osquery dependencies
-#to build, osquery scripts want sudo and a user to sudo with.
-ENV OSQUERY_BUILD_USER=osquerybuilder
-RUN apt-get -y install git make python ruby sudo curl
-RUN useradd --shell /bin/bash --create-home --user-group --groups sudo "$OSQUERY_BUILD_USER" \
- && sed -i 's/^%sudo.*/%sudo\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
-COPY --from=osquery_image /osquery /home/"$OSQUERY_BUILD_USER"/osquery
-RUN mkdir -p /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
-USER $OSQUERY_BUILD_USER
-ENV SKIP_TESTS=1
-RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
- && make sysprep \
-#have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
- && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \
- && make deps \
- && make \
- && make strip
-USER root
-RUN cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery \
- && cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd \
- && chown -R root. /opt/osquery \
- && chmod -R 500 /opt/osquery/* \
-#put augeas lenses into the default directory that we changed earlier
- && mkdir -p /opt/osquery/lenses \
- && cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses \
- && chmod -R 400 /opt/osquery/lenses/*
-RUN ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version
+#copy in and process osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg
+ARG OSQUERY_TAR_FILENAME=osquery_4hubble.tar
+COPY ${OSQUERY_TAR_FILENAME} /opt/osquery/${OSQUERY_TAR_FILENAME}
+RUN cd /opt/osquery \
+ && tar xf "$OSQUERY_TAR_FILENAME" \
+ && rm -f "$OSQUERY_TAR_FILENAME" \
+ && cd / \
+ && /opt/osquery/osqueryi --version
 
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
-RUN apt-get -y install  \
-               python-dev libffi-dev libssl-dev libyaml-dev libssh2-1 libssh2-1-dev autoconf automake libtool \
-               libxml2-dev libxslt1-dev python-cffi \
-               zlib1g-dev cmake python-setuptools  \
-               gcc wget python-pip openssl \
+RUN apt-get -y install git curl \
+    python-dev libffi-dev libssl-dev libyaml-dev libssh2-1 libssh2-1-dev autoconf automake libtool \
+    libxml2-dev libxslt1-dev python-cffi \
+    zlib1g-dev cmake python-setuptools  \
+    gcc wget python-pip openssl \
  && apt-get clean
 
 #libcurl install start

--- a/pkg/debian9/Dockerfile
+++ b/pkg/debian9/Dockerfile
@@ -17,14 +17,10 @@ RUN apt-get update \
 #paths that hubble or hubble parts need in the package
 RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osquery/backuplogs
 
-#copy in and process osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg
+#extract osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg
 ARG OSQUERY_TAR_FILENAME=osquery_4hubble.tar
-COPY ${OSQUERY_TAR_FILENAME} /opt/osquery/${OSQUERY_TAR_FILENAME}
-RUN cd /opt/osquery \
- && tar xf "$OSQUERY_TAR_FILENAME" \
- && rm -f "$OSQUERY_TAR_FILENAME" \
- && cd / \
- && /opt/osquery/osqueryi --version
+ADD ${OSQUERY_TAR_FILENAME} /opt/osquery/
+RUN /opt/osquery/osqueryi --version
 
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
 RUN apt-get -y install git curl \

--- a/pkg/osquery/Dockerfile
+++ b/pkg/osquery/Dockerfile
@@ -1,0 +1,56 @@
+# This dockerfile builds the osquery binary and files that will run on majority of current Linux distributions.
+# To build the image: docker build -t <image_name> .
+# The image can be used to include the needed osquery files in Hubble packaging process.
+# To override the name of the tar file pass in OSQUERY_TAR_FILENAME environment variable with the desired value.
+# To create the file run the container: docker run -it --rm -v `pwd`:/data <image_name>
+
+FROM ubuntu:18.04
+
+#osquery build start
+ENV OSQUERY_BUILD_USER=osquerybuilder
+ENV OSQUERY_GIT_URL=https://github.com/osquery/osquery.git
+ENV OSQUERY_SRC_VERSION=4.3.0
+
+#building osquery requires osquery-toolchain and cmake
+#make sure osquery-toolchain is compatible with the osquery version you want to build
+ENV OSQUERY_TOOLCHAIN_SRC_URL=https://github.com/osquery/osquery-toolchain/releases/download/1.1.0/osquery-toolchain-1.1.0-x86_64.tar.xz
+ENV OSQUERY_TOOLCHAIN_SRC_SHA256=9cc3980383e0626276d3762af60035f36ada5886389a1292774e89db013a2353
+ENV CMAKE_SRC_URL=https://github.com/Kitware/CMake/releases/download/v3.14.6/cmake-3.14.6-Linux-x86_64.tar.gz
+ENV CMAKE_SRC_SHA256=82e08e50ba921035efa82b859c74c5fbe27d3e49a4003020e3c77618a4e912cd
+#prepare the requirements for building
+RUN apt-get -y update && apt-get -y upgrade \
+ && apt-get -y install --no-install-recommends wget ca-certificates xz-utils git python3 bison flex make \
+ && apt-get clean && rm -rf /var/lib/apt/lists/* \
+ && useradd --shell /bin/bash --create-home --user-group "$OSQUERY_BUILD_USER"
+
+RUN wget -q "$OSQUERY_TOOLCHAIN_SRC_URL" -O osquery-toolchain-x86_64.tar.xz \
+ && echo "$OSQUERY_TOOLCHAIN_SRC_SHA256 osquery-toolchain-x86_64.tar.xz" | sha256sum -c - \
+ && tar xf osquery-toolchain-x86_64.tar.xz -C /usr/local \
+ && wget -q "$CMAKE_SRC_URL" -O cmake-Linux-x86_64.tar.gz \
+ && echo "$CMAKE_SRC_SHA256 cmake-Linux-x86_64.tar.gz" | sha256sum -c - \
+ && tar xf cmake-Linux-x86_64.tar.gz -C /usr/local --strip 1 
+
+USER $OSQUERY_BUILD_USER
+
+RUN cd /home/"$OSQUERY_BUILD_USER" \
+ && git clone "$OSQUERY_GIT_URL" \
+ && cd osquery/ \
+ && git checkout "$OSQUERY_SRC_VERSION" \
+ && mkdir build \
+ && cd build \
+ && cmake -DOSQUERY_TOOLCHAIN_SYSROOT=/usr/local/osquery-toolchain .. \
+#adjust j to number of cores available for building
+ && cmake --build . -j4 \
+ && /usr/local/osquery-toolchain/usr/bin/strip osquery/osqueryd
+
+USER root
+
+#collect all files and prepare them into a tar file
+RUN mkdir -p /opt/osquery/lenses /opt/osquery/yara /opt/osquery/extensions \
+ && cp /home/"$OSQUERY_BUILD_USER"/osquery/build/osquery/osqueryd /opt/osquery \
+ && cp -r /home/"$OSQUERY_BUILD_USER"/osquery/libraries/cmake/source/augeas/src/lenses /opt/osquery/ \
+ && rm -rf /opt/osquery/lenses/tests/ \
+ && chown -R root. /opt/osquery \
+ && chmod -R 500 /opt/osquery/*
+
+CMD [ "/bin/bash", "-c", "cd /opt/osquery ; tar -cvf /data/${OSQUERY_TAR_FILENAME:-osquery_4hubble.tar} *" ]


### PR DESCRIPTION
* include new Dockerfile for building osquery
* remove osquery build from all other Dockerfiles
* have augeas lens folder to be passed in by Hubble for snapshot queries