### PR TITLE
Modifying Dockerfiles to support use pre-built osquery

### DIFF
--- a/pkg/amazonlinux2016.09/Dockerfile
+++ b/pkg/amazonlinux2016.09/Dockerfile
@@ -8,8 +8,8 @@
 # Requires docker 17.05 or higher
 
 #Hubble builds can have the following 3 combinations wrt osquery:
-# 1. Package already built osquery. (BUILD_OSQUERY=false)
-# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 1. Package already built osquery. (BUILD_OSQUERY=false). Keep the osquery tar file besides this Dockerfile.
+# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true). Keep the osquery source code besides this Dockerfile.
 # 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM amazonlinux:2016.09

--- a/pkg/amazonlinux2016.09/Dockerfile
+++ b/pkg/amazonlinux2016.09/Dockerfile
@@ -1,38 +1,16 @@
 # This Dockerfile aims to make building Hubble v2 packages easier.
 # To build an image: 1. copy pkg/scripts/pyinstaller-requirements.txt to directory with this Dockerfile
-#                    2. docker build -t <image_name> .
+#                    2. copy osquerybuilder.sh to this directory. This is needed to bundle osquery with Hubble
+#                    3. docker build -t <image_name> .
 # The resulting image is ready to run the pyinstaller on container start and drop hubble<version>-coreos.tar.gz
 # in the /data directory. Mount /data volume into a directory on the host to access the package.
 # To run the container:  docker run -it --rm -v `pwd`:/data <image_name>
 # Requires docker 17.05 or higher
 
-# Set this arguement to "local" if you want to build osquery for local code.
-# In that case, osquery folder must exist besides Dockerfile
-#ARG OSQUERY_BUILD_ENV=remote
-
-#--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
-#FROM alpine as osquery_local
-#ONBUILD COPY osquery /osquery
-#ONBUILD RUN echo "Copying osquery from local folder"
-
-
-
-#--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
-#FROM alpine/git as osquery_remote
-#to pin osquery to a different version change the following envirnment variable
-#ENV OSQUERY_SRC_VERSION=3.3.2
-#ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
-#ONBUILD RUN cd / \
-# && git clone "$OSQUERY_GIT_URL" \
-# && cd osquery/ \
-# && git checkout "$OSQUERY_SRC_VERSION" \
-# && echo "Fetching osquery from git"
-
-
-#--------------- TEMP CONTAINER FOR OSQUERY ( BASED ON ARGUMENT ) --------------
-#FROM osquery_"$OSQUERY_BUILD_ENV" as osquery_image
-
-
+#Hubble builds can have the following 3 combinations wrt osquery:
+# 1. Package already built osquery. (BUILD_OSQUERY=false)
+# 2. Build osquery from https://git.corp.adobe.com/hubblestack/osquery. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM amazonlinux:2016.09
 
@@ -58,29 +36,6 @@ RUN useradd --shell /bin/bash --create-home --user-group --groups wheel "$OSQUER
  && sed -i '0,/^#\ %wheel/s/^#\ %wheel.*/%wheel\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
 ADD osquerybuilder.sh /osquerybuilder.sh
 RUN sh /osquerybuilder.sh "$BUILD_OSQUERY" "$BUILD_OSQUERY_LOCALLY"
-#COPY --from=osquery_image /osquery /home/"$OSQUERY_BUILD_USER"/osquery
-#RUN mkdir -p /usr/local/osquery/ \
-# && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
-# && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
-#USER $OSQUERY_BUILD_USER
-#ENV SKIP_TESTS=1
-#RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
-# && make sysprep \
-#have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
-# && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \
-# && make deps \
-# && make \
-# && make strip
-#USER root
-#RUN cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery \
-# && cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd \
-# && chown -R root. /opt/osquery \
-# && chmod -R 500 /opt/osquery/* \
-#put augeas lenses into the default directory that we changed earlier
-# && mkdir -p /opt/osquery/lenses \
-# && cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses \
-# && chmod -R 400 /opt/osquery/lenses/*
-#RUN ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version
 
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
 USER root

--- a/pkg/amazonlinux2016.09/Dockerfile
+++ b/pkg/amazonlinux2016.09/Dockerfile
@@ -8,29 +8,29 @@
 
 # Set this arguement to "local" if you want to build osquery for local code.
 # In that case, osquery folder must exist besides Dockerfile
-ARG OSQUERY_BUILD_ENV=remote
+#ARG OSQUERY_BUILD_ENV=remote
 
 #--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
-FROM alpine as osquery_local
-ONBUILD COPY osquery /osquery
-ONBUILD RUN echo "Copying osquery from local folder"
+#FROM alpine as osquery_local
+#ONBUILD COPY osquery /osquery
+#ONBUILD RUN echo "Copying osquery from local folder"
 
 
 
 #--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
-FROM alpine/git as osquery_remote
+#FROM alpine/git as osquery_remote
 #to pin osquery to a different version change the following envirnment variable
-ENV OSQUERY_SRC_VERSION=3.3.2
-ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
-ONBUILD RUN cd / \
- && git clone "$OSQUERY_GIT_URL" \
- && cd osquery/ \
- && git checkout "$OSQUERY_SRC_VERSION" \
- && echo "Fetching osquery from git"
+#ENV OSQUERY_SRC_VERSION=3.3.2
+#ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
+#ONBUILD RUN cd / \
+# && git clone "$OSQUERY_GIT_URL" \
+# && cd osquery/ \
+# && git checkout "$OSQUERY_SRC_VERSION" \
+# && echo "Fetching osquery from git"
 
 
 #--------------- TEMP CONTAINER FOR OSQUERY ( BASED ON ARGUMENT ) --------------
-FROM osquery_"$OSQUERY_BUILD_ENV" as osquery_image
+#FROM osquery_"$OSQUERY_BUILD_ENV" as osquery_image
 
 
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
@@ -45,34 +45,45 @@ RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osque
 #osquery should be built first since requirements for other packages can interfere with osquery dependencies
 #to build, osquery scripts want sudo and a user to sudo with.
 ENV OSQUERY_BUILD_USER=osquerybuilder
+ARG BUILD_OSQUERY=true
+ARG BUILD_OSQUERY_LOCALLY=false
+ARG OSQUERY_SRC_VERSION=osquery_3.3.2_tob
+COPY osquery /osquery
+COPY $OSQUERY_SRC_VERSION /osqueryi
+COPY $OSQUERY_SRC_VERSION /osqueryd
+
+ENV OSQUERY_BUILD_USER=osquerybuilder
 RUN yum -y install git make python ruby sudo which
 RUN useradd --shell /bin/bash --create-home --user-group --groups wheel "$OSQUERY_BUILD_USER" \
  && sed -i '0,/^#\ %wheel/s/^#\ %wheel.*/%wheel\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
-COPY --from=osquery_image /osquery /home/"$OSQUERY_BUILD_USER"/osquery
-RUN mkdir -p /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
-USER $OSQUERY_BUILD_USER
-ENV SKIP_TESTS=1
-RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
- && make sysprep \
+ADD osquerybuilder.sh /osquerybuilder.sh
+RUN sh /osquerybuilder.sh "$BUILD_OSQUERY" "$BUILD_OSQUERY_LOCALLY"
+#COPY --from=osquery_image /osquery /home/"$OSQUERY_BUILD_USER"/osquery
+#RUN mkdir -p /usr/local/osquery/ \
+# && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
+# && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
+#USER $OSQUERY_BUILD_USER
+#ENV SKIP_TESTS=1
+#RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
+# && make sysprep \
 #have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
- && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \
- && make deps \
- && make \
- && make strip
-USER root
-RUN cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery \
- && cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd \
- && chown -R root. /opt/osquery \
- && chmod -R 500 /opt/osquery/* \
+# && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \
+# && make deps \
+# && make \
+# && make strip
+#USER root
+#RUN cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery \
+# && cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd \
+# && chown -R root. /opt/osquery \
+# && chmod -R 500 /opt/osquery/* \
 #put augeas lenses into the default directory that we changed earlier
- && mkdir -p /opt/osquery/lenses \
- && cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses \
- && chmod -R 400 /opt/osquery/lenses/*
-RUN ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version
+# && mkdir -p /opt/osquery/lenses \
+# && cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses \
+# && chmod -R 400 /opt/osquery/lenses/*
+#RUN ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version
 
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
+USER root
 RUN yum -y install  \
                python27-devel libffi-devel openssl-devel libssh2-devel autoconf automake libtool \
                libxml2-devel libxslt-devel libjpeg-devel \

--- a/pkg/amazonlinux2016.09/Dockerfile
+++ b/pkg/amazonlinux2016.09/Dockerfile
@@ -49,8 +49,8 @@ ARG BUILD_OSQUERY=true
 ARG BUILD_OSQUERY_LOCALLY=false
 ARG OSQUERY_SRC_VERSION=osquery_3.3.2_tob
 COPY osquery /osquery
-COPY $OSQUERY_SRC_VERSION /osqueryi
-COPY $OSQUERY_SRC_VERSION /osqueryd
+ENV OSQUERY_TAR_FILENAME=$OSQUERY_SRC_VERSION"_amazonlinux2016.09.tar"
+COPY $OSQUERY_TAR_FILENAME /
 
 ENV OSQUERY_BUILD_USER=osquerybuilder
 RUN yum -y install git make python ruby sudo which

--- a/pkg/amazonlinux2016.09/Dockerfile
+++ b/pkg/amazonlinux2016.09/Dockerfile
@@ -117,8 +117,8 @@ RUN yum install -y ruby ruby-devel rpmbuild rpm-build rubygems gcc make \
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
-ENV HUBBLE_CHECKOUT=v3.0.12
-ENV HUBBLE_VERSION=3.0.12
+ENV HUBBLE_CHECKOUT=v3.0.13
+ENV HUBBLE_VERSION=3.0.13
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_URL=https://github.com/hubblestack/hubble
 ENV HUBBLE_DESCRIPTION="Hubble is a modular, open-source, security & compliance auditing framework which is built in python, using SaltStack as a library."

--- a/pkg/amazonlinux2016.09/Dockerfile
+++ b/pkg/amazonlinux2016.09/Dockerfile
@@ -9,7 +9,7 @@
 
 #Hubble builds can have the following 3 combinations wrt osquery:
 # 1. Package already built osquery. (BUILD_OSQUERY=false)
-# 2. Build osquery from https://git.corp.adobe.com/hubblestack/osquery. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
 # 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM amazonlinux:2016.09

--- a/pkg/amazonlinux2016.09/osquerybuilder.sh
+++ b/pkg/amazonlinux2016.09/osquerybuilder.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+build_osquery=$1
+build_osquery_locally=$2
+
+if [ $build_osquery != true ]
+then
+  mkdir -p /opt/osquery/
+  cp /osqueryi /opt/osquery/osqueryi
+  cp /osqueryd /opt/osquery/hubble_osqueryd
+  echo $build_osquery
+else
+  echo $build_osquery_locally
+  if [ $build_osquery_locally == true ]
+  then
+    echo "Building osquery from local folder"
+  else
+    rm -rf /osquery
+    OSQUERY_SRC_VERSION=3.3.2
+    OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
+    cd /
+    git clone "$OSQUERY_GIT_URL"
+    cd osquery/
+    git checkout "$OSQUERY_SRC_VERSION"
+    echo "Fetching osquery from git"
+    echo $OSQUERY_SRC_VERSION
+  fi
+  mkdir /home/"$OSQUERY_BUILD_USER"/osquery
+  cp -r /osquery/ /home/"$OSQUERY_BUILD_USER"/
+  mkdir -p /usr/local/osquery/
+  chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/
+  chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
+  
+  export SKIP_TESTS=1
+  cd /home/"$OSQUERY_BUILD_USER"/osquery 
+  sudo -u "$OSQUERY_BUILD_USER" make sysprep
+  sudo -u "$OSQUERY_BUILD_USER" sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp
+  sudo -u "$OSQUERY_BUILD_USER" make deps
+  sudo -u "$OSQUERY_BUILD_USER" make
+  sudo -u "$OSQUERY_BUILD_USER" make strip
+  cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery/osqueryi
+  cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd
+fi
+chown -R root. /opt/osquery
+chmod -R 500 /opt/osquery/*
+mkdir -p /opt/osquery/lenses
+cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses
+chmod -R 400 /opt/osquery/lenses/*
+ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version

--- a/pkg/amazonlinux2016.09/osquerybuilder.sh
+++ b/pkg/amazonlinux2016.09/osquerybuilder.sh
@@ -5,9 +5,7 @@ build_osquery_locally=$2
 
 if [ $build_osquery != true ]
 then
-  mkdir -p /opt/osquery/
-  cp /osqueryi /opt/osquery/osqueryi
-  cp /osqueryd /opt/osquery/hubble_osqueryd
+  tar -C /opt/ -zxvf osquery_*_tob_amazonlinux2016.09.tar
   echo $build_osquery
 else
   echo $build_osquery_locally

--- a/pkg/amazonlinux2016.09/osquerybuilder.sh
+++ b/pkg/amazonlinux2016.09/osquerybuilder.sh
@@ -40,10 +40,10 @@ else
   sudo -u "$OSQUERY_BUILD_USER" make strip
   cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery/osqueryi
   cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd
+  mkdir -p /opt/osquery/lenses
+  cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses
 fi
 chown -R root. /opt/osquery
 chmod -R 500 /opt/osquery/*
-mkdir -p /opt/osquery/lenses
-cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses
 chmod -R 400 /opt/osquery/lenses/*
 ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version

--- a/pkg/centos6/Dockerfile
+++ b/pkg/centos6/Dockerfile
@@ -8,29 +8,29 @@
 
 # Set this arguement to "local" if you want to build osquery for local code.
 # In that case, osquery folder must exist besides Dockerfile
-ARG OSQUERY_BUILD_ENV=remote
+#ARG OSQUERY_BUILD_ENV=remote
 
 #--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
-FROM alpine as osquery_local
-ONBUILD COPY osquery /osquery
-ONBUILD RUN echo "Copying osquery from local folder"
+#FROM alpine as osquery_local
+#ONBUILD COPY osquery /osquery
+#ONBUILD RUN echo "Copying osquery from local folder"
 
 
 
 #--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
-FROM alpine/git as osquery_remote
+#FROM alpine/git as osquery_remote
 #to pin osquery to a different version change the following envirnment variable
-ENV OSQUERY_SRC_VERSION=3.3.2
-ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
-ONBUILD RUN cd / \
- && git clone "$OSQUERY_GIT_URL" \
- && cd osquery/ \
- && git checkout "$OSQUERY_SRC_VERSION" \
- && echo "Fetching osquery from git"
+#ENV OSQUERY_SRC_VERSION=3.3.2
+#ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
+#ONBUILD RUN cd / \
+# && git clone "$OSQUERY_GIT_URL" \
+# && cd osquery/ \
+# && git checkout "$OSQUERY_SRC_VERSION" \
+# && echo "Fetching osquery from git"
 
 
 #--------------- TEMP CONTAINER FOR OSQUERY ( BASED ON ARGUMENT ) ---------------
-FROM osquery_"$OSQUERY_BUILD_ENV" as osquery_image
+#FROM osquery_"$OSQUERY_BUILD_ENV" as osquery_image
 
 
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
@@ -44,35 +44,48 @@ RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osque
 #osquery build start
 #osquery should be built first since requirements for other packages can interfere with osquery dependencies
 #to build, osquery scripts want sudo and a user to sudo with.
+
 ENV OSQUERY_BUILD_USER=osquerybuilder
+ARG BUILD_OSQUERY=true
+ARG BUILD_OSQUERY_LOCALLY=false
+ARG OSQUERY_SRC_VERSION=osquery_3.3.2_tob
+COPY osquery /osquery
+COPY $OSQUERY_SRC_VERSION /osqueryi
+COPY $OSQUERY_SRC_VERSION /osqueryd
+
 RUN yum -y install xz git make python ruby sudo which python-argparse
 RUN useradd --shell /bin/bash --create-home --user-group --groups wheel "$OSQUERY_BUILD_USER" \
  && sed -i '0,/^#\ %wheel/s/^#\ %wheel.*/%wheel\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
-COPY --from=osquery_image /osquery /home/"$OSQUERY_BUILD_USER"/osquery
-RUN mkdir -p /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
-USER $OSQUERY_BUILD_USER
-ENV SKIP_TESTS=1
-RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
- && make sysprep \
+
+ADD osquerybuilder.sh /osquerybuilder.sh
+RUN sh /osquerybuilder.sh "$BUILD_OSQUERY" "$BUILD_OSQUERY_LOCALLY"
+
+#COPY --from=osquery_image /osquery /home/"$OSQUERY_BUILD_USER"/osquery
+#RUN mkdir -p /usr/local/osquery/ \
+# && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
+# && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
+#USER $OSQUERY_BUILD_USER
+#ENV SKIP_TESTS=1
+#RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
+# && make sysprep \
 #have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
- && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \
- && make deps \
- && make \
- && make strip
-USER root
-RUN cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery \
- && cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd \
- && chown -R root. /opt/osquery \
- && chmod -R 500 /opt/osquery/* \
+# && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \
+# && make deps \
+# && make \
+# && make strip
+#USER root
+#RUN cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery \
+# && cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd \
+# && chown -R root. /opt/osquery \
+# && chmod -R 500 /opt/osquery/* \
 #put augeas lenses into the default directory that we changed earlier
- && mkdir -p /opt/osquery/lenses \
- && cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses \
- && chmod -R 400 /opt/osquery/lenses/*
-RUN ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version
+# && mkdir -p /opt/osquery/lenses \
+# && cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses \
+# && chmod -R 400 /opt/osquery/lenses/*
+#RUN ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version
 
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
+USER root
 RUN yum -y install  \
                libffi-devel openssl-devel libxml2-devel libxslt-devel libffi libssh2-devel autoconf automake libtool \
                libjpeg-devel zlib-devel python-devel make cmake gcc \

--- a/pkg/centos6/Dockerfile
+++ b/pkg/centos6/Dockerfile
@@ -8,8 +8,8 @@
 # Requires docker 17.05 or higher
 
 #Hubble builds can have the following 3 combinations wrt osquery:
-# 1. Package already built osquery. (BUILD_OSQUERY=false)
-# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 1. Package already built osquery. (BUILD_OSQUERY=false). Keep the osquery tar file besides this Dockerfile.
+# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true). Keep the osquery source code besides this Dockerfile.
 # 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM centos:6

--- a/pkg/centos6/Dockerfile
+++ b/pkg/centos6/Dockerfile
@@ -50,8 +50,8 @@ ARG BUILD_OSQUERY=true
 ARG BUILD_OSQUERY_LOCALLY=false
 ARG OSQUERY_SRC_VERSION=osquery_3.3.2_tob
 COPY osquery /osquery
-COPY $OSQUERY_SRC_VERSION /osqueryi
-COPY $OSQUERY_SRC_VERSION /osqueryd
+ENV OSQUERY_TAR_FILENAME=$OSQUERY_SRC_VERSION"_centos6.tar"
+COPY $OSQUERY_TAR_FILENAME /
 
 RUN yum -y install xz git make python ruby sudo which python-argparse
 RUN useradd --shell /bin/bash --create-home --user-group --groups wheel "$OSQUERY_BUILD_USER" \

--- a/pkg/centos6/Dockerfile
+++ b/pkg/centos6/Dockerfile
@@ -1,38 +1,16 @@
 # This Dockerfile aims to make building Hubble v2 packages easier.
 # To build an image: 1. copy pkg/scripts/pyinstaller-requirements.txt to directory with this Dockerfile
-#                    2. docker build -t <image_name> .
+#                    2. copy osquerybuilder.sh to this directory. This is needed to bundle osquery with Hubble
+#                    3. docker build -t <image_name> .
 # The resulting image is ready to run the pyinstaller on container start and drop hubble<version>-coreos.tar.gz
 # in the /data directory. Mount /data volume into a directory on the host to access the package.
 # To run the container:  docker run -it --rm -v `pwd`:/data <image_name>
 # Requires docker 17.05 or higher
 
-# Set this arguement to "local" if you want to build osquery for local code.
-# In that case, osquery folder must exist besides Dockerfile
-#ARG OSQUERY_BUILD_ENV=remote
-
-#--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
-#FROM alpine as osquery_local
-#ONBUILD COPY osquery /osquery
-#ONBUILD RUN echo "Copying osquery from local folder"
-
-
-
-#--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
-#FROM alpine/git as osquery_remote
-#to pin osquery to a different version change the following envirnment variable
-#ENV OSQUERY_SRC_VERSION=3.3.2
-#ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
-#ONBUILD RUN cd / \
-# && git clone "$OSQUERY_GIT_URL" \
-# && cd osquery/ \
-# && git checkout "$OSQUERY_SRC_VERSION" \
-# && echo "Fetching osquery from git"
-
-
-#--------------- TEMP CONTAINER FOR OSQUERY ( BASED ON ARGUMENT ) ---------------
-#FROM osquery_"$OSQUERY_BUILD_ENV" as osquery_image
-
-
+#Hubble builds can have the following 3 combinations wrt osquery:
+# 1. Package already built osquery. (BUILD_OSQUERY=false)
+# 2. Build osquery from https://git.corp.adobe.com/hubblestack/osquery. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM centos:6
 
@@ -59,30 +37,6 @@ RUN useradd --shell /bin/bash --create-home --user-group --groups wheel "$OSQUER
 
 ADD osquerybuilder.sh /osquerybuilder.sh
 RUN sh /osquerybuilder.sh "$BUILD_OSQUERY" "$BUILD_OSQUERY_LOCALLY"
-
-#COPY --from=osquery_image /osquery /home/"$OSQUERY_BUILD_USER"/osquery
-#RUN mkdir -p /usr/local/osquery/ \
-# && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
-# && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
-#USER $OSQUERY_BUILD_USER
-#ENV SKIP_TESTS=1
-#RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
-# && make sysprep \
-#have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
-# && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \
-# && make deps \
-# && make \
-# && make strip
-#USER root
-#RUN cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery \
-# && cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd \
-# && chown -R root. /opt/osquery \
-# && chmod -R 500 /opt/osquery/* \
-#put augeas lenses into the default directory that we changed earlier
-# && mkdir -p /opt/osquery/lenses \
-# && cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses \
-# && chmod -R 400 /opt/osquery/lenses/*
-#RUN ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version
 
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
 USER root

--- a/pkg/centos6/Dockerfile
+++ b/pkg/centos6/Dockerfile
@@ -120,8 +120,8 @@ RUN yum install -y rpmbuild rpm-build gcc make rh-ruby23 rh-ruby23-ruby-devel \
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
-ENV HUBBLE_CHECKOUT=v3.0.12
-ENV HUBBLE_VERSION=3.0.12
+ENV HUBBLE_CHECKOUT=v3.0.13
+ENV HUBBLE_VERSION=3.0.13
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_URL=https://github.com/hubblestack/hubble
 ENV HUBBLE_DESCRIPTION="Hubble is a modular, open-source, security & compliance auditing framework which is built in python, using SaltStack as a library."

--- a/pkg/centos6/Dockerfile
+++ b/pkg/centos6/Dockerfile
@@ -9,7 +9,7 @@
 
 #Hubble builds can have the following 3 combinations wrt osquery:
 # 1. Package already built osquery. (BUILD_OSQUERY=false)
-# 2. Build osquery from https://git.corp.adobe.com/hubblestack/osquery. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
 # 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM centos:6

--- a/pkg/centos6/osquerybuilder.sh
+++ b/pkg/centos6/osquerybuilder.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+build_osquery=$1
+build_osquery_locally=$2
+
+if [ $build_osquery != true ]
+then
+  mkdir -p /opt/osquery/
+  cp /osqueryi /opt/osquery/osqueryi
+  cp /osqueryd /opt/osquery/hubble_osqueryd
+  echo $build_osquery
+else
+  echo $build_osquery_locally
+  if [ $build_osquery_locally == true ]
+  then
+    echo "Building osquery from local folder"
+  else
+    rm -rf /osquery
+    OSQUERY_SRC_VERSION=3.3.2
+    OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
+    cd /
+    git clone "$OSQUERY_GIT_URL"
+    cd osquery/
+    git checkout "$OSQUERY_SRC_VERSION"
+    echo "Fetching osquery from git"
+    echo $OSQUERY_SRC_VERSION
+  fi
+  mkdir /home/"$OSQUERY_BUILD_USER"/osquery
+  cp -r /osquery/ /home/"$OSQUERY_BUILD_USER"/
+  mkdir -p /usr/local/osquery/
+  chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/
+  chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
+  
+  export SKIP_TESTS=1
+  cd /home/"$OSQUERY_BUILD_USER"/osquery 
+  sudo -u "$OSQUERY_BUILD_USER" make sysprep
+  sudo -u "$OSQUERY_BUILD_USER" sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp
+  sudo -u "$OSQUERY_BUILD_USER" make deps
+  sudo -u "$OSQUERY_BUILD_USER" make
+  sudo -u "$OSQUERY_BUILD_USER" make strip
+  cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery/osqueryi
+  cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd
+fi
+chown -R root. /opt/osquery
+chmod -R 500 /opt/osquery/*
+mkdir -p /opt/osquery/lenses
+cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses
+chmod -R 400 /opt/osquery/lenses/*
+ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version

--- a/pkg/centos6/osquerybuilder.sh
+++ b/pkg/centos6/osquerybuilder.sh
@@ -5,9 +5,7 @@ build_osquery_locally=$2
 
 if [ $build_osquery != true ]
 then
-  mkdir -p /opt/osquery/
-  cp /osqueryi /opt/osquery/osqueryi
-  cp /osqueryd /opt/osquery/hubble_osqueryd
+  tar -C /opt/ -zxvf osquery_*_tob_centos6.tar
   echo $build_osquery
 else
   echo $build_osquery_locally

--- a/pkg/centos6/osquerybuilder.sh
+++ b/pkg/centos6/osquerybuilder.sh
@@ -40,10 +40,10 @@ else
   sudo -u "$OSQUERY_BUILD_USER" make strip
   cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery/osqueryi
   cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd
+  mkdir -p /opt/osquery/lenses
+  cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses
 fi
 chown -R root. /opt/osquery
 chmod -R 500 /opt/osquery/*
-mkdir -p /opt/osquery/lenses
-cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses
 chmod -R 400 /opt/osquery/lenses/*
 ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version

--- a/pkg/centos7/Dockerfile
+++ b/pkg/centos7/Dockerfile
@@ -53,8 +53,7 @@ ARG BUILD_OSQUERY=true
 ARG BUILD_OSQUERY_LOCALLY=false
 ARG OSQUERY_SRC_VERSION=osquery_3.3.2_tob
 COPY osquery /osquery
-COPY $OSQUERY_SRC_VERSION /osqueryi
-COPY $OSQUERY_SRC_VERSION /osqueryd
+COPY $OSQUERY_SRC_VERSION_centos7.tar /
 RUN yum -y install git make python ruby sudo which
 RUN useradd --shell /bin/bash --create-home --user-group --groups wheel "$OSQUERY_BUILD_USER" \
  && sed -i '0,/^#\ %wheel/s/^#\ %wheel.*/%wheel\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers

--- a/pkg/centos7/Dockerfile
+++ b/pkg/centos7/Dockerfile
@@ -53,7 +53,8 @@ ARG BUILD_OSQUERY=true
 ARG BUILD_OSQUERY_LOCALLY=false
 ARG OSQUERY_SRC_VERSION=osquery_3.3.2_tob
 COPY osquery /osquery
-COPY $OSQUERY_SRC_VERSION_centos7.tar /
+ENV OSQUERY_TAR_FILENAME=$OSQUERY_SRC_VERSION"_centos7.tar"
+COPY $OSQUERY_TAR_FILENAME /
 RUN yum -y install git make python ruby sudo which
 RUN useradd --shell /bin/bash --create-home --user-group --groups wheel "$OSQUERY_BUILD_USER" \
  && sed -i '0,/^#\ %wheel/s/^#\ %wheel.*/%wheel\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers

--- a/pkg/centos7/Dockerfile
+++ b/pkg/centos7/Dockerfile
@@ -9,7 +9,7 @@
 
 #Hubble builds can have the following 3 combinations wrt osquery:
 # 1. Package already built osquery. (BUILD_OSQUERY=false)
-# 2. Build osquery from https://git.corp.adobe.com/hubblestack/osquery. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
 # 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM centos:7

--- a/pkg/centos7/Dockerfile
+++ b/pkg/centos7/Dockerfile
@@ -8,12 +8,18 @@
 
 # Set this argument to "local" if you want to build osquery for local code.
 # In that case, osquery folder must exist besides Dockerfile
-#ARG OSQUERY_BUILD_ENV=local
+#ARG BUILD_OSQUERY=true
 
 #--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
-#FROM alpine as osquery_local
+#FROM alpine as BUILD_OSQUERY_true
 #ONBUILD COPY osquery /osquery
 #ONBUILD RUN echo "Copying osquery from local folder"
+
+
+#--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
+#FROM alpine as BUILD_OSQUERY_false
+#ONBUILD COPY osquery_3.3.2_tob /osqueryi
+#ONBUILD COPY osquery_3.3.2_tob /osqueryd
 
 
 
@@ -30,7 +36,7 @@
 
 
 #--------------- TEMP CONTAINER FOR OSQUERY ( BASED ON ARGUMENT ) ---------------
-#FROM osquery_"$OSQUERY_BUILD_ENV" as osquery_image
+#FROM BUILD_OSQUERY_"$BUILD_OSQUERY" as osquery_image
 
 
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
@@ -46,8 +52,8 @@ ENV OSQUERY_BUILD_USER=osquerybuilder
 ARG BUILD_OSQUERY=true
 ARG BUILD_OSQUERY_LOCALLY=false
 COPY osquery /osquery
-COPY osqueryi /osqueryi
-COPY osqueryd /osqueryd
+COPY osquery_3.3.2_tob /osqueryi
+COPY osquery_3.3.2_tob /osqueryd
 RUN yum -y install git make python ruby sudo which
 RUN useradd --shell /bin/bash --create-home --user-group --groups wheel "$OSQUERY_BUILD_USER" \
  && sed -i '0,/^#\ %wheel/s/^#\ %wheel.*/%wheel\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers

--- a/pkg/centos7/Dockerfile
+++ b/pkg/centos7/Dockerfile
@@ -51,9 +51,10 @@ RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osque
 ENV OSQUERY_BUILD_USER=osquerybuilder
 ARG BUILD_OSQUERY=true
 ARG BUILD_OSQUERY_LOCALLY=false
+ARG OSQUERY_SRC_VERSION=osquery_3.3.2_tob
 COPY osquery /osquery
-COPY osquery_3.3.2_tob /osqueryi
-COPY osquery_3.3.2_tob /osqueryd
+COPY $OSQUERY_SRC_VERSION /osqueryi
+COPY $OSQUERY_SRC_VERSION /osqueryd
 RUN yum -y install git make python ruby sudo which
 RUN useradd --shell /bin/bash --create-home --user-group --groups wheel "$OSQUERY_BUILD_USER" \
  && sed -i '0,/^#\ %wheel/s/^#\ %wheel.*/%wheel\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers

--- a/pkg/centos7/Dockerfile
+++ b/pkg/centos7/Dockerfile
@@ -88,6 +88,7 @@ RUN sh /osquerybuilder.sh "$BUILD_OSQUERY" "$BUILD_OSQUERY_LOCALLY"
 #RUN ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version
 
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
+USER root
 RUN yum -y install  \
                libffi-devel openssl-devel libffi libssh2-devel autoconf automake libtool \
                libxml2-devel libxslt-devel libjpeg-devel zlib-devel \

--- a/pkg/centos7/Dockerfile
+++ b/pkg/centos7/Dockerfile
@@ -8,34 +8,33 @@
 
 # Set this argument to "local" if you want to build osquery for local code.
 # In that case, osquery folder must exist besides Dockerfile
-ARG OSQUERY_BUILD_ENV=remote
+#ARG OSQUERY_BUILD_ENV=local
 
 #--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
-FROM alpine as osquery_local
-ONBUILD COPY osquery /osquery
-ONBUILD RUN echo "Copying osquery from local folder"
+#FROM alpine as osquery_local
+#ONBUILD COPY osquery /osquery
+#ONBUILD RUN echo "Copying osquery from local folder"
 
 
 
 #--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
-FROM alpine/git as osquery_remote
+#FROM alpine/git as osquery_remote
 #to pin osquery to a different version change the following envirnment variable
-ENV OSQUERY_SRC_VERSION=3.3.2
-ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
-ONBUILD RUN cd / \
- && git clone "$OSQUERY_GIT_URL" \
- && cd osquery/ \
- && git checkout "$OSQUERY_SRC_VERSION" \
- && echo "Fetching osquery from git"
+#ENV OSQUERY_SRC_VERSION=3.3.2
+#ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
+#ONBUILD RUN cd / \
+# && git clone "$OSQUERY_GIT_URL" \
+# && cd osquery/ \
+# && git checkout "$OSQUERY_SRC_VERSION" \
+# && echo "Fetching osquery from git"
 
 
 #--------------- TEMP CONTAINER FOR OSQUERY ( BASED ON ARGUMENT ) ---------------
-FROM osquery_"$OSQUERY_BUILD_ENV" as osquery_image
+#FROM osquery_"$OSQUERY_BUILD_ENV" as osquery_image
 
 
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM centos:7
-
 RUN yum makecache fast && yum -y update
 
 #paths that hubble or hubble parts need in the package
@@ -44,32 +43,42 @@ RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osque
 #osquery should be built first since requirements for other packages can interfere with osquery dependencies
 #to build, osquery scripts want sudo and a user to sudo with.
 ENV OSQUERY_BUILD_USER=osquerybuilder
+ARG BUILD_OSQUERY=true
+ARG BUILD_OSQUERY_LOCALLY=false
+COPY osquery /osquery
+COPY osqueryi /osqueryi
+COPY osqueryd /osqueryd
 RUN yum -y install git make python ruby sudo which
 RUN useradd --shell /bin/bash --create-home --user-group --groups wheel "$OSQUERY_BUILD_USER" \
  && sed -i '0,/^#\ %wheel/s/^#\ %wheel.*/%wheel\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
-COPY --from=osquery_image /osquery /home/"$OSQUERY_BUILD_USER"/osquery
-RUN mkdir -p /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
-USER $OSQUERY_BUILD_USER
-ENV SKIP_TESTS=1
-RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
- && make sysprep \
+ADD osquerybuilder.sh /osquerybuilder.sh
+RUN sh /osquerybuilder.sh "$BUILD_OSQUERY" "$BUILD_OSQUERY_LOCALLY"
+
+#RUN mkdir /home/"$OSQUERY_BUILD_USER"/osquery
+# && cp -r /osquery/ /home/"$OSQUERY_BUILD_USER"/
+#COPY --from=osquery_image /osquery /home/"$OSQUERY_BUILD_USER"/osquery
+#RUN mkdir -p /usr/local/osquery/ \
+# && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
+# && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
+#USER $OSQUERY_BUILD_USER
+#ENV SKIP_TESTS=1
+#RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
+# && make sysprep \
 #have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
- && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \
- && make deps \
- && make \
- && make strip
-USER root
-RUN cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery \
- && cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd \
- && chown -R root. /opt/osquery \
- && chmod -R 500 /opt/osquery/* \
+# && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \
+# && make deps \
+# && make \
+# && make strip
+#USER root
+#RUN cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery \
+# && cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd \
+# && chown -R root. /opt/osquery \
+# && chmod -R 500 /opt/osquery/* \
 #put augeas lenses into the default directory that we changed earlier
- && mkdir -p /opt/osquery/lenses \
- && cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses \
- && chmod -R 400 /opt/osquery/lenses/*
-RUN ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version
+# && mkdir -p /opt/osquery/lenses \
+# && cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses \
+# && chmod -R 400 /opt/osquery/lenses/*
+#RUN ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version
 
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
 RUN yum -y install  \
@@ -149,8 +158,8 @@ RUN yum install -y ruby ruby-devel rpmbuild rpm-build rubygems gcc make \
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
-ENV HUBBLE_CHECKOUT=v3.0.12
-ENV HUBBLE_VERSION=3.0.12
+ENV HUBBLE_CHECKOUT=3.0
+ENV HUBBLE_VERSION=3.0.12_19
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_URL=https://github.com/hubblestack/hubble
 ENV HUBBLE_DESCRIPTION="Hubble is a modular, open-source, security & compliance auditing framework which is built in python, using SaltStack as a library."

--- a/pkg/centos7/Dockerfile
+++ b/pkg/centos7/Dockerfile
@@ -112,8 +112,8 @@ RUN yum install -y ruby ruby-devel rpmbuild rpm-build rubygems gcc make \
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
-ENV HUBBLE_CHECKOUT=3.0
-ENV HUBBLE_VERSION=3.0.12_19
+ENV HUBBLE_CHECKOUT=v3.0.13
+ENV HUBBLE_VERSION=3.0.13
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_URL=https://github.com/hubblestack/hubble
 ENV HUBBLE_DESCRIPTION="Hubble is a modular, open-source, security & compliance auditing framework which is built in python, using SaltStack as a library."

--- a/pkg/centos7/Dockerfile
+++ b/pkg/centos7/Dockerfile
@@ -1,44 +1,16 @@
 # This Dockerfile aims to make building Hubble v2 packages easier.
 # To build an image: 1. copy pkg/scripts/pyinstaller-requirements.txt to directory with this Dockerfile
-#                    2. docker build -t <image_name> .
+#                    2. copy osquerybuilder.sh to this directory. This is needed to bundle osquery with Hubble
+#                    3. docker build -t <image_name> .
 # The resulting image is ready to run the pyinstaller on container start and drop hubble<version>-coreos.tar.gz
 # in the /data directory. Mount /data volume into a directory on the host to access the package.
 # To run the container:  docker run -it --rm -v `pwd`:/data <image_name>
 # Requires docker 17.05 or higher
 
-# Set this argument to "local" if you want to build osquery for local code.
-# In that case, osquery folder must exist besides Dockerfile
-#ARG BUILD_OSQUERY=true
-
-#--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
-#FROM alpine as BUILD_OSQUERY_true
-#ONBUILD COPY osquery /osquery
-#ONBUILD RUN echo "Copying osquery from local folder"
-
-
-#--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
-#FROM alpine as BUILD_OSQUERY_false
-#ONBUILD COPY osquery_3.3.2_tob /osqueryi
-#ONBUILD COPY osquery_3.3.2_tob /osqueryd
-
-
-
-#--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
-#FROM alpine/git as osquery_remote
-#to pin osquery to a different version change the following envirnment variable
-#ENV OSQUERY_SRC_VERSION=3.3.2
-#ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
-#ONBUILD RUN cd / \
-# && git clone "$OSQUERY_GIT_URL" \
-# && cd osquery/ \
-# && git checkout "$OSQUERY_SRC_VERSION" \
-# && echo "Fetching osquery from git"
-
-
-#--------------- TEMP CONTAINER FOR OSQUERY ( BASED ON ARGUMENT ) ---------------
-#FROM BUILD_OSQUERY_"$BUILD_OSQUERY" as osquery_image
-
-
+#Hubble builds can have the following 3 combinations wrt osquery:
+# 1. Package already built osquery. (BUILD_OSQUERY=false)
+# 2. Build osquery from https://git.corp.adobe.com/hubblestack/osquery. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM centos:7
 RUN yum makecache fast && yum -y update
@@ -60,32 +32,6 @@ RUN useradd --shell /bin/bash --create-home --user-group --groups wheel "$OSQUER
  && sed -i '0,/^#\ %wheel/s/^#\ %wheel.*/%wheel\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
 ADD osquerybuilder.sh /osquerybuilder.sh
 RUN sh /osquerybuilder.sh "$BUILD_OSQUERY" "$BUILD_OSQUERY_LOCALLY"
-
-#RUN mkdir /home/"$OSQUERY_BUILD_USER"/osquery
-# && cp -r /osquery/ /home/"$OSQUERY_BUILD_USER"/
-#COPY --from=osquery_image /osquery /home/"$OSQUERY_BUILD_USER"/osquery
-#RUN mkdir -p /usr/local/osquery/ \
-# && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
-# && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
-#USER $OSQUERY_BUILD_USER
-#ENV SKIP_TESTS=1
-#RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
-# && make sysprep \
-#have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
-# && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \
-# && make deps \
-# && make \
-# && make strip
-#USER root
-#RUN cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery \
-# && cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd \
-# && chown -R root. /opt/osquery \
-# && chmod -R 500 /opt/osquery/* \
-#put augeas lenses into the default directory that we changed earlier
-# && mkdir -p /opt/osquery/lenses \
-# && cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses \
-# && chmod -R 400 /opt/osquery/lenses/*
-#RUN ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version
 
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
 USER root

--- a/pkg/centos7/Dockerfile
+++ b/pkg/centos7/Dockerfile
@@ -8,8 +8,8 @@
 # Requires docker 17.05 or higher
 
 #Hubble builds can have the following 3 combinations wrt osquery:
-# 1. Package already built osquery. (BUILD_OSQUERY=false)
-# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 1. Package already built osquery. (BUILD_OSQUERY=false). Keep the osquery tar file besides this Dockerfile.
+# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true). Keep the osquery source code besides this Dockerfile.
 # 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM centos:7

--- a/pkg/centos7/osquerybuilder.sh
+++ b/pkg/centos7/osquerybuilder.sh
@@ -38,10 +38,10 @@ else
   sudo -u "$OSQUERY_BUILD_USER" make strip
   cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery/osqueryi
   cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd
+  mkdir -p /opt/osquery/lenses
+  cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses
 fi
 chown -R root. /opt/osquery
 chmod -R 500 /opt/osquery/*
-mkdir -p /opt/osquery/lenses
-cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses
 chmod -R 400 /opt/osquery/lenses/*
 ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version

--- a/pkg/centos7/osquerybuilder.sh
+++ b/pkg/centos7/osquerybuilder.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+build_osquery=$1
+build_osquery_locally=$2
+
+if [ $build_osquery != true ]
+then
+  mkdir -p /opt/osquery/
+  cp /osqueryi /opt/osquery/osqueryi
+  cp /osqueryd /opt/osquery/hubble_osqueryd
+  echo $build_osquery
+else
+  echo $build_osquery_locally
+  if [ $build_osquery_locally == true ]
+  then
+    echo "Building osquery from local folder"
+  else
+    rm -rf /osquery
+    OSQUERY_SRC_VERSION=3.3.2
+    OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
+    cd /
+    git clone "$OSQUERY_GIT_URL"
+    cd osquery/
+    git checkout "$OSQUERY_SRC_VERSION"
+    echo "Fetching osquery from git"
+    echo $OSQUERY_SRC_VERSION
+  fi
+  mkdir /home/"$OSQUERY_BUILD_USER"/osquery
+  cp -r /osquery/ /home/"$OSQUERY_BUILD_USER"/
+  mkdir -p /usr/local/osquery/
+  chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/
+  chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
+  
+  export SKIP_TESTS=1
+  cd /home/"$OSQUERY_BUILD_USER"/osquery 
+  sudo -u "$OSQUERY_BUILD_USER" make sysprep
+  sudo -u "$OSQUERY_BUILD_USER" sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp
+  sudo -u "$OSQUERY_BUILD_USER" make deps
+  sudo -u "$OSQUERY_BUILD_USER" make
+  sudo -u "$OSQUERY_BUILD_USER" make strip
+  cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery/osqueryi
+  cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd
+fi
+chown -R root. /opt/osquery
+chmod -R 500 /opt/osquery/*
+mkdir -p /opt/osquery/lenses
+cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses
+chmod -R 400 /opt/osquery/lenses/*
+ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version

--- a/pkg/centos7/osquerybuilder.sh
+++ b/pkg/centos7/osquerybuilder.sh
@@ -5,9 +5,7 @@ build_osquery_locally=$2
 
 if [ $build_osquery != true ]
 then
-  mkdir -p /opt/osquery/
-  cp /osqueryi /opt/osquery/osqueryi
-  cp /osqueryd /opt/osquery/hubble_osqueryd
+  tar -C /opt/ -zxvf osquery_*_tob_centos7.tar 
   echo $build_osquery
 else
   echo $build_osquery_locally

--- a/pkg/centos8/Dockerfile
+++ b/pkg/centos8/Dockerfile
@@ -8,8 +8,8 @@
 # Requires docker 17.05 or higher
 
 #Hubble builds can have the following 3 combinations wrt osquery:
-# 1. Package already built osquery. (BUILD_OSQUERY=false)
-# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 1. Package already built osquery. (BUILD_OSQUERY=false). Keep the osquery tar file besides this Dockerfile.
+# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true). Keep the osquery source code besides this Dockerfile.
 # 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM centos:8

--- a/pkg/centos8/Dockerfile
+++ b/pkg/centos8/Dockerfile
@@ -9,7 +9,7 @@
 
 #Hubble builds can have the following 3 combinations wrt osquery:
 # 1. Package already built osquery. (BUILD_OSQUERY=false)
-# 2. Build osquery from https://git.corp.adobe.com/hubblestack/osquery. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
 # 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM centos:8

--- a/pkg/centos8/Dockerfile
+++ b/pkg/centos8/Dockerfile
@@ -8,29 +8,29 @@
 
 # Set this argument to "local" if you want to build osquery for local code.
 # In that case, osquery folder must exist besides Dockerfile
-ARG OSQUERY_BUILD_ENV=remote
+#ARG OSQUERY_BUILD_ENV=remote
 
 #--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
-FROM alpine as osquery_local
-ONBUILD COPY osquery /osquery
-ONBUILD RUN echo "Copying osquery from local folder"
+#FROM alpine as osquery_local
+#ONBUILD COPY osquery /osquery
+#ONBUILD RUN echo "Copying osquery from local folder"
 
 
 
 #--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
-FROM alpine/git as osquery_remote
+#FROM alpine/git as osquery_remote
 #to pin osquery to a different version change the following envirnment variable
-ENV OSQUERY_SRC_VERSION=3.3.2
-ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
-ONBUILD RUN cd / \
- && git clone "$OSQUERY_GIT_URL" \
- && cd osquery/ \
- && git checkout "$OSQUERY_SRC_VERSION" \
- && echo "Fetching osquery from git"
+#ENV OSQUERY_SRC_VERSION=3.3.2
+#ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
+#ONBUILD RUN cd / \
+# && git clone "$OSQUERY_GIT_URL" \
+# && cd osquery/ \
+# && git checkout "$OSQUERY_SRC_VERSION" \
+# && echo "Fetching osquery from git"
 
 
 #--------------- TEMP CONTAINER FOR OSQUERY ( BASED ON ARGUMENT ) ---------------
-FROM osquery_"$OSQUERY_BUILD_ENV" as osquery_image
+#FROM osquery_"$OSQUERY_BUILD_ENV" as osquery_image
 
 
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
@@ -48,33 +48,43 @@ RUN dnf -y install dnf-plugins-core \
  && dnf config-manager --set-enabled PowerTools \
  && dnf -y install python2 git make ruby sudo which doxygen \
  && ln -svf /usr/bin/python2 /usr/bin/python
+ENV OSQUERY_BUILD_USER=osquerybuilder
+ARG BUILD_OSQUERY=true
+ARG BUILD_OSQUERY_LOCALLY=false
+ARG OSQUERY_SRC_VERSION=osquery_3.3.2_tob
+COPY osquery /osquery
+COPY $OSQUERY_SRC_VERSION /osqueryi
+COPY $OSQUERY_SRC_VERSION /osqueryd
 RUN useradd --shell /bin/bash --create-home --user-group --groups wheel "$OSQUERY_BUILD_USER" \
  && sed -i '0,/^#\ %wheel/s/^#\ %wheel.*/%wheel\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
-COPY --from=osquery_image /osquery /home/"$OSQUERY_BUILD_USER"/osquery
-RUN mkdir -p /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
-USER $OSQUERY_BUILD_USER
-ENV SKIP_TESTS=1
-RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
- && make sysprep \
+ADD osquerybuilder.sh /osquerybuilder.sh
+RUN sh /osquerybuilder.sh "$BUILD_OSQUERY" "$BUILD_OSQUERY_LOCALLY"
+#COPY --from=osquery_image /osquery /home/"$OSQUERY_BUILD_USER"/osquery
+#RUN mkdir -p /usr/local/osquery/ \
+# && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
+# && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
+#USER $OSQUERY_BUILD_USER
+#ENV SKIP_TESTS=1
+#RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
+# && make sysprep \
 #have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
- && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \
- && make deps \
- && make \
- && make strip
-USER root
-RUN cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery \
- && cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd \
- && chown -R root. /opt/osquery \
- && chmod -R 500 /opt/osquery/* \
+# && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \
+# && make deps \
+# && make \
+# && make strip
+#USER root
+#RUN cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery \
+# && cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd \
+# && chown -R root. /opt/osquery \
+# && chmod -R 500 /opt/osquery/* \
 #put augeas lenses into the default directory that we changed earlier
- && mkdir -p /opt/osquery/lenses \
- && cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses \
- && chmod -R 400 /opt/osquery/lenses/*
-RUN ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version
+# && mkdir -p /opt/osquery/lenses \
+# && cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses \
+# && chmod -R 400 /opt/osquery/lenses/*
+#RUN ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version
 
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
+USER root
 RUN dnf -y install  \
                libffi-devel openssl-devel libffi libssh-devel autoconf automake libtool \
                libxml2-devel libxslt-devel libjpeg-devel zlib-devel \

--- a/pkg/centos8/Dockerfile
+++ b/pkg/centos8/Dockerfile
@@ -53,8 +53,8 @@ ARG BUILD_OSQUERY=true
 ARG BUILD_OSQUERY_LOCALLY=false
 ARG OSQUERY_SRC_VERSION=osquery_3.3.2_tob
 COPY osquery /osquery
-COPY $OSQUERY_SRC_VERSION /osqueryi
-COPY $OSQUERY_SRC_VERSION /osqueryd
+ENV OSQUERY_TAR_FILENAME=$OSQUERY_SRC_VERSION"_centos8.tar"
+COPY $OSQUERY_TAR_FILENAME /
 RUN useradd --shell /bin/bash --create-home --user-group --groups wheel "$OSQUERY_BUILD_USER" \
  && sed -i '0,/^#\ %wheel/s/^#\ %wheel.*/%wheel\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
 ADD osquerybuilder.sh /osquerybuilder.sh

--- a/pkg/centos8/Dockerfile
+++ b/pkg/centos8/Dockerfile
@@ -117,8 +117,8 @@ RUN dnf install -y ruby ruby-devel rpm-build rubygems gcc make \
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
-ENV HUBBLE_CHECKOUT=v3.0.12
-ENV HUBBLE_VERSION=3.0.12
+ENV HUBBLE_CHECKOUT=v3.0.13
+ENV HUBBLE_VERSION=3.0.13
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_URL=https://github.com/hubblestack/hubble
 ENV HUBBLE_DESCRIPTION="Hubble is a modular, open-source, security & compliance auditing framework which is built in python, using SaltStack as a library."

--- a/pkg/centos8/Dockerfile
+++ b/pkg/centos8/Dockerfile
@@ -1,38 +1,16 @@
 # This Dockerfile aims to make building Hubble v2 packages easier.
 # To build an image: 1. copy pkg/scripts/pyinstaller-requirements.txt to directory with this Dockerfile
-#                    2. docker build -t <image_name> .
+#                    2. copy osquerybuilder.sh to this directory. This is needed to bundle osquery with Hubble
+#                    3. docker build -t <image_name> .
 # The resulting image is ready to run the pyinstaller on container start and drop hubble<version>-coreos.tar.gz
 # in the /data directory. Mount /data volume into a directory on the host to access the package.
 # To run the container:  docker run -it --rm -v `pwd`:/data <image_name>
 # Requires docker 17.05 or higher
 
-# Set this argument to "local" if you want to build osquery for local code.
-# In that case, osquery folder must exist besides Dockerfile
-#ARG OSQUERY_BUILD_ENV=remote
-
-#--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
-#FROM alpine as osquery_local
-#ONBUILD COPY osquery /osquery
-#ONBUILD RUN echo "Copying osquery from local folder"
-
-
-
-#--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
-#FROM alpine/git as osquery_remote
-#to pin osquery to a different version change the following envirnment variable
-#ENV OSQUERY_SRC_VERSION=3.3.2
-#ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
-#ONBUILD RUN cd / \
-# && git clone "$OSQUERY_GIT_URL" \
-# && cd osquery/ \
-# && git checkout "$OSQUERY_SRC_VERSION" \
-# && echo "Fetching osquery from git"
-
-
-#--------------- TEMP CONTAINER FOR OSQUERY ( BASED ON ARGUMENT ) ---------------
-#FROM osquery_"$OSQUERY_BUILD_ENV" as osquery_image
-
-
+#Hubble builds can have the following 3 combinations wrt osquery:
+# 1. Package already built osquery. (BUILD_OSQUERY=false)
+# 2. Build osquery from https://git.corp.adobe.com/hubblestack/osquery. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM centos:8
 
@@ -59,29 +37,6 @@ RUN useradd --shell /bin/bash --create-home --user-group --groups wheel "$OSQUER
  && sed -i '0,/^#\ %wheel/s/^#\ %wheel.*/%wheel\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
 ADD osquerybuilder.sh /osquerybuilder.sh
 RUN sh /osquerybuilder.sh "$BUILD_OSQUERY" "$BUILD_OSQUERY_LOCALLY"
-#COPY --from=osquery_image /osquery /home/"$OSQUERY_BUILD_USER"/osquery
-#RUN mkdir -p /usr/local/osquery/ \
-# && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
-# && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
-#USER $OSQUERY_BUILD_USER
-#ENV SKIP_TESTS=1
-#RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
-# && make sysprep \
-#have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
-# && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \
-# && make deps \
-# && make \
-# && make strip
-#USER root
-#RUN cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery \
-# && cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd \
-# && chown -R root. /opt/osquery \
-# && chmod -R 500 /opt/osquery/* \
-#put augeas lenses into the default directory that we changed earlier
-# && mkdir -p /opt/osquery/lenses \
-# && cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses \
-# && chmod -R 400 /opt/osquery/lenses/*
-#RUN ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version
 
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
 USER root

--- a/pkg/centos8/osquerybuilder.sh
+++ b/pkg/centos8/osquerybuilder.sh
@@ -5,9 +5,7 @@ build_osquery_locally=$2
 
 if [ $build_osquery != true ]
 then
-  mkdir -p /opt/osquery/
-  cp /osqueryi /opt/osquery/osqueryi
-  cp /osqueryd /opt/osquery/hubble_osqueryd
+  tar -C /opt/ -zxvf osquery_*_tob_centos8.tar
   echo $build_osquery
 else
   echo $build_osquery_locally

--- a/pkg/centos8/osquerybuilder.sh
+++ b/pkg/centos8/osquerybuilder.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+build_osquery=$1
+build_osquery_locally=$2
+
+if [ $build_osquery != true ]
+then
+  mkdir -p /opt/osquery/
+  cp /osqueryi /opt/osquery/osqueryi
+  cp /osqueryd /opt/osquery/hubble_osqueryd
+  echo $build_osquery
+else
+  echo $build_osquery_locally
+  if [ $build_osquery_locally == true ]
+  then
+    echo "Building osquery from local folder"
+  else
+    rm -rf /osquery
+    OSQUERY_SRC_VERSION=3.3.2
+    OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
+    cd /
+    git clone "$OSQUERY_GIT_URL"
+    cd osquery/
+    git checkout "$OSQUERY_SRC_VERSION"
+    echo "Fetching osquery from git"
+    echo $OSQUERY_SRC_VERSION
+  fi
+  mkdir /home/"$OSQUERY_BUILD_USER"/osquery
+  cp -r /osquery/ /home/"$OSQUERY_BUILD_USER"/
+  mkdir -p /usr/local/osquery/
+  chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/
+  chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
+  
+  export SKIP_TESTS=1
+  cd /home/"$OSQUERY_BUILD_USER"/osquery 
+  sudo -u "$OSQUERY_BUILD_USER" make sysprep
+  sudo -u "$OSQUERY_BUILD_USER" sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp
+  sudo -u "$OSQUERY_BUILD_USER" make deps
+  sudo -u "$OSQUERY_BUILD_USER" make
+  sudo -u "$OSQUERY_BUILD_USER" make strip
+  cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery/osqueryi
+  cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd
+fi
+chown -R root. /opt/osquery
+chmod -R 500 /opt/osquery/*
+mkdir -p /opt/osquery/lenses
+cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses
+chmod -R 400 /opt/osquery/lenses/*
+ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version

--- a/pkg/centos8/osquerybuilder.sh
+++ b/pkg/centos8/osquerybuilder.sh
@@ -40,10 +40,10 @@ else
   sudo -u "$OSQUERY_BUILD_USER" make strip
   cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery/osqueryi
   cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd
+  mkdir -p /opt/osquery/lenses
+  cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses
 fi
 chown -R root. /opt/osquery
 chmod -R 500 /opt/osquery/*
-mkdir -p /opt/osquery/lenses
-cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses
 chmod -R 400 /opt/osquery/lenses/*
 ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version

--- a/pkg/coreos/Dockerfile
+++ b/pkg/coreos/Dockerfile
@@ -126,9 +126,9 @@ RUN pip -v install -r pyinstaller-requirements.txt
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
-ENV HUBBLE_CHECKOUT=v3.0.12
+ENV HUBBLE_CHECKOUT=v3.0.13
 ENV HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
-ENV HUBBLE_VERSION=3.0.12
+ENV HUBBLE_VERSION=3.0.13
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_SRC_PATH=/hubble_src
 ENV _HOOK_DIR="./pkg/"

--- a/pkg/coreos/Dockerfile
+++ b/pkg/coreos/Dockerfile
@@ -8,8 +8,8 @@
 # Requires docker 17.05 or higher
 
 #Hubble builds can have the following 3 combinations wrt osquery:
-# 1. Package already built osquery. (BUILD_OSQUERY=false)
-# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 1. Package already built osquery. (BUILD_OSQUERY=false). Keep the osquery tar file besides this Dockerfile.
+# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true). Keep the osquery source code besides this Dockerfile.
 # 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM debian:9

--- a/pkg/coreos/Dockerfile
+++ b/pkg/coreos/Dockerfile
@@ -6,29 +6,29 @@
 # To run the container:  docker run -it --rm -v `pwd`:/data <image_name>
 # Requires docker 17.05 or higher
 
-ARG OSQUERY_BUILD_ENV=remote
+#ARG OSQUERY_BUILD_ENV=remote
 
 #--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
-FROM alpine as osquery_local
-ONBUILD COPY osquery /osquery
-ONBUILD RUN echo "Copying osquery from local folder"
+#FROM alpine as osquery_local
+#ONBUILD COPY osquery /osquery
+#ONBUILD RUN echo "Copying osquery from local folder"
 
 
 
 #--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
-FROM alpine/git as osquery_remote
+#FROM alpine/git as osquery_remote
 #to osquery pin to a different version change the following envirnment variable
-ENV OSQUERY_SRC_VERSION=3.3.2
-ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
-ONBUILD RUN cd / \
- && git clone "$OSQUERY_GIT_URL" \
- && cd osquery/ \
- && git checkout "$OSQUERY_SRC_VERSION" \
- && echo "Fetching osquery from git"
+#ENV OSQUERY_SRC_VERSION=3.3.2
+#ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
+#ONBUILD RUN cd / \
+# && git clone "$OSQUERY_GIT_URL" \
+# && cd osquery/ \
+# && git checkout "$OSQUERY_SRC_VERSION" \
+# && echo "Fetching osquery from git"
 
 
 #--------------- TEMP CONTAINER FOR OSQUERY ( BASED UPON ARGUMENT ) -------------
-FROM osquery_"$OSQUERY_BUILD_ENV" as osquery
+#FROM osquery_"$OSQUERY_BUILD_ENV" as osquery
 
 
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
@@ -59,34 +59,43 @@ RUN mkdir -p "$PATCHELF_TEMP" \
 #osquery should be built first since requirements for other packages can interfere with osquery dependencies
 #to build, osquery scripts want sudo and a user to sudo with.
 ENV OSQUERY_BUILD_USER=osquerybuilder
+ARG BUILD_OSQUERY=true
+ARG BUILD_OSQUERY_LOCALLY=false
+ARG OSQUERY_SRC_VERSION=osquery_3.3.2_tob
+COPY osquery /osquery
+COPY $OSQUERY_SRC_VERSION /osqueryi
+COPY $OSQUERY_SRC_VERSION /osqueryd
 RUN apt-get -y install git make python ruby sudo curl
 RUN useradd --shell /bin/bash --create-home --user-group --groups sudo "$OSQUERY_BUILD_USER" \
  && sed -i 's/^%sudo.*/%sudo\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
-COPY --from=osquery /osquery /home/"$OSQUERY_BUILD_USER"/osquery
-RUN mkdir -p /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
-USER $OSQUERY_BUILD_USER
-ENV SKIP_TESTS=1
-RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
- && make sysprep \
+ADD osquerybuilder.sh /osquerybuilder.sh
+RUN sh /osquerybuilder.sh "$BUILD_OSQUERY" "$BUILD_OSQUERY_LOCALLY"
+#COPY --from=osquery /osquery /home/"$OSQUERY_BUILD_USER"/osquery
+#RUN mkdir -p /usr/local/osquery/ \
+# && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
+# && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
+#USER $OSQUERY_BUILD_USER
+#ENV SKIP_TESTS=1
+#RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
+# && make sysprep \
 #have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
- && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \
- && make deps \
- && make \
- && make strip
-USER root
-RUN cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery \
- && cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd \
- && chown -R root. /opt/osquery \
- && chmod -R 500 /opt/osquery/* \
+# && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \
+# && make deps \
+# && make \
+# && make strip
+#USER root
+#RUN cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery \
+# && cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd \
+# && chown -R root. /opt/osquery \
+# && chmod -R 500 /opt/osquery/* \
 #put augeas lenses into the default directory that we changed earlier
- && mkdir -p /opt/osquery/lenses \
- && cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses \
- && chmod -R 400 /opt/osquery/lenses/*
-RUN ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version
+# && mkdir -p /opt/osquery/lenses \
+# && cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses \
+# && chmod -R 400 /opt/osquery/lenses/*
+#RUN ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version
 
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
+USER root
 RUN apt-get -y install  \
                python-dev libffi-dev libssl-dev libyaml-dev libssh2-1 libssh2-1-dev autoconf automake libtool \
                libxml2-dev libxslt1-dev python-cffi \

--- a/pkg/coreos/Dockerfile
+++ b/pkg/coreos/Dockerfile
@@ -9,7 +9,7 @@
 
 #Hubble builds can have the following 3 combinations wrt osquery:
 # 1. Package already built osquery. (BUILD_OSQUERY=false)
-# 2. Build osquery from https://git.corp.adobe.com/hubblestack/osquery. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
 # 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM debian:9

--- a/pkg/coreos/Dockerfile
+++ b/pkg/coreos/Dockerfile
@@ -1,36 +1,16 @@
 # This Dockerfile aims to make building Hubble v2 packages easier.
 # To build an image: 1. copy pkg/scripts/pyinstaller-requirements.txt to directory with this Dockerfile
-#                    2. docker build -t <image_name> .
+#                    2. copy osquerybuilder.sh to this directory. This is needed to bundle osquery with Hubble
+#                    3. docker build -t <image_name> .
 # The resulting image is ready to run the pyinstaller on container start and drop hubble<version>-coreos.tar.gz
 # in the /data directory. Mount /data volume into a directory on the host to access the package.
 # To run the container:  docker run -it --rm -v `pwd`:/data <image_name>
 # Requires docker 17.05 or higher
 
-#ARG OSQUERY_BUILD_ENV=remote
-
-#--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
-#FROM alpine as osquery_local
-#ONBUILD COPY osquery /osquery
-#ONBUILD RUN echo "Copying osquery from local folder"
-
-
-
-#--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
-#FROM alpine/git as osquery_remote
-#to osquery pin to a different version change the following envirnment variable
-#ENV OSQUERY_SRC_VERSION=3.3.2
-#ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
-#ONBUILD RUN cd / \
-# && git clone "$OSQUERY_GIT_URL" \
-# && cd osquery/ \
-# && git checkout "$OSQUERY_SRC_VERSION" \
-# && echo "Fetching osquery from git"
-
-
-#--------------- TEMP CONTAINER FOR OSQUERY ( BASED UPON ARGUMENT ) -------------
-#FROM osquery_"$OSQUERY_BUILD_ENV" as osquery
-
-
+#Hubble builds can have the following 3 combinations wrt osquery:
+# 1. Package already built osquery. (BUILD_OSQUERY=false)
+# 2. Build osquery from https://git.corp.adobe.com/hubblestack/osquery. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM debian:9
 
@@ -70,29 +50,6 @@ RUN useradd --shell /bin/bash --create-home --user-group --groups sudo "$OSQUERY
  && sed -i 's/^%sudo.*/%sudo\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
 ADD osquerybuilder.sh /osquerybuilder.sh
 RUN sh /osquerybuilder.sh "$BUILD_OSQUERY" "$BUILD_OSQUERY_LOCALLY"
-#COPY --from=osquery /osquery /home/"$OSQUERY_BUILD_USER"/osquery
-#RUN mkdir -p /usr/local/osquery/ \
-# && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
-# && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
-#USER $OSQUERY_BUILD_USER
-#ENV SKIP_TESTS=1
-#RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
-# && make sysprep \
-#have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
-# && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \
-# && make deps \
-# && make \
-# && make strip
-#USER root
-#RUN cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery \
-# && cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd \
-# && chown -R root. /opt/osquery \
-# && chmod -R 500 /opt/osquery/* \
-#put augeas lenses into the default directory that we changed earlier
-# && mkdir -p /opt/osquery/lenses \
-# && cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses \
-# && chmod -R 400 /opt/osquery/lenses/*
-#RUN ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version
 
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
 USER root

--- a/pkg/coreos/Dockerfile
+++ b/pkg/coreos/Dockerfile
@@ -63,8 +63,8 @@ ARG BUILD_OSQUERY=true
 ARG BUILD_OSQUERY_LOCALLY=false
 ARG OSQUERY_SRC_VERSION=osquery_3.3.2_tob
 COPY osquery /osquery
-COPY $OSQUERY_SRC_VERSION /osqueryi
-COPY $OSQUERY_SRC_VERSION /osqueryd
+ENV OSQUERY_TAR_FILENAME=$OSQUERY_SRC_VERSION"_coreos.tar"
+COPY $OSQUERY_TAR_FILENAME /
 RUN apt-get -y install git make python ruby sudo curl
 RUN useradd --shell /bin/bash --create-home --user-group --groups sudo "$OSQUERY_BUILD_USER" \
  && sed -i 's/^%sudo.*/%sudo\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers

--- a/pkg/coreos/osquerybuilder.sh
+++ b/pkg/coreos/osquerybuilder.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+build_osquery=$1
+build_osquery_locally=$2
+
+if [ $build_osquery != true ]
+then
+  mkdir -p /opt/osquery/
+  cp /osqueryi /opt/osquery/osqueryi
+  cp /osqueryd /opt/osquery/hubble_osqueryd
+  echo $build_osquery
+else
+  echo $build_osquery_locally
+  if [ $build_osquery_locally == true ]
+  then
+    echo "Building osquery from local folder"
+  else
+    rm -rf /osquery
+    OSQUERY_SRC_VERSION=3.3.2
+    OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
+    cd /
+    git clone "$OSQUERY_GIT_URL"
+    cd osquery/
+    git checkout "$OSQUERY_SRC_VERSION"
+    echo "Fetching osquery from git"
+    echo $OSQUERY_SRC_VERSION
+  fi
+  mkdir /home/"$OSQUERY_BUILD_USER"/osquery
+  cp -r /osquery/ /home/"$OSQUERY_BUILD_USER"/
+  mkdir -p /usr/local/osquery/
+  chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/
+  chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
+  
+  export SKIP_TESTS=1
+  cd /home/"$OSQUERY_BUILD_USER"/osquery 
+  sudo -u "$OSQUERY_BUILD_USER" make sysprep
+  sudo -u "$OSQUERY_BUILD_USER" sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp
+  sudo -u "$OSQUERY_BUILD_USER" make deps
+  sudo -u "$OSQUERY_BUILD_USER" make
+  sudo -u "$OSQUERY_BUILD_USER" make strip
+  cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery/osqueryi
+  cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd
+fi
+chown -R root. /opt/osquery
+chmod -R 500 /opt/osquery/*
+mkdir -p /opt/osquery/lenses
+cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses
+chmod -R 400 /opt/osquery/lenses/*
+ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version

--- a/pkg/coreos/osquerybuilder.sh
+++ b/pkg/coreos/osquerybuilder.sh
@@ -5,9 +5,7 @@ build_osquery_locally=$2
 
 if [ $build_osquery != true ]
 then
-  mkdir -p /opt/osquery/
-  cp /osqueryi /opt/osquery/osqueryi
-  cp /osqueryd /opt/osquery/hubble_osqueryd
+  tar -C /opt/ -zxvf osquery_*_tob_coreos.tar
   echo $build_osquery
 else
   echo $build_osquery_locally

--- a/pkg/coreos/osquerybuilder.sh
+++ b/pkg/coreos/osquerybuilder.sh
@@ -40,10 +40,10 @@ else
   sudo -u "$OSQUERY_BUILD_USER" make strip
   cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery/osqueryi
   cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd
+  mkdir -p /opt/osquery/lenses
+  cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses
 fi
 chown -R root. /opt/osquery
 chmod -R 500 /opt/osquery/*
-mkdir -p /opt/osquery/lenses
-cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses
 chmod -R 400 /opt/osquery/lenses/*
 ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version

--- a/pkg/debian10/Dockerfile
+++ b/pkg/debian10/Dockerfile
@@ -1,36 +1,16 @@
 # This Dockerfile aims to make building Hubble v2 packages easier.
 # To build an image: 1. copy pkg/scripts/pyinstaller-requirements.txt to directory with this Dockerfile
-#                    2. docker build -t <image_name> .
+#                    2. copy osquerybuilder.sh to this directory. This is needed to bundle osquery with Hubble
+#                    3. docker build -t <image_name> .
 # The resulting image is ready to run the pyinstaller on container start and drop hubble<version>-coreos.tar.gz
 # in the /data directory. Mount /data volume into a directory on the host to access the package.
 # To run the container:  docker run -it --rm -v `pwd`:/data <image_name>
 # Requires docker 17.05 or higher
 
-#ARG OSQUERY_BUILD_ENV=remote
-
-#--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
-#FROM alpine as osquery_local
-#ONBUILD COPY osquery /osquery
-#ONBUILD RUN echo "Copying osquery from local folder"
-
-
-
-#--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
-#FROM alpine/git as osquery_remote
-#to osquery pin to a different version change the following envirnment variable
-#ENV OSQUERY_SRC_VERSION=3.3.2
-#ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
-#ONBUILD RUN cd / \
-# && git clone "$OSQUERY_GIT_URL" \
-# && cd osquery/ \
-# && git checkout "$OSQUERY_SRC_VERSION" \
-# && echo "Fetching osquery from git"
-
-
-#--------------- TEMP CONTAINER FOR OSQUERY ( BASED UPON ARGUMENT )  ------------
-#FROM osquery_"$OSQUERY_BUILD_ENV" as osquery
-
-
+#Hubble builds can have the following 3 combinations wrt osquery:
+# 1. Package already built osquery. (BUILD_OSQUERY=false)
+# 2. Build osquery from https://git.corp.adobe.com/hubblestack/osquery. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM debian:10
 
@@ -70,29 +50,6 @@ RUN useradd --shell /bin/bash --create-home --user-group --groups sudo "$OSQUERY
  && sed -i 's/^%sudo.*/%sudo\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
 ADD osquerybuilder.sh /osquerybuilder.sh
 RUN sh /osquerybuilder.sh "$BUILD_OSQUERY" "$BUILD_OSQUERY_LOCALLY"
-#COPY --from=osquery /osquery /home/"$OSQUERY_BUILD_USER"/osquery
-#RUN mkdir -p /usr/local/osquery/ \
-# && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
-# && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
-#USER $OSQUERY_BUILD_USER
-#ENV SKIP_TESTS=1
-#RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
-# && make sysprep \
-#have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
-# && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \
-# && make deps \
-# && make \
-# && make strip
-#USER root
-#RUN cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery \
-# && cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd \
-# && chown -R root. /opt/osquery \
-# && chmod -R 500 /opt/osquery/* \
-#put augeas lenses into the default directory that we changed earlier
-# && mkdir -p /opt/osquery/lenses \
-# && cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses \
-# && chmod -R 400 /opt/osquery/lenses/*
-#RUN ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version
 
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
 USER root

--- a/pkg/debian10/Dockerfile
+++ b/pkg/debian10/Dockerfile
@@ -6,29 +6,29 @@
 # To run the container:  docker run -it --rm -v `pwd`:/data <image_name>
 # Requires docker 17.05 or higher
 
-ARG OSQUERY_BUILD_ENV=remote
+#ARG OSQUERY_BUILD_ENV=remote
 
 #--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
-FROM alpine as osquery_local
-ONBUILD COPY osquery /osquery
-ONBUILD RUN echo "Copying osquery from local folder"
+#FROM alpine as osquery_local
+#ONBUILD COPY osquery /osquery
+#ONBUILD RUN echo "Copying osquery from local folder"
 
 
 
 #--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
-FROM alpine/git as osquery_remote
+#FROM alpine/git as osquery_remote
 #to osquery pin to a different version change the following envirnment variable
-ENV OSQUERY_SRC_VERSION=3.3.2
-ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
-ONBUILD RUN cd / \
- && git clone "$OSQUERY_GIT_URL" \
- && cd osquery/ \
- && git checkout "$OSQUERY_SRC_VERSION" \
- && echo "Fetching osquery from git"
+#ENV OSQUERY_SRC_VERSION=3.3.2
+#ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
+#ONBUILD RUN cd / \
+# && git clone "$OSQUERY_GIT_URL" \
+# && cd osquery/ \
+# && git checkout "$OSQUERY_SRC_VERSION" \
+# && echo "Fetching osquery from git"
 
 
 #--------------- TEMP CONTAINER FOR OSQUERY ( BASED UPON ARGUMENT )  ------------
-FROM osquery_"$OSQUERY_BUILD_ENV" as osquery
+#FROM osquery_"$OSQUERY_BUILD_ENV" as osquery
 
 
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
@@ -59,34 +59,43 @@ RUN mkdir -p "$PATCHELF_TEMP" \
 #osquery should be built first since requirements for other packages can interfere with osquery dependencies
 #to build, osquery scripts want sudo and a user to sudo with.
 ENV OSQUERY_BUILD_USER=osquerybuilder
+ARG BUILD_OSQUERY=true
+ARG BUILD_OSQUERY_LOCALLY=false
+ARG OSQUERY_SRC_VERSION=osquery_3.3.2_tob
+COPY osquery /osquery
+COPY $OSQUERY_SRC_VERSION /osqueryi
+COPY $OSQUERY_SRC_VERSION /osqueryd
 RUN apt-get -y install git make python ruby sudo curl
 RUN useradd --shell /bin/bash --create-home --user-group --groups sudo "$OSQUERY_BUILD_USER" \
  && sed -i 's/^%sudo.*/%sudo\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
-COPY --from=osquery /osquery /home/"$OSQUERY_BUILD_USER"/osquery
-RUN mkdir -p /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
-USER $OSQUERY_BUILD_USER
-ENV SKIP_TESTS=1
-RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
- && make sysprep \
+ADD osquerybuilder.sh /osquerybuilder.sh
+RUN sh /osquerybuilder.sh "$BUILD_OSQUERY" "$BUILD_OSQUERY_LOCALLY"
+#COPY --from=osquery /osquery /home/"$OSQUERY_BUILD_USER"/osquery
+#RUN mkdir -p /usr/local/osquery/ \
+# && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
+# && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
+#USER $OSQUERY_BUILD_USER
+#ENV SKIP_TESTS=1
+#RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
+# && make sysprep \
 #have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
- && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \
- && make deps \
- && make \
- && make strip
-USER root
-RUN cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery \
- && cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd \
- && chown -R root. /opt/osquery \
- && chmod -R 500 /opt/osquery/* \
+# && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \
+# && make deps \
+# && make \
+# && make strip
+#USER root
+#RUN cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery \
+# && cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd \
+# && chown -R root. /opt/osquery \
+# && chmod -R 500 /opt/osquery/* \
 #put augeas lenses into the default directory that we changed earlier
- && mkdir -p /opt/osquery/lenses \
- && cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses \
- && chmod -R 400 /opt/osquery/lenses/*
-RUN ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version
+# && mkdir -p /opt/osquery/lenses \
+# && cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses \
+# && chmod -R 400 /opt/osquery/lenses/*
+#RUN ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version
 
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
+USER root
 RUN apt-get -y install  \
                python-dev libffi-dev libssl-dev libyaml-dev libssh2-1 libssh2-1-dev autoconf automake libtool \
                libxml2-dev libxslt1-dev python-cffi \

--- a/pkg/debian10/Dockerfile
+++ b/pkg/debian10/Dockerfile
@@ -9,7 +9,7 @@
 
 #Hubble builds can have the following 3 combinations wrt osquery:
 # 1. Package already built osquery. (BUILD_OSQUERY=false)
-# 2. Build osquery from https://git.corp.adobe.com/hubblestack/osquery. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
 # 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM debian:10

--- a/pkg/debian10/Dockerfile
+++ b/pkg/debian10/Dockerfile
@@ -8,8 +8,8 @@
 # Requires docker 17.05 or higher
 
 #Hubble builds can have the following 3 combinations wrt osquery:
-# 1. Package already built osquery. (BUILD_OSQUERY=false)
-# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 1. Package already built osquery. (BUILD_OSQUERY=false). Keep the osquery tar file besides this Dockerfile.
+# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true). Keep the osquery source code besides this Dockerfile.
 # 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM debian:10

--- a/pkg/debian10/Dockerfile
+++ b/pkg/debian10/Dockerfile
@@ -63,8 +63,8 @@ ARG BUILD_OSQUERY=true
 ARG BUILD_OSQUERY_LOCALLY=false
 ARG OSQUERY_SRC_VERSION=osquery_3.3.2_tob
 COPY osquery /osquery
-COPY $OSQUERY_SRC_VERSION /osqueryi
-COPY $OSQUERY_SRC_VERSION /osqueryd
+ENV OSQUERY_TAR_FILENAME=$OSQUERY_SRC_VERSION"_debian10.tar"
+COPY $OSQUERY_TAR_FILENAME /
 RUN apt-get -y install git make python ruby sudo curl
 RUN useradd --shell /bin/bash --create-home --user-group --groups sudo "$OSQUERY_BUILD_USER" \
  && sed -i 's/^%sudo.*/%sudo\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers

--- a/pkg/debian10/Dockerfile
+++ b/pkg/debian10/Dockerfile
@@ -130,9 +130,9 @@ RUN apt-get install -y ruby ruby-dev rubygems gcc make \
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
-ENV HUBBLE_CHECKOUT=v3.0.12
+ENV HUBBLE_CHECKOUT=v3.0.13
 ENV HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
-ENV HUBBLE_VERSION=3.0.12
+ENV HUBBLE_VERSION=3.0.13
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_URL=https://github.com/hubblestack/hubble
 ENV HUBBLE_SRC_PATH=/hubble_src

--- a/pkg/debian10/osquerybuilder.sh
+++ b/pkg/debian10/osquerybuilder.sh
@@ -43,10 +43,10 @@ else
   sudo -u "$OSQUERY_BUILD_USER" make strip
   cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery/osqueryi
   cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd
+  mkdir -p /opt/osquery/lenses
+  cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses
 fi
 chown -R root. /opt/osquery
 chmod -R 500 /opt/osquery/*
-mkdir -p /opt/osquery/lenses
-cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses
 chmod -R 400 /opt/osquery/lenses/*
 ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version

--- a/pkg/debian10/osquerybuilder.sh
+++ b/pkg/debian10/osquerybuilder.sh
@@ -5,9 +5,7 @@ build_osquery_locally=$2
 
 if [ $build_osquery != true ]
 then
-  mkdir -p /opt/osquery/
-  cp /osqueryi /opt/osquery/osqueryi
-  cp /osqueryd /opt/osquery/hubble_osqueryd
+  tar -C /opt/ -zxvf osquery_*_tob_debian10.tar
   echo $build_osquery
 else
   echo $build_osquery_locally

--- a/pkg/debian10/osquerybuilder.sh
+++ b/pkg/debian10/osquerybuilder.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+build_osquery=$1
+build_osquery_locally=$2
+
+if [ $build_osquery != true ]
+then
+  mkdir -p /opt/osquery/
+  cp /osqueryi /opt/osquery/osqueryi
+  cp /osqueryd /opt/osquery/hubble_osqueryd
+  echo $build_osquery
+else
+  echo $build_osquery_locally
+  if [ $build_osquery_locally == true ]
+  then
+    echo "Building osquery from local folder"
+  else
+    rm -rf /osquery
+    OSQUERY_SRC_VERSION=3.3.2
+    OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
+    cd /
+    git clone "$OSQUERY_GIT_URL"
+    cd osquery/
+    git checkout "$OSQUERY_SRC_VERSION"
+    echo "Fetching osquery from git"
+    echo $OSQUERY_SRC_VERSION
+  fi
+  mkdir /home/"$OSQUERY_BUILD_USER"/osquery
+  cp -r /osquery/ /home/"$OSQUERY_BUILD_USER"/
+  mkdir -p /usr/local/osquery/
+  chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/
+  chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
+  echo "LC_ALL=en_US.UTF-8" >> /etc/default/locale
+  sed -i '/en_US.UTF-8\ UTF-8/s/^#//' /etc/locale.gen
+  locale-gen
+  
+  export SKIP_TESTS=1
+  cd /home/"$OSQUERY_BUILD_USER"/osquery 
+  sudo -u "$OSQUERY_BUILD_USER" make sysprep
+  sudo -u "$OSQUERY_BUILD_USER" sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp
+  sudo -u "$OSQUERY_BUILD_USER" make deps
+  sudo -u "$OSQUERY_BUILD_USER" make
+  sudo -u "$OSQUERY_BUILD_USER" make strip
+  cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery/osqueryi
+  cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd
+fi
+chown -R root. /opt/osquery
+chmod -R 500 /opt/osquery/*
+mkdir -p /opt/osquery/lenses
+cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses
+chmod -R 400 /opt/osquery/lenses/*
+ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version

--- a/pkg/debian8/Dockerfile
+++ b/pkg/debian8/Dockerfile
@@ -1,36 +1,16 @@
 # This Dockerfile aims to make building Hubble v2 packages easier.
 # To build an image: 1. copy pkg/scripts/pyinstaller-requirements.txt to directory with this Dockerfile
-#                    2. docker build -t <image_name> .
+#                    2. copy osquerybuilder.sh to this directory. This is needed to bundle osquery with Hubble
+#                    3. docker build -t <image_name> .
 # The resulting image is ready to run the pyinstaller on container start and drop hubble<version>-coreos.tar.gz
 # in the /data directory. Mount /data volume into a directory on the host to access the package.
 # To run the container:  docker run -it --rm -v `pwd`:/data <image_name>
 # Requires docker 17.05 or higher
 
-#ARG OSQUERY_BUILD_ENV=remote
-
-#--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
-#FROM alpine as osquery_local
-#ONBUILD COPY osquery /osquery
-#ONBUILD RUN echo "Copying osquery from local folder"
-
-
-
-#--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
-#FROM alpine/git as osquery_remote
-#to osquery pin to a different version change the following envirnment variable
-#ENV OSQUERY_SRC_VERSION=3.3.2
-#ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
-#ONBUILD RUN cd / \
-# && git clone "$OSQUERY_GIT_URL" \
-# && cd osquery/ \
-# && git checkout "$OSQUERY_SRC_VERSION" \
-# && echo "Fetching osquery from git"
-
-
-#--------------- TEMP CONTAINER FOR OSQUERY ( BASED UPON ARGUMENT )  ----------------
-#FROM osquery_"$OSQUERY_BUILD_ENV" as osquery
-
-
+#Hubble builds can have the following 3 combinations wrt osquery:
+# 1. Package already built osquery. (BUILD_OSQUERY=false)
+# 2. Build osquery from https://git.corp.adobe.com/hubblestack/osquery. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM debian:8
 
@@ -71,32 +51,6 @@ RUN useradd --shell /bin/bash --create-home --user-group --groups sudo "$OSQUERY
  && sed -i 's/^%sudo.*/%sudo\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
 ADD osquerybuilder.sh /osquerybuilder.sh
 RUN sh /osquerybuilder.sh "$BUILD_OSQUERY" "$BUILD_OSQUERY_LOCALLY"
-#COPY --from=osquery /osquery /home/"$OSQUERY_BUILD_USER"/osquery
-#RUN mkdir -p /usr/local/osquery/ \
-# && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
-# && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery \
-# && echo "LC_ALL=en_US.UTF-8" >> /etc/default/locale \
-# && sed -i '/en_US.UTF-8\ UTF-8/s/^#//' /etc/locale.gen \
-# && locale-gen
-#USER $OSQUERY_BUILD_USER
-#ENV SKIP_TESTS=1
-#RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
-# && make sysprep \
-#have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
-# && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \
-# && make deps \
-# && make \
-# && make strip
-#USER root
-#RUN cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery \
-# && cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd \
-# && chown -R root. /opt/osquery \
-# && chmod -R 500 /opt/osquery/* \
-#put augeas lenses into the default directory that we changed earlier
-# && mkdir -p /opt/osquery/lenses \
-# && cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses \
-# && chmod -R 400 /opt/osquery/lenses/*
-#RUN ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version
 
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
 USER root

--- a/pkg/debian8/Dockerfile
+++ b/pkg/debian8/Dockerfile
@@ -6,29 +6,29 @@
 # To run the container:  docker run -it --rm -v `pwd`:/data <image_name>
 # Requires docker 17.05 or higher
 
-ARG OSQUERY_BUILD_ENV=remote
+#ARG OSQUERY_BUILD_ENV=remote
 
 #--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
-FROM alpine as osquery_local
-ONBUILD COPY osquery /osquery
-ONBUILD RUN echo "Copying osquery from local folder"
+#FROM alpine as osquery_local
+#ONBUILD COPY osquery /osquery
+#ONBUILD RUN echo "Copying osquery from local folder"
 
 
 
 #--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
-FROM alpine/git as osquery_remote
+#FROM alpine/git as osquery_remote
 #to osquery pin to a different version change the following envirnment variable
-ENV OSQUERY_SRC_VERSION=3.3.2
-ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
-ONBUILD RUN cd / \
- && git clone "$OSQUERY_GIT_URL" \
- && cd osquery/ \
- && git checkout "$OSQUERY_SRC_VERSION" \
- && echo "Fetching osquery from git"
+#ENV OSQUERY_SRC_VERSION=3.3.2
+#ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
+#ONBUILD RUN cd / \
+# && git clone "$OSQUERY_GIT_URL" \
+# && cd osquery/ \
+# && git checkout "$OSQUERY_SRC_VERSION" \
+# && echo "Fetching osquery from git"
 
 
 #--------------- TEMP CONTAINER FOR OSQUERY ( BASED UPON ARGUMENT )  ----------------
-FROM osquery_"$OSQUERY_BUILD_ENV" as osquery
+#FROM osquery_"$OSQUERY_BUILD_ENV" as osquery
 
 
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
@@ -59,35 +59,44 @@ RUN mkdir -p "$PATCHELF_TEMP" \
 #osquery should be built first since requirements for other packages can interfere with osquery dependencies
 #to build, osquery scripts want sudo and a user to sudo with.
 ENV OSQUERY_BUILD_USER=osquerybuilder
+ARG BUILD_OSQUERY=true
+ARG BUILD_OSQUERY_LOCALLY=false
+ARG OSQUERY_SRC_VERSION=osquery_3.3.2_tob
+COPY osquery /osquery
+COPY $OSQUERY_SRC_VERSION /osqueryi
+COPY $OSQUERY_SRC_VERSION /osqueryd
+
 RUN apt-get -y install git make python ruby sudo locales curl xz-utils
 RUN useradd --shell /bin/bash --create-home --user-group --groups sudo "$OSQUERY_BUILD_USER" \
  && sed -i 's/^%sudo.*/%sudo\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
-COPY --from=osquery /osquery /home/"$OSQUERY_BUILD_USER"/osquery
-RUN mkdir -p /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery \
- && echo "LC_ALL=en_US.UTF-8" >> /etc/default/locale \
- && sed -i '/en_US.UTF-8\ UTF-8/s/^#//' /etc/locale.gen \
- && locale-gen
-USER $OSQUERY_BUILD_USER
-ENV SKIP_TESTS=1
-RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
- && make sysprep \
+ADD osquerybuilder.sh /osquerybuilder.sh
+RUN sh /osquerybuilder.sh "$BUILD_OSQUERY" "$BUILD_OSQUERY_LOCALLY"
+#COPY --from=osquery /osquery /home/"$OSQUERY_BUILD_USER"/osquery
+#RUN mkdir -p /usr/local/osquery/ \
+# && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
+# && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery \
+# && echo "LC_ALL=en_US.UTF-8" >> /etc/default/locale \
+# && sed -i '/en_US.UTF-8\ UTF-8/s/^#//' /etc/locale.gen \
+# && locale-gen
+#USER $OSQUERY_BUILD_USER
+#ENV SKIP_TESTS=1
+#RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
+# && make sysprep \
 #have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
- && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \
- && make deps \
- && make \
- && make strip
-USER root
-RUN cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery \
- && cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd \
- && chown -R root. /opt/osquery \
- && chmod -R 500 /opt/osquery/* \
+# && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \
+# && make deps \
+# && make \
+# && make strip
+#USER root
+#RUN cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery \
+# && cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd \
+# && chown -R root. /opt/osquery \
+# && chmod -R 500 /opt/osquery/* \
 #put augeas lenses into the default directory that we changed earlier
- && mkdir -p /opt/osquery/lenses \
- && cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses \
- && chmod -R 400 /opt/osquery/lenses/*
-RUN ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version
+# && mkdir -p /opt/osquery/lenses \
+# && cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses \
+# && chmod -R 400 /opt/osquery/lenses/*
+#RUN ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version
 
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
 RUN apt-get -y install  \

--- a/pkg/debian8/Dockerfile
+++ b/pkg/debian8/Dockerfile
@@ -63,8 +63,8 @@ ARG BUILD_OSQUERY=true
 ARG BUILD_OSQUERY_LOCALLY=false
 ARG OSQUERY_SRC_VERSION=osquery_3.3.2_tob
 COPY osquery /osquery
-COPY $OSQUERY_SRC_VERSION /osqueryi
-COPY $OSQUERY_SRC_VERSION /osqueryd
+ENV OSQUERY_TAR_FILENAME=$OSQUERY_SRC_VERSION"_debian8.tar"
+COPY $OSQUERY_TAR_FILENAME /
 
 RUN apt-get -y install git make python ruby sudo locales curl xz-utils
 RUN useradd --shell /bin/bash --create-home --user-group --groups sudo "$OSQUERY_BUILD_USER" \

--- a/pkg/debian8/Dockerfile
+++ b/pkg/debian8/Dockerfile
@@ -133,9 +133,9 @@ RUN apt-get install -y ruby ruby-dev rubygems gcc make \
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
-ENV HUBBLE_CHECKOUT=v3.0.12
+ENV HUBBLE_CHECKOUT=v3.0.13
 ENV HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
-ENV HUBBLE_VERSION=3.0.12
+ENV HUBBLE_VERSION=3.0.13
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_URL=https://github.com/hubblestack/hubble
 ENV HUBBLE_SRC_PATH=/hubble_src

--- a/pkg/debian8/Dockerfile
+++ b/pkg/debian8/Dockerfile
@@ -9,7 +9,7 @@
 
 #Hubble builds can have the following 3 combinations wrt osquery:
 # 1. Package already built osquery. (BUILD_OSQUERY=false)
-# 2. Build osquery from https://git.corp.adobe.com/hubblestack/osquery. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
 # 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM debian:8

--- a/pkg/debian8/Dockerfile
+++ b/pkg/debian8/Dockerfile
@@ -99,6 +99,7 @@ RUN sh /osquerybuilder.sh "$BUILD_OSQUERY" "$BUILD_OSQUERY_LOCALLY"
 #RUN ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version
 
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
+USER root
 RUN apt-get -y install  \
                python-dev libffi-dev libssl-dev libyaml-dev libssh2-1 libssh2-1-dev autoconf automake libtool \
                libxml2-dev libxslt1-dev zlib1g-dev cmake python-setuptools \

--- a/pkg/debian8/Dockerfile
+++ b/pkg/debian8/Dockerfile
@@ -8,8 +8,8 @@
 # Requires docker 17.05 or higher
 
 #Hubble builds can have the following 3 combinations wrt osquery:
-# 1. Package already built osquery. (BUILD_OSQUERY=false)
-# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 1. Package already built osquery. (BUILD_OSQUERY=false). Keep the osquery tar file besides this Dockerfile.
+# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true). Keep the osquery source code besides this Dockerfile.
 # 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM debian:8

--- a/pkg/debian8/osquerybuilder.sh
+++ b/pkg/debian8/osquerybuilder.sh
@@ -5,9 +5,7 @@ build_osquery_locally=$2
 
 if [ $build_osquery != true ]
 then
-  mkdir -p /opt/osquery/
-  cp /osqueryi /opt/osquery/osqueryi
-  cp /osqueryd /opt/osquery/hubble_osqueryd
+  tar -C /opt/ -zxvf osquery_*_tob_debian8.tar
   echo $build_osquery
 else
   echo $build_osquery_locally

--- a/pkg/debian8/osquerybuilder.sh
+++ b/pkg/debian8/osquerybuilder.sh
@@ -43,10 +43,10 @@ else
   sudo -u "$OSQUERY_BUILD_USER" make strip
   cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery/osqueryi
   cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd
+  mkdir -p /opt/osquery/lenses
+  cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses
 fi
 chown -R root. /opt/osquery
 chmod -R 500 /opt/osquery/*
-mkdir -p /opt/osquery/lenses
-cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses
 chmod -R 400 /opt/osquery/lenses/*
 ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version

--- a/pkg/debian8/osquerybuilder.sh
+++ b/pkg/debian8/osquerybuilder.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+build_osquery=$1
+build_osquery_locally=$2
+
+if [ $build_osquery != true ]
+then
+  mkdir -p /opt/osquery/
+  cp /osqueryi /opt/osquery/osqueryi
+  cp /osqueryd /opt/osquery/hubble_osqueryd
+  echo $build_osquery
+else
+  echo $build_osquery_locally
+  if [ $build_osquery_locally == true ]
+  then
+    echo "Building osquery from local folder"
+  else
+    rm -rf /osquery
+    OSQUERY_SRC_VERSION=3.3.2
+    OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
+    cd /
+    git clone "$OSQUERY_GIT_URL"
+    cd osquery/
+    git checkout "$OSQUERY_SRC_VERSION"
+    echo "Fetching osquery from git"
+    echo $OSQUERY_SRC_VERSION
+  fi
+  mkdir /home/"$OSQUERY_BUILD_USER"/osquery
+  cp -r /osquery/ /home/"$OSQUERY_BUILD_USER"/
+  mkdir -p /usr/local/osquery/
+  chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/
+  chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
+  echo "LC_ALL=en_US.UTF-8" >> /etc/default/locale
+  sed -i '/en_US.UTF-8\ UTF-8/s/^#//' /etc/locale.gen
+  locale-gen
+  
+  export SKIP_TESTS=1
+  cd /home/"$OSQUERY_BUILD_USER"/osquery 
+  sudo -u "$OSQUERY_BUILD_USER" make sysprep
+  sudo -u "$OSQUERY_BUILD_USER" sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp
+  sudo -u "$OSQUERY_BUILD_USER" make deps
+  sudo -u "$OSQUERY_BUILD_USER" make
+  sudo -u "$OSQUERY_BUILD_USER" make strip
+  cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery/osqueryi
+  cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd
+fi
+chown -R root. /opt/osquery
+chmod -R 500 /opt/osquery/*
+mkdir -p /opt/osquery/lenses
+cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses
+chmod -R 400 /opt/osquery/lenses/*
+ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version

--- a/pkg/debian9/Dockerfile
+++ b/pkg/debian9/Dockerfile
@@ -63,8 +63,8 @@ ARG BUILD_OSQUERY=true
 ARG BUILD_OSQUERY_LOCALLY=false
 ARG OSQUERY_SRC_VERSION=osquery_3.3.2_tob
 COPY osquery /osquery
-COPY $OSQUERY_SRC_VERSION /osqueryi
-COPY $OSQUERY_SRC_VERSION /osqueryd
+ENV OSQUERY_TAR_FILENAME=$OSQUERY_SRC_VERSION"_debian9.tar"
+COPY $OSQUERY_TAR_FILENAME /
 RUN apt-get -y install git make python ruby sudo curl
 RUN useradd --shell /bin/bash --create-home --user-group --groups sudo "$OSQUERY_BUILD_USER" \
  && sed -i 's/^%sudo.*/%sudo\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers

--- a/pkg/debian9/Dockerfile
+++ b/pkg/debian9/Dockerfile
@@ -6,29 +6,29 @@
 # To run the container:  docker run -it --rm -v `pwd`:/data <image_name>
 # Requires docker 17.05 or higher
 
-ARG OSQUERY_BUILD_ENV=remote
+#ARG OSQUERY_BUILD_ENV=remote
 
 #--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
-FROM alpine as osquery_local
-ONBUILD COPY osquery /osquery
-ONBUILD RUN echo "Copying osquery from local folder"
+#FROM alpine as osquery_local
+#ONBUILD COPY osquery /osquery
+#ONBUILD RUN echo "Copying osquery from local folder"
 
 
 
 #--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
-FROM alpine/git as osquery_remote
+#FROM alpine/git as osquery_remote
 #to osquery pin to a different version change the following envirnment variable
-ENV OSQUERY_SRC_VERSION=3.3.2
-ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
-ONBUILD RUN cd / \
- && git clone "$OSQUERY_GIT_URL" \
- && cd osquery/ \
- && git checkout "$OSQUERY_SRC_VERSION" \
- && echo "Fetching osquery from git"
+#ENV OSQUERY_SRC_VERSION=3.3.2
+#ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
+#ONBUILD RUN cd / \
+# && git clone "$OSQUERY_GIT_URL" \
+# && cd osquery/ \
+# && git checkout "$OSQUERY_SRC_VERSION" \
+# && echo "Fetching osquery from git"
 
 
 #--------------- TEMP CONTAINER FOR OSQUERY ( BASED UPON ARGUMENT )  ------------
-FROM osquery_"$OSQUERY_BUILD_ENV" as osquery
+#FROM osquery_"$OSQUERY_BUILD_ENV" as osquery
 
 
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
@@ -59,34 +59,43 @@ RUN mkdir -p "$PATCHELF_TEMP" \
 #osquery should be built first since requirements for other packages can interfere with osquery dependencies
 #to build, osquery scripts want sudo and a user to sudo with.
 ENV OSQUERY_BUILD_USER=osquerybuilder
+ARG BUILD_OSQUERY=true
+ARG BUILD_OSQUERY_LOCALLY=false
+ARG OSQUERY_SRC_VERSION=osquery_3.3.2_tob
+COPY osquery /osquery
+COPY $OSQUERY_SRC_VERSION /osqueryi
+COPY $OSQUERY_SRC_VERSION /osqueryd
 RUN apt-get -y install git make python ruby sudo curl
 RUN useradd --shell /bin/bash --create-home --user-group --groups sudo "$OSQUERY_BUILD_USER" \
  && sed -i 's/^%sudo.*/%sudo\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
-COPY --from=osquery /osquery /home/"$OSQUERY_BUILD_USER"/osquery
-RUN mkdir -p /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
-USER $OSQUERY_BUILD_USER
-ENV SKIP_TESTS=1
-RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
- && make sysprep \
+ADD osquerybuilder.sh /osquerybuilder.sh
+RUN sh /osquerybuilder.sh "$BUILD_OSQUERY" "$BUILD_OSQUERY_LOCALLY"
+#COPY --from=osquery /osquery /home/"$OSQUERY_BUILD_USER"/osquery
+#RUN mkdir -p /usr/local/osquery/ \
+# && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
+# && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
+#USER $OSQUERY_BUILD_USER
+#ENV SKIP_TESTS=1
+#RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
+# && make sysprep \
 #have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
- && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \
- && make deps \
- && make \
- && make strip
-USER root
-RUN cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery \
- && cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd \
- && chown -R root. /opt/osquery \
- && chmod -R 500 /opt/osquery/* \
+# && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \
+# && make deps \
+# && make \
+# && make strip
+#USER root
+#RUN cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery \
+# && cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd \
+# && chown -R root. /opt/osquery \
+# && chmod -R 500 /opt/osquery/* \
 #put augeas lenses into the default directory that we changed earlier
- && mkdir -p /opt/osquery/lenses \
- && cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses \
- && chmod -R 400 /opt/osquery/lenses/*
-RUN ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version
+# && mkdir -p /opt/osquery/lenses \
+# && cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses \
+# && chmod -R 400 /opt/osquery/lenses/*
+#RUN ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version
 
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
+USER root
 RUN apt-get -y install  \
                python-dev libffi-dev libssl-dev libyaml-dev libssh2-1 libssh2-1-dev autoconf automake libtool \
                libxml2-dev libxslt1-dev python-cffi \

--- a/pkg/debian9/Dockerfile
+++ b/pkg/debian9/Dockerfile
@@ -8,8 +8,8 @@
 # Requires docker 17.05 or higher
 
 #Hubble builds can have the following 3 combinations wrt osquery:
-# 1. Package already built osquery. (BUILD_OSQUERY=false)
-# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 1. Package already built osquery. (BUILD_OSQUERY=false). Keep the osquery tar file besides this Dockerfile.
+# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true). Keep the osquery source code besides this Dockerfile.
 # 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM debian:9

--- a/pkg/debian9/Dockerfile
+++ b/pkg/debian9/Dockerfile
@@ -9,7 +9,7 @@
 
 #Hubble builds can have the following 3 combinations wrt osquery:
 # 1. Package already built osquery. (BUILD_OSQUERY=false)
-# 2. Build osquery from https://git.corp.adobe.com/hubblestack/osquery. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
 # 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM debian:9

--- a/pkg/debian9/Dockerfile
+++ b/pkg/debian9/Dockerfile
@@ -1,36 +1,16 @@
 # This Dockerfile aims to make building Hubble v2 packages easier.
 # To build an image: 1. copy pkg/scripts/pyinstaller-requirements.txt to directory with this Dockerfile
-#                    2. docker build -t <image_name> .
+#                    2. copy osquerybuilder.sh to this directory. This is needed to bundle osquery with Hubble
+#                    3. docker build -t <image_name> .
 # The resulting image is ready to run the pyinstaller on container start and drop hubble<version>-coreos.tar.gz
 # in the /data directory. Mount /data volume into a directory on the host to access the package.
 # To run the container:  docker run -it --rm -v `pwd`:/data <image_name>
 # Requires docker 17.05 or higher
 
-#ARG OSQUERY_BUILD_ENV=remote
-
-#--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
-#FROM alpine as osquery_local
-#ONBUILD COPY osquery /osquery
-#ONBUILD RUN echo "Copying osquery from local folder"
-
-
-
-#--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
-#FROM alpine/git as osquery_remote
-#to osquery pin to a different version change the following envirnment variable
-#ENV OSQUERY_SRC_VERSION=3.3.2
-#ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
-#ONBUILD RUN cd / \
-# && git clone "$OSQUERY_GIT_URL" \
-# && cd osquery/ \
-# && git checkout "$OSQUERY_SRC_VERSION" \
-# && echo "Fetching osquery from git"
-
-
-#--------------- TEMP CONTAINER FOR OSQUERY ( BASED UPON ARGUMENT )  ------------
-#FROM osquery_"$OSQUERY_BUILD_ENV" as osquery
-
-
+#Hubble builds can have the following 3 combinations wrt osquery:
+# 1. Package already built osquery. (BUILD_OSQUERY=false)
+# 2. Build osquery from https://git.corp.adobe.com/hubblestack/osquery. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM debian:9
 
@@ -70,29 +50,6 @@ RUN useradd --shell /bin/bash --create-home --user-group --groups sudo "$OSQUERY
  && sed -i 's/^%sudo.*/%sudo\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
 ADD osquerybuilder.sh /osquerybuilder.sh
 RUN sh /osquerybuilder.sh "$BUILD_OSQUERY" "$BUILD_OSQUERY_LOCALLY"
-#COPY --from=osquery /osquery /home/"$OSQUERY_BUILD_USER"/osquery
-#RUN mkdir -p /usr/local/osquery/ \
-# && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
-# && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
-#USER $OSQUERY_BUILD_USER
-#ENV SKIP_TESTS=1
-#RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
-# && make sysprep \
-#have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
-# && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \
-# && make deps \
-# && make \
-# && make strip
-#USER root
-#RUN cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery \
-# && cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd \
-# && chown -R root. /opt/osquery \
-# && chmod -R 500 /opt/osquery/* \
-#put augeas lenses into the default directory that we changed earlier
-# && mkdir -p /opt/osquery/lenses \
-# && cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses \
-# && chmod -R 400 /opt/osquery/lenses/*
-#RUN ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version
 
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
 USER root

--- a/pkg/debian9/Dockerfile
+++ b/pkg/debian9/Dockerfile
@@ -130,9 +130,9 @@ RUN apt-get install -y ruby ruby-dev rubygems gcc make \
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
-ENV HUBBLE_CHECKOUT=v3.0.12
+ENV HUBBLE_CHECKOUT=v3.0.13
 ENV HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
-ENV HUBBLE_VERSION=3.0.12
+ENV HUBBLE_VERSION=3.0.13
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_URL=https://github.com/hubblestack/hubble
 ENV HUBBLE_SRC_PATH=/hubble_src

--- a/pkg/debian9/osquerybuilder.sh
+++ b/pkg/debian9/osquerybuilder.sh
@@ -5,9 +5,7 @@ build_osquery_locally=$2
 
 if [ $build_osquery != true ]
 then
-  mkdir -p /opt/osquery/
-  cp /osqueryi /opt/osquery/osqueryi
-  cp /osqueryd /opt/osquery/hubble_osqueryd
+  tar -C /opt/ -zxvf osquery_*_tob_debian9.tar
   echo $build_osquery
 else
   echo $build_osquery_locally

--- a/pkg/debian9/osquerybuilder.sh
+++ b/pkg/debian9/osquerybuilder.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+build_osquery=$1
+build_osquery_locally=$2
+
+if [ $build_osquery != true ]
+then
+  mkdir -p /opt/osquery/
+  cp /osqueryi /opt/osquery/osqueryi
+  cp /osqueryd /opt/osquery/hubble_osqueryd
+  echo $build_osquery
+else
+  echo $build_osquery_locally
+  if [ $build_osquery_locally == true ]
+  then
+    echo "Building osquery from local folder"
+  else
+    rm -rf /osquery
+    OSQUERY_SRC_VERSION=3.3.2
+    OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
+    cd /
+    git clone "$OSQUERY_GIT_URL"
+    cd osquery/
+    git checkout "$OSQUERY_SRC_VERSION"
+    echo "Fetching osquery from git"
+    echo $OSQUERY_SRC_VERSION
+  fi
+  mkdir /home/"$OSQUERY_BUILD_USER"/osquery
+  cp -r /osquery/ /home/"$OSQUERY_BUILD_USER"/
+  mkdir -p /usr/local/osquery/
+  chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/
+  chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
+  
+  export SKIP_TESTS=1
+  cd /home/"$OSQUERY_BUILD_USER"/osquery 
+  sudo -u "$OSQUERY_BUILD_USER" make sysprep
+  sudo -u "$OSQUERY_BUILD_USER" sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp
+  sudo -u "$OSQUERY_BUILD_USER" make deps
+  sudo -u "$OSQUERY_BUILD_USER" make
+  sudo -u "$OSQUERY_BUILD_USER" make strip
+  cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery/osqueryi
+  cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd
+fi
+chown -R root. /opt/osquery
+chmod -R 500 /opt/osquery/*
+mkdir -p /opt/osquery/lenses
+cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses
+chmod -R 400 /opt/osquery/lenses/*
+ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version

--- a/pkg/debian9/osquerybuilder.sh
+++ b/pkg/debian9/osquerybuilder.sh
@@ -40,10 +40,10 @@ else
   sudo -u "$OSQUERY_BUILD_USER" make strip
   cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery/osqueryi
   cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd
+  mkdir -p /opt/osquery/lenses
+  cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses
 fi
 chown -R root. /opt/osquery
 chmod -R 500 /opt/osquery/*
-mkdir -p /opt/osquery/lenses
-cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses
 chmod -R 400 /opt/osquery/lenses/*
 ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version

--- a/pkg/dev/amazonlinux2016.09/Dockerfile
+++ b/pkg/dev/amazonlinux2016.09/Dockerfile
@@ -1,38 +1,16 @@
 # This Dockerfile aims to make building Hubble v2 packages easier.
 # To build an image: 1. copy pkg/scripts/pyinstaller-requirements.txt to directory with this Dockerfile
-#                    2. docker build -t <image_name> . --build-arg=HUBBLE_GIT_URL=<git_repo_url>
-#                                                      --build-arg=HUBBLE_CHECKOUT=<branch/tag/commit>
+#                    2. copy osquerybuilder.sh to this directory. This is needed to bundle osquery with Hubble
+#                    3. docker build -t <image_name> .
 # The resulting image is ready to run the pyinstaller on container start and drop hubble<version>-coreos.tar.gz
 # in the /data directory. Mount /data volume into a directory on the host to access the package.
 # To run the container:  docker run -it --rm -v `pwd`:/data <image_name>
 # Requires docker 17.05 or higher
 
-# Set this arguement to "local" if you want to build osquery for local code.
-# In that case, osquery folder must exist besides Dockerfile
-ARG OSQUERY_BUILD_ENV=remote
-
-#--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
-FROM alpine as osquery_local
-ONBUILD COPY osquery /osquery
-ONBUILD RUN echo "Copying osquery from local folder"
-
-
-
-#--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
-FROM alpine/git as osquery_remote
-ENV OSQUERY_SRC_VERSION=3.3.2
-ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
-ONBUILD RUN cd / \
- && git clone "$OSQUERY_GIT_URL" \
- && cd osquery/ \
- && git checkout "$OSQUERY_SRC_VERSION" \
- && echo "Fetching osquery from git"
-
-
-#--------------- TEMP CONTAINER FOR OSQUERY ( BASED ON ARG)  ----------------
-FROM osquery_"$OSQUERY_BUILD_ENV" as osquery_image
-
-
+#Hubble builds can have the following 3 combinations wrt osquery:
+# 1. Package already built osquery. (BUILD_OSQUERY=false)
+# 2. Build osquery from https://git.corp.adobe.com/hubblestack/osquery. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM amazonlinux:2016.09
 
@@ -44,36 +22,23 @@ RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osque
 #osquery build start
 #osquery should be built first since requirements for other packages can interfere with osquery dependencies
 #to build, osquery scripts want sudo and a user to sudo with.
-#to pin to a different version change the following envirnment variable
+ENV OSQUERY_BUILD_USER=osquerybuilder
+ARG BUILD_OSQUERY=true
+ARG BUILD_OSQUERY_LOCALLY=false
+ARG OSQUERY_SRC_VERSION=osquery_3.3.2_tob
+COPY osquery /osquery
+ENV OSQUERY_TAR_FILENAME=$OSQUERY_SRC_VERSION"_amazonlinux2016.09.tar"
+COPY $OSQUERY_TAR_FILENAME /
+
 ENV OSQUERY_BUILD_USER=osquerybuilder
 RUN yum -y install git make python ruby sudo which
 RUN useradd --shell /bin/bash --create-home --user-group --groups wheel "$OSQUERY_BUILD_USER" \
  && sed -i '0,/^#\ %wheel/s/^#\ %wheel.*/%wheel\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
-COPY --from=osquery_image /osquery /home/"$OSQUERY_BUILD_USER"/osquery
-RUN mkdir -p /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
-USER $OSQUERY_BUILD_USER
-ENV SKIP_TESTS=1
-RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
- && make sysprep \
-#have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
- && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \
- && make deps \
- && make \
- && make strip
-USER root
-RUN cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery \
- && cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd \
- && chown -R root. /opt/osquery \
- && chmod -R 500 /opt/osquery/* \
-#put augeas lenses into the default directory that we changed earlier
- && mkdir -p /opt/osquery/lenses \
- && cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses \
- && chmod -R 400 /opt/osquery/lenses/*
-RUN ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version
+ADD osquerybuilder.sh /osquerybuilder.sh
+RUN sh /osquerybuilder.sh "$BUILD_OSQUERY" "$BUILD_OSQUERY_LOCALLY"
 
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
+USER root
 RUN yum -y install  \
                python27-devel libffi-devel openssl-devel libssh2-devel autoconf automake libtool \
                libxml2-devel libxslt-devel libjpeg-devel \
@@ -152,21 +117,21 @@ RUN yum install -y ruby ruby-devel rpmbuild rpm-build rubygems gcc make \
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
-ARG HUBBLE_CHECKOUT=3.0
-ARG HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
-ENV HUBBLE_VERSION=3.0_branch
+ENV HUBBLE_CHECKOUT=v3.0.12
+ENV HUBBLE_VERSION=3.0.12
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_URL=https://github.com/hubblestack/hubble
 ENV HUBBLE_DESCRIPTION="Hubble is a modular, open-source, security & compliance auditing framework which is built in python, using SaltStack as a library."
 ENV HUBBLE_SUMMARY="Profile based on-demand auditing and monitoring tool"
+ENV HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
 ENV HUBBLE_SRC_PATH=/hubble_src
 ENV _HOOK_DIR="./pkg/"
 ENV _BINARY_LOG_LEVEL="INFO"
 ENV _INCLUDE_PATH=""
 ENV LD_LIBRARY_PATH=/opt/hubble/lib:/lib:/lib64:/usr/lib:/usr/lib64:/usr/local/lib:/usr/local/lib64
-RUN git clone ${HUBBLE_GIT_URL} "$HUBBLE_SRC_PATH" \
+RUN git clone "$HUBBLE_GIT_URL" "$HUBBLE_SRC_PATH" \
  && cd "$HUBBLE_SRC_PATH" \
- && git checkout ${HUBBLE_CHECKOUT} \
+ && git checkout "$HUBBLE_CHECKOUT" \
  && cp -rf "$HUBBLE_SRC_PATH" /hubble_build \
  && sed -i "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT}/g" /hubble_build/hubblestack/__init__.py \
  && sed -i "s/COMMIT_NOT_SET/`git describe`/g" /hubble_build/hubblestack/__init__.py
@@ -185,7 +150,7 @@ CMD [ "if [ -f /data/hubble_buildinfo ] ; then echo \"\" >> /hubble_build/hubble
     # make sure rpm shared libs are taken out to avoid mismatch between rpm database and shared libs that pyinstaller includes
     && rm -rf /opt/hubble/hubble-libs/librpm* \
 #rpm pkg start
-    && tar -cPvzf /data/hubblestack-${HUBBLE_VERSION}.tar.gz /etc/hubble /opt/hubble /opt/osquery /etc/profile.d/hubble-profile.sh /var/log/hubble_osquery/backuplogs\
+    && tar -cPvzf /data/hubblestack-${HUBBLE_VERSION}.tar.gz /etc/hubble /opt/hubble /opt/osquery /etc/profile.d/hubble-profile.sh /var/log/hubble_osquery/backuplogs \
     && mkdir -p /hubble_build/debbuild/hubblestack-${HUBBLE_VERSION} \
     && tar -xzvf /data/hubblestack-${HUBBLE_VERSION}.tar.gz -C /hubble_build/debbuild/hubblestack-${HUBBLE_VERSION} \
     && mkdir -p /hubble_build/debbuild/hubblestack-${HUBBLE_VERSION}/etc/init.d \

--- a/pkg/dev/amazonlinux2016.09/Dockerfile
+++ b/pkg/dev/amazonlinux2016.09/Dockerfile
@@ -8,8 +8,8 @@
 # Requires docker 17.05 or higher
 
 #Hubble builds can have the following 3 combinations wrt osquery:
-# 1. Package already built osquery. (BUILD_OSQUERY=false)
-# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 1. Package already built osquery. (BUILD_OSQUERY=false). Keep the osquery tar file besides this Dockerfile.
+# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true). Keep the osquery source code besides this Dockerfile.
 # 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM amazonlinux:2016.09

--- a/pkg/dev/amazonlinux2016.09/Dockerfile
+++ b/pkg/dev/amazonlinux2016.09/Dockerfile
@@ -117,8 +117,8 @@ RUN yum install -y ruby ruby-devel rpmbuild rpm-build rubygems gcc make \
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
-ENV HUBBLE_CHECKOUT=v3.0.12
-ENV HUBBLE_VERSION=3.0.12
+ENV HUBBLE_CHECKOUT=v3.0.13
+ENV HUBBLE_VERSION=3.0.13
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_URL=https://github.com/hubblestack/hubble
 ENV HUBBLE_DESCRIPTION="Hubble is a modular, open-source, security & compliance auditing framework which is built in python, using SaltStack as a library."

--- a/pkg/dev/amazonlinux2016.09/Dockerfile
+++ b/pkg/dev/amazonlinux2016.09/Dockerfile
@@ -9,7 +9,7 @@
 
 #Hubble builds can have the following 3 combinations wrt osquery:
 # 1. Package already built osquery. (BUILD_OSQUERY=false)
-# 2. Build osquery from https://git.corp.adobe.com/hubblestack/osquery. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
 # 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM amazonlinux:2016.09

--- a/pkg/dev/amazonlinux2016.09/osquerybuilder.sh
+++ b/pkg/dev/amazonlinux2016.09/osquerybuilder.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+build_osquery=$1
+build_osquery_locally=$2
+
+if [ $build_osquery != true ]
+then
+  mkdir -p /opt/osquery/
+  cp /osqueryi /opt/osquery/osqueryi
+  cp /osqueryd /opt/osquery/hubble_osqueryd
+  echo $build_osquery
+else
+  echo $build_osquery_locally
+  if [ $build_osquery_locally == true ]
+  then
+    echo "Building osquery from local folder"
+  else
+    rm -rf /osquery
+    OSQUERY_SRC_VERSION=3.3.2
+    OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
+    cd /
+    git clone "$OSQUERY_GIT_URL"
+    cd osquery/
+    git checkout "$OSQUERY_SRC_VERSION"
+    echo "Fetching osquery from git"
+    echo $OSQUERY_SRC_VERSION
+  fi
+  mkdir /home/"$OSQUERY_BUILD_USER"/osquery
+  cp -r /osquery/ /home/"$OSQUERY_BUILD_USER"/
+  mkdir -p /usr/local/osquery/
+  chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/
+  chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
+  
+  export SKIP_TESTS=1
+  cd /home/"$OSQUERY_BUILD_USER"/osquery 
+  sudo -u "$OSQUERY_BUILD_USER" make sysprep
+  sudo -u "$OSQUERY_BUILD_USER" sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp
+  sudo -u "$OSQUERY_BUILD_USER" make deps
+  sudo -u "$OSQUERY_BUILD_USER" make
+  sudo -u "$OSQUERY_BUILD_USER" make strip
+  cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery/osqueryi
+  cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd
+  mkdir -p /opt/osquery/lenses
+  cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses
+fi
+chown -R root. /opt/osquery
+chmod -R 500 /opt/osquery/*
+chmod -R 400 /opt/osquery/lenses/*
+ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version

--- a/pkg/dev/amazonlinux2016.09/osquerybuilder.sh
+++ b/pkg/dev/amazonlinux2016.09/osquerybuilder.sh
@@ -5,9 +5,7 @@ build_osquery_locally=$2
 
 if [ $build_osquery != true ]
 then
-  mkdir -p /opt/osquery/
-  cp /osqueryi /opt/osquery/osqueryi
-  cp /osqueryd /opt/osquery/hubble_osqueryd
+  tar -C /opt/ -zxvf osquery_*_tob_amazonlinux2016.09.tar
   echo $build_osquery
 else
   echo $build_osquery_locally

--- a/pkg/dev/centos6/Dockerfile
+++ b/pkg/dev/centos6/Dockerfile
@@ -8,8 +8,8 @@
 # Requires docker 17.05 or higher
 
 #Hubble builds can have the following 3 combinations wrt osquery:
-# 1. Package already built osquery. (BUILD_OSQUERY=false)
-# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 1. Package already built osquery. (BUILD_OSQUERY=false). Keep the osquery tar file besides this Dockerfile.
+# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true). Keep the osquery source code besides this Dockerfile.
 # 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM centos:6

--- a/pkg/dev/centos6/Dockerfile
+++ b/pkg/dev/centos6/Dockerfile
@@ -120,8 +120,8 @@ RUN yum install -y rpmbuild rpm-build gcc make rh-ruby23 rh-ruby23-ruby-devel \
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
-ENV HUBBLE_CHECKOUT=v3.0.12
-ENV HUBBLE_VERSION=3.0.12
+ENV HUBBLE_CHECKOUT=v3.0.13
+ENV HUBBLE_VERSION=3.0.13
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_URL=https://github.com/hubblestack/hubble
 ENV HUBBLE_DESCRIPTION="Hubble is a modular, open-source, security & compliance auditing framework which is built in python, using SaltStack as a library."

--- a/pkg/dev/centos6/Dockerfile
+++ b/pkg/dev/centos6/Dockerfile
@@ -1,79 +1,45 @@
 # This Dockerfile aims to make building Hubble v2 packages easier.
 # To build an image: 1. copy pkg/scripts/pyinstaller-requirements.txt to directory with this Dockerfile
-#                    2. docker build -t <image_name> . --build-arg=HUBBLE_GIT_URL=<git_repo_url>
-#                                                      --build-arg=HUBBLE_CHECKOUT=<branch/tag/commit>
+#                    2. copy osquerybuilder.sh to this directory. This is needed to bundle osquery with Hubble
+#                    3. docker build -t <image_name> .
 # The resulting image is ready to run the pyinstaller on container start and drop hubble<version>-coreos.tar.gz
 # in the /data directory. Mount /data volume into a directory on the host to access the package.
 # To run the container:  docker run -it --rm -v `pwd`:/data <image_name>
 # Requires docker 17.05 or higher
 
-# Set this arguement to "local" if you want to build osquery for local code.
-# In that case, osquery folder must exist besides Dockerfile
-ARG OSQUERY_BUILD_ENV=remote
-
-#--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
-FROM alpine as osquery_local
-ONBUILD COPY osquery /osquery
-ONBUILD RUN echo "Copying osquery from local folder"
-
-
-
-#--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
-FROM alpine/git as osquery_remote
-ENV OSQUERY_SRC_VERSION=3.3.2
-ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
-ONBUILD RUN cd / \
- && git clone "$OSQUERY_GIT_URL" \
- && cd osquery/ \
- && git checkout "$OSQUERY_SRC_VERSION" \
- && echo "Fetching osquery from git"
-
-
-#--------------- TEMP CONTAINER FOR OSQUERY ( BASED ON ARG)  ----------------
-FROM osquery_"$OSQUERY_BUILD_ENV" as osquery_image
-
-
+#Hubble builds can have the following 3 combinations wrt osquery:
+# 1. Package already built osquery. (BUILD_OSQUERY=false)
+# 2. Build osquery from https://git.corp.adobe.com/hubblestack/osquery. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM centos:6
 
 RUN yum makecache fast && yum -y update
 
 #paths that hubble or hubble parts need in the package
-RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osquery/backuplogs
+RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osquery/backuplogs 
 
 #osquery build start
 #osquery should be built first since requirements for other packages can interfere with osquery dependencies
 #to build, osquery scripts want sudo and a user to sudo with.
-#to pin to a different version change the following envirnment variable
+
 ENV OSQUERY_BUILD_USER=osquerybuilder
+ARG BUILD_OSQUERY=true
+ARG BUILD_OSQUERY_LOCALLY=false
+ARG OSQUERY_SRC_VERSION=osquery_3.3.2_tob
+COPY osquery /osquery
+ENV OSQUERY_TAR_FILENAME=$OSQUERY_SRC_VERSION"_centos6.tar"
+COPY $OSQUERY_TAR_FILENAME /
+
 RUN yum -y install xz git make python ruby sudo which python-argparse
 RUN useradd --shell /bin/bash --create-home --user-group --groups wheel "$OSQUERY_BUILD_USER" \
  && sed -i '0,/^#\ %wheel/s/^#\ %wheel.*/%wheel\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
-COPY --from=osquery_image /osquery /home/"$OSQUERY_BUILD_USER"/osquery
-RUN mkdir -p /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
-USER $OSQUERY_BUILD_USER
-ENV SKIP_TESTS=1
-RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
- && make sysprep \
-#have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
- && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \
- && make deps \
- && make \
- && make strip
-USER root
-RUN cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery \
- && cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd \
- && chown -R root. /opt/osquery \
- && chmod -R 500 /opt/osquery/* \
-#put augeas lenses into the default directory that we changed earlier
- && mkdir -p /opt/osquery/lenses \
- && cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses \
- && chmod -R 400 /opt/osquery/lenses/*
-RUN ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version
+
+ADD osquerybuilder.sh /osquerybuilder.sh
+RUN sh /osquerybuilder.sh "$BUILD_OSQUERY" "$BUILD_OSQUERY_LOCALLY"
 
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
+USER root
 RUN yum -y install  \
                libffi-devel openssl-devel libxml2-devel libxslt-devel libffi libssh2-devel autoconf automake libtool \
                libjpeg-devel zlib-devel python-devel make cmake gcc \
@@ -154,21 +120,21 @@ RUN yum install -y rpmbuild rpm-build gcc make rh-ruby23 rh-ruby23-ruby-devel \
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
-ARG HUBBLE_CHECKOUT=3.0
-ARG HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
-ENV HUBBLE_VERSION=3.0_branch
+ENV HUBBLE_CHECKOUT=v3.0.12
+ENV HUBBLE_VERSION=3.0.12
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_URL=https://github.com/hubblestack/hubble
 ENV HUBBLE_DESCRIPTION="Hubble is a modular, open-source, security & compliance auditing framework which is built in python, using SaltStack as a library."
 ENV HUBBLE_SUMMARY="Profile based on-demand auditing and monitoring tool"
+ENV HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
 ENV HUBBLE_SRC_PATH=/hubble_src
 ENV _HOOK_DIR="./pkg/"
 ENV _BINARY_LOG_LEVEL="INFO"
 ENV _INCLUDE_PATH=""
 ENV LD_LIBRARY_PATH=/opt/hubble/lib:/lib:/lib64:/usr/lib:/usr/lib64:/usr/local/lib:/usr/local/lib64
-RUN git clone ${HUBBLE_GIT_URL} "$HUBBLE_SRC_PATH" \
+RUN git clone "$HUBBLE_GIT_URL" "$HUBBLE_SRC_PATH" \
  && cd "$HUBBLE_SRC_PATH" \
- && git checkout ${HUBBLE_CHECKOUT} \
+ && git checkout "$HUBBLE_CHECKOUT" \
  && cp -rf "$HUBBLE_SRC_PATH" /hubble_build \
  && sed -i "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT}/g" /hubble_build/hubblestack/__init__.py \
  && sed -i "s/COMMIT_NOT_SET/`git describe`/g" /hubble_build/hubblestack/__init__.py
@@ -187,7 +153,7 @@ CMD [ "if [ -f /data/hubble_buildinfo ] ; then echo \"\" >> /hubble_build/hubble
     # make sure rpm shared libs are taken out to avoid mismatch between rpm database and shared libs that pyinstaller includes
     && rm -rf /opt/hubble/hubble-libs/librpm* \
 #rpm pkg start
-    && tar -cPvzf /data/hubblestack-${HUBBLE_VERSION}.tar.gz /etc/hubble /opt/hubble /opt/osquery /etc/profile.d/hubble-profile.sh /var/log/hubble_osquery/backuplogs\
+    && tar -cPvzf /data/hubblestack-${HUBBLE_VERSION}.tar.gz /etc/hubble /opt/hubble /opt/osquery /etc/profile.d/hubble-profile.sh /var/log/hubble_osquery/backuplogs \
     && mkdir -p /hubble_build/debbuild/hubblestack-${HUBBLE_VERSION} \
     && tar -xzvf /data/hubblestack-${HUBBLE_VERSION}.tar.gz -C /hubble_build/debbuild/hubblestack-${HUBBLE_VERSION} \
     && mkdir -p /hubble_build/debbuild/hubblestack-${HUBBLE_VERSION}/etc/init.d \

--- a/pkg/dev/centos6/Dockerfile
+++ b/pkg/dev/centos6/Dockerfile
@@ -9,7 +9,7 @@
 
 #Hubble builds can have the following 3 combinations wrt osquery:
 # 1. Package already built osquery. (BUILD_OSQUERY=false)
-# 2. Build osquery from https://git.corp.adobe.com/hubblestack/osquery. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
 # 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM centos:6

--- a/pkg/dev/centos6/osquerybuilder.sh
+++ b/pkg/dev/centos6/osquerybuilder.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+build_osquery=$1
+build_osquery_locally=$2
+
+if [ $build_osquery != true ]
+then
+  mkdir -p /opt/osquery/
+  cp /osqueryi /opt/osquery/osqueryi
+  cp /osqueryd /opt/osquery/hubble_osqueryd
+  echo $build_osquery
+else
+  echo $build_osquery_locally
+  if [ $build_osquery_locally == true ]
+  then
+    echo "Building osquery from local folder"
+  else
+    rm -rf /osquery
+    OSQUERY_SRC_VERSION=3.3.2
+    OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
+    cd /
+    git clone "$OSQUERY_GIT_URL"
+    cd osquery/
+    git checkout "$OSQUERY_SRC_VERSION"
+    echo "Fetching osquery from git"
+    echo $OSQUERY_SRC_VERSION
+  fi
+  mkdir /home/"$OSQUERY_BUILD_USER"/osquery
+  cp -r /osquery/ /home/"$OSQUERY_BUILD_USER"/
+  mkdir -p /usr/local/osquery/
+  chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/
+  chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
+  
+  export SKIP_TESTS=1
+  cd /home/"$OSQUERY_BUILD_USER"/osquery 
+  sudo -u "$OSQUERY_BUILD_USER" make sysprep
+  sudo -u "$OSQUERY_BUILD_USER" sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp
+  sudo -u "$OSQUERY_BUILD_USER" make deps
+  sudo -u "$OSQUERY_BUILD_USER" make
+  sudo -u "$OSQUERY_BUILD_USER" make strip
+  cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery/osqueryi
+  cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd
+  mkdir -p /opt/osquery/lenses
+  cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses
+fi
+chown -R root. /opt/osquery
+chmod -R 500 /opt/osquery/*
+chmod -R 400 /opt/osquery/lenses/*
+ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version

--- a/pkg/dev/centos6/osquerybuilder.sh
+++ b/pkg/dev/centos6/osquerybuilder.sh
@@ -5,9 +5,7 @@ build_osquery_locally=$2
 
 if [ $build_osquery != true ]
 then
-  mkdir -p /opt/osquery/
-  cp /osqueryi /opt/osquery/osqueryi
-  cp /osqueryd /opt/osquery/hubble_osqueryd
+  tar -C /opt/ -zxvf osquery_*_tob_centos6.tar
   echo $build_osquery
 else
   echo $build_osquery_locally

--- a/pkg/dev/centos7/Dockerfile
+++ b/pkg/dev/centos7/Dockerfile
@@ -1,79 +1,40 @@
 # This Dockerfile aims to make building Hubble v2 packages easier.
 # To build an image: 1. copy pkg/scripts/pyinstaller-requirements.txt to directory with this Dockerfile
-#                    2. docker build -t <image_name> . --build-arg=HUBBLE_GIT_URL=<git_repo_url>
-#                                                      --build-arg=HUBBLE_CHECKOUT=<branch/tag/commit>
+#                    2. copy osquerybuilder.sh to this directory. This is needed to bundle osquery with Hubble
+#                    3. docker build -t <image_name> .
 # The resulting image is ready to run the pyinstaller on container start and drop hubble<version>-coreos.tar.gz
 # in the /data directory. Mount /data volume into a directory on the host to access the package.
 # To run the container:  docker run -it --rm -v `pwd`:/data <image_name>
 # Requires docker 17.05 or higher
 
-# Set this arguement to "local" if you want to build osquery for local code.
-# In that case, osquery folder must exist besides Dockerfile
-ARG OSQUERY_BUILD_ENV=remote
-
-#--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
-FROM alpine as osquery_local
-ONBUILD COPY osquery /osquery
-ONBUILD RUN echo "Copying osquery from local folder"
-
-
-
-#--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
-FROM alpine/git as osquery_remote
-ENV OSQUERY_SRC_VERSION=3.3.2
-ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
-ONBUILD RUN cd / \
- && git clone "$OSQUERY_GIT_URL" \
- && cd osquery/ \
- && git checkout "$OSQUERY_SRC_VERSION" \
- && echo "Fetching osquery from git"
-
-
-#--------------- TEMP CONTAINER FOR OSQUERY ( BASED ON ARG)  ----------------
-FROM osquery_"$OSQUERY_BUILD_ENV" as osquery_image
-
-
+#Hubble builds can have the following 3 combinations wrt osquery:
+# 1. Package already built osquery. (BUILD_OSQUERY=false)
+# 2. Build osquery from https://git.corp.adobe.com/hubblestack/osquery. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM centos:7
-
 RUN yum makecache fast && yum -y update
 
 #paths that hubble or hubble parts need in the package
 RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osquery/backuplogs
-
 #osquery build start
 #osquery should be built first since requirements for other packages can interfere with osquery dependencies
 #to build, osquery scripts want sudo and a user to sudo with.
-#to pin to a different version change the following envirnment variable
 ENV OSQUERY_BUILD_USER=osquerybuilder
+ARG BUILD_OSQUERY=true
+ARG BUILD_OSQUERY_LOCALLY=false
+ARG OSQUERY_SRC_VERSION=osquery_3.3.2_tob
+COPY osquery /osquery
+ENV OSQUERY_TAR_FILENAME=$OSQUERY_SRC_VERSION"_centos7.tar"
+COPY $OSQUERY_TAR_FILENAME /
 RUN yum -y install git make python ruby sudo which
 RUN useradd --shell /bin/bash --create-home --user-group --groups wheel "$OSQUERY_BUILD_USER" \
  && sed -i '0,/^#\ %wheel/s/^#\ %wheel.*/%wheel\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
-COPY --from=osquery_image /osquery /home/"$OSQUERY_BUILD_USER"/osquery
-RUN mkdir -p /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
-USER $OSQUERY_BUILD_USER
-ENV SKIP_TESTS=1
-RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
- && make sysprep \
-#have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
- && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \
- && make deps \
- && make \
- && make strip
-USER root
-RUN cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery \
- && cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd \
- && chown -R root. /opt/osquery \
- && chmod -R 500 /opt/osquery/* \
-#put augeas lenses into the default directory that we changed earlier
- && mkdir -p /opt/osquery/lenses \
- && cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses \
- && chmod -R 400 /opt/osquery/lenses/*
-RUN ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version
+ADD osquerybuilder.sh /osquerybuilder.sh
+RUN sh /osquerybuilder.sh "$BUILD_OSQUERY" "$BUILD_OSQUERY_LOCALLY"
 
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
+USER root
 RUN yum -y install  \
                libffi-devel openssl-devel libffi libssh2-devel autoconf automake libtool \
                libxml2-devel libxslt-devel libjpeg-devel zlib-devel \
@@ -151,21 +112,21 @@ RUN yum install -y ruby ruby-devel rpmbuild rpm-build rubygems gcc make \
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
-ARG HUBBLE_CHECKOUT=3.0
-ARG HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
-ENV HUBBLE_VERSION=3.0_branch
+ENV HUBBLE_CHECKOUT=3.0
+ENV HUBBLE_VERSION=3.0.12_19
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_URL=https://github.com/hubblestack/hubble
 ENV HUBBLE_DESCRIPTION="Hubble is a modular, open-source, security & compliance auditing framework which is built in python, using SaltStack as a library."
 ENV HUBBLE_SUMMARY="Profile based on-demand auditing and monitoring tool"
+ENV HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
 ENV HUBBLE_SRC_PATH=/hubble_src
 ENV _HOOK_DIR="./pkg/"
 ENV _BINARY_LOG_LEVEL="INFO"
 ENV _INCLUDE_PATH=""
 ENV LD_LIBRARY_PATH=/opt/hubble/lib:/lib:/lib64:/usr/lib:/usr/lib64:/usr/local/lib:/usr/local/lib64
-RUN git clone ${HUBBLE_GIT_URL} "$HUBBLE_SRC_PATH" \
+RUN git clone "$HUBBLE_GIT_URL" "$HUBBLE_SRC_PATH" \
  && cd "$HUBBLE_SRC_PATH" \
- && git checkout ${HUBBLE_CHECKOUT} \
+ && git checkout "$HUBBLE_CHECKOUT" \
  && cp -rf "$HUBBLE_SRC_PATH" /hubble_build \
  && sed -i "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT}/g" /hubble_build/hubblestack/__init__.py \
  && sed -i "s/COMMIT_NOT_SET/`git describe`/g" /hubble_build/hubblestack/__init__.py
@@ -184,7 +145,7 @@ CMD [ "if [ -f /data/hubble_buildinfo ] ; then echo \"\" >> /hubble_build/hubble
     # make sure rpm shared libs are taken out to avoid mismatch between rpm database and shared libs that pyinstaller includes
     && rm -rf /opt/hubble/hubble-libs/librpm* \
 #rpm pkg start
-    && tar -cPvzf /data/hubblestack-${HUBBLE_VERSION}.tar.gz /etc/hubble /opt/hubble /opt/osquery /etc/profile.d/hubble-profile.sh /var/log/hubble_osquery/backuplogs\
+    && tar -cPvzf /data/hubblestack-${HUBBLE_VERSION}.tar.gz /etc/hubble /opt/hubble /opt/osquery /etc/profile.d/hubble-profile.sh /var/log/hubble_osquery/backuplogs \
     && mkdir -p /hubble_build/debbuild/hubblestack-${HUBBLE_VERSION} \
     && tar -xzvf /data/hubblestack-${HUBBLE_VERSION}.tar.gz -C /hubble_build/debbuild/hubblestack-${HUBBLE_VERSION} \
     && mkdir -p /hubble_build/debbuild/hubblestack-${HUBBLE_VERSION}/usr/lib/systemd/system \

--- a/pkg/dev/centos7/Dockerfile
+++ b/pkg/dev/centos7/Dockerfile
@@ -9,7 +9,7 @@
 
 #Hubble builds can have the following 3 combinations wrt osquery:
 # 1. Package already built osquery. (BUILD_OSQUERY=false)
-# 2. Build osquery from https://git.corp.adobe.com/hubblestack/osquery. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
 # 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM centos:7

--- a/pkg/dev/centos7/Dockerfile
+++ b/pkg/dev/centos7/Dockerfile
@@ -112,8 +112,8 @@ RUN yum install -y ruby ruby-devel rpmbuild rpm-build rubygems gcc make \
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
-ENV HUBBLE_CHECKOUT=3.0
-ENV HUBBLE_VERSION=3.0.12_19
+ENV HUBBLE_CHECKOUT=v3.0.13
+ENV HUBBLE_VERSION=3.0.13
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_URL=https://github.com/hubblestack/hubble
 ENV HUBBLE_DESCRIPTION="Hubble is a modular, open-source, security & compliance auditing framework which is built in python, using SaltStack as a library."

--- a/pkg/dev/centos7/Dockerfile
+++ b/pkg/dev/centos7/Dockerfile
@@ -8,8 +8,8 @@
 # Requires docker 17.05 or higher
 
 #Hubble builds can have the following 3 combinations wrt osquery:
-# 1. Package already built osquery. (BUILD_OSQUERY=false)
-# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 1. Package already built osquery. (BUILD_OSQUERY=false). Keep the osquery tar file besides this Dockerfile.
+# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true). Keep the osquery source code besides this Dockerfile.
 # 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM centos:7

--- a/pkg/dev/centos7/osquerybuilder.sh
+++ b/pkg/dev/centos7/osquerybuilder.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+build_osquery=$1
+build_osquery_locally=$2
+
+if [ $build_osquery != true ]
+then
+  tar -C /opt/ -zxvf osquery_*_tob_centos7.tar 
+  echo $build_osquery
+else
+  echo $build_osquery_locally
+  if [ $build_osquery_locally == true ]
+  then
+    echo "Building osquery from local folder"
+  else
+    rm -rf /osquery
+    OSQUERY_SRC_VERSION=3.3.2
+    OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
+    cd /
+    git clone "$OSQUERY_GIT_URL"
+    cd osquery/
+    git checkout "$OSQUERY_SRC_VERSION"
+    echo "Fetching osquery from git"
+    echo $OSQUERY_SRC_VERSION
+  fi
+  mkdir /home/"$OSQUERY_BUILD_USER"/osquery
+  cp -r /osquery/ /home/"$OSQUERY_BUILD_USER"/
+  mkdir -p /usr/local/osquery/
+  chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/
+  chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
+  
+  export SKIP_TESTS=1
+  cd /home/"$OSQUERY_BUILD_USER"/osquery 
+  sudo -u "$OSQUERY_BUILD_USER" make sysprep
+  sudo -u "$OSQUERY_BUILD_USER" sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp
+  sudo -u "$OSQUERY_BUILD_USER" make deps
+  sudo -u "$OSQUERY_BUILD_USER" make
+  sudo -u "$OSQUERY_BUILD_USER" make strip
+  cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery/osqueryi
+  cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd
+  mkdir -p /opt/osquery/lenses
+  cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses
+fi
+chown -R root. /opt/osquery
+chmod -R 500 /opt/osquery/*
+chmod -R 400 /opt/osquery/lenses/*
+ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version

--- a/pkg/dev/centos8/Dockerfile
+++ b/pkg/dev/centos8/Dockerfile
@@ -8,8 +8,8 @@
 # Requires docker 17.05 or higher
 
 #Hubble builds can have the following 3 combinations wrt osquery:
-# 1. Package already built osquery. (BUILD_OSQUERY=false)
-# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 1. Package already built osquery. (BUILD_OSQUERY=false). Keep the osquery tar file besides this Dockerfile.
+# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true). Keep the osquery source code besides this Dockerfile.
 # 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM centos:8

--- a/pkg/dev/centos8/Dockerfile
+++ b/pkg/dev/centos8/Dockerfile
@@ -9,7 +9,7 @@
 
 #Hubble builds can have the following 3 combinations wrt osquery:
 # 1. Package already built osquery. (BUILD_OSQUERY=false)
-# 2. Build osquery from https://git.corp.adobe.com/hubblestack/osquery. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
 # 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM centos:8

--- a/pkg/dev/centos8/Dockerfile
+++ b/pkg/dev/centos8/Dockerfile
@@ -1,39 +1,16 @@
 # This Dockerfile aims to make building Hubble v2 packages easier.
 # To build an image: 1. copy pkg/scripts/pyinstaller-requirements.txt to directory with this Dockerfile
-#                    2. docker build -t <image_name> . --build-arg=HUBBLE_GIT_URL=<git_repo_url>
-#                                                      --build-arg=HUBBLE_CHECKOUT=<branch/tag/commit>
+#                    2. copy osquerybuilder.sh to this directory. This is needed to bundle osquery with Hubble
+#                    3. docker build -t <image_name> .
 # The resulting image is ready to run the pyinstaller on container start and drop hubble<version>-coreos.tar.gz
 # in the /data directory. Mount /data volume into a directory on the host to access the package.
 # To run the container:  docker run -it --rm -v `pwd`:/data <image_name>
 # Requires docker 17.05 or higher
 
-# Set this argument to "local" if you want to build osquery for local code.
-# In that case, osquery folder must exist besides Dockerfile
-ARG OSQUERY_BUILD_ENV=remote
-
-#--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
-FROM alpine as osquery_local
-ONBUILD COPY osquery /osquery
-ONBUILD RUN echo "Copying osquery from local folder"
-
-
-
-#--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
-FROM alpine/git as osquery_remote
-#to pin osquery to a different version change the following envirnment variable
-ENV OSQUERY_SRC_VERSION=3.3.2
-ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
-ONBUILD RUN cd / \
- && git clone "$OSQUERY_GIT_URL" \
- && cd osquery/ \
- && git checkout "$OSQUERY_SRC_VERSION" \
- && echo "Fetching osquery from git"
-
-
-#--------------- TEMP CONTAINER FOR OSQUERY ( BASED ON ARGUMENT ) ---------------
-FROM osquery_"$OSQUERY_BUILD_ENV" as osquery_image
-
-
+#Hubble builds can have the following 3 combinations wrt osquery:
+# 1. Package already built osquery. (BUILD_OSQUERY=false)
+# 2. Build osquery from https://git.corp.adobe.com/hubblestack/osquery. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM centos:8
 
@@ -44,39 +21,25 @@ RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osque
 #osquery build start
 #osquery should be built first since requirements for other packages can interfere with osquery dependencies
 #to build, osquery scripts want sudo and a user to sudo with.
-#to pin to a different version change the following envirnment variable
 ENV OSQUERY_BUILD_USER=osquerybuilder
 RUN dnf -y install dnf-plugins-core \
  && dnf config-manager --set-enabled PowerTools \
  && dnf -y install python2 git make ruby sudo which doxygen \
  && ln -svf /usr/bin/python2 /usr/bin/python
+ENV OSQUERY_BUILD_USER=osquerybuilder
+ARG BUILD_OSQUERY=true
+ARG BUILD_OSQUERY_LOCALLY=false
+ARG OSQUERY_SRC_VERSION=osquery_3.3.2_tob
+COPY osquery /osquery
+ENV OSQUERY_TAR_FILENAME=$OSQUERY_SRC_VERSION"_centos8.tar"
+COPY $OSQUERY_TAR_FILENAME /
 RUN useradd --shell /bin/bash --create-home --user-group --groups wheel "$OSQUERY_BUILD_USER" \
  && sed -i '0,/^#\ %wheel/s/^#\ %wheel.*/%wheel\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
-COPY --from=osquery_image /osquery /home/"$OSQUERY_BUILD_USER"/osquery
-RUN mkdir -p /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
-USER $OSQUERY_BUILD_USER
-ENV SKIP_TESTS=1
-RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
- && make sysprep \
-#have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
- && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \
- && make deps \
- && make \
- && make strip
-USER root
-RUN cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery \
- && cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd \
- && chown -R root. /opt/osquery \
- && chmod -R 500 /opt/osquery/* \
-#put augeas lenses into the default directory that we changed earlier
- && mkdir -p /opt/osquery/lenses \
- && cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses \
- && chmod -R 400 /opt/osquery/lenses/*
-RUN ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version
+ADD osquerybuilder.sh /osquerybuilder.sh
+RUN sh /osquerybuilder.sh "$BUILD_OSQUERY" "$BUILD_OSQUERY_LOCALLY"
 
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
+USER root
 RUN dnf -y install  \
                libffi-devel openssl-devel libffi libssh-devel autoconf automake libtool \
                libxml2-devel libxslt-devel libjpeg-devel zlib-devel \
@@ -154,21 +117,21 @@ RUN dnf install -y ruby ruby-devel rpm-build rubygems gcc make \
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
-ARG HUBBLE_CHECKOUT=3.0
-ARG HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
-ENV HUBBLE_VERSION=3.0_branch
+ENV HUBBLE_CHECKOUT=v3.0.12
+ENV HUBBLE_VERSION=3.0.12
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_URL=https://github.com/hubblestack/hubble
 ENV HUBBLE_DESCRIPTION="Hubble is a modular, open-source, security & compliance auditing framework which is built in python, using SaltStack as a library."
 ENV HUBBLE_SUMMARY="Profile based on-demand auditing and monitoring tool"
+ENV HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
 ENV HUBBLE_SRC_PATH=/hubble_src
 ENV _HOOK_DIR="./pkg/"
 ENV _BINARY_LOG_LEVEL="INFO"
 ENV _INCLUDE_PATH=""
 ENV LD_LIBRARY_PATH=/opt/hubble/lib:/lib:/lib64:/usr/lib:/usr/lib64:/usr/local/lib:/usr/local/lib64
-RUN git clone "${HUBBLE_GIT_URL}" "$HUBBLE_SRC_PATH" \
+RUN git clone "$HUBBLE_GIT_URL" "$HUBBLE_SRC_PATH" \
  && cd "$HUBBLE_SRC_PATH" \
- && git checkout "${HUBBLE_CHECKOUT}" \
+ && git checkout "$HUBBLE_CHECKOUT" \
  && cp -rf "$HUBBLE_SRC_PATH" /hubble_build \
  && sed -i "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT}/g" /hubble_build/hubblestack/__init__.py \
  && sed -i "s/COMMIT_NOT_SET/`git describe`/g" /hubble_build/hubblestack/__init__.py

--- a/pkg/dev/centos8/Dockerfile
+++ b/pkg/dev/centos8/Dockerfile
@@ -117,8 +117,8 @@ RUN dnf install -y ruby ruby-devel rpm-build rubygems gcc make \
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
-ENV HUBBLE_CHECKOUT=v3.0.12
-ENV HUBBLE_VERSION=3.0.12
+ENV HUBBLE_CHECKOUT=v3.0.13
+ENV HUBBLE_VERSION=3.0.13
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_URL=https://github.com/hubblestack/hubble
 ENV HUBBLE_DESCRIPTION="Hubble is a modular, open-source, security & compliance auditing framework which is built in python, using SaltStack as a library."

--- a/pkg/dev/centos8/osquerybuilder.sh
+++ b/pkg/dev/centos8/osquerybuilder.sh
@@ -5,9 +5,7 @@ build_osquery_locally=$2
 
 if [ $build_osquery != true ]
 then
-  mkdir -p /opt/osquery/
-  cp /osqueryi /opt/osquery/osqueryi
-  cp /osqueryd /opt/osquery/hubble_osqueryd
+  tar -C /opt/ -zxvf osquery_*_tob_centos8.tar
   echo $build_osquery
 else
   echo $build_osquery_locally

--- a/pkg/dev/centos8/osquerybuilder.sh
+++ b/pkg/dev/centos8/osquerybuilder.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+build_osquery=$1
+build_osquery_locally=$2
+
+if [ $build_osquery != true ]
+then
+  mkdir -p /opt/osquery/
+  cp /osqueryi /opt/osquery/osqueryi
+  cp /osqueryd /opt/osquery/hubble_osqueryd
+  echo $build_osquery
+else
+  echo $build_osquery_locally
+  if [ $build_osquery_locally == true ]
+  then
+    echo "Building osquery from local folder"
+  else
+    rm -rf /osquery
+    OSQUERY_SRC_VERSION=3.3.2
+    OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
+    cd /
+    git clone "$OSQUERY_GIT_URL"
+    cd osquery/
+    git checkout "$OSQUERY_SRC_VERSION"
+    echo "Fetching osquery from git"
+    echo $OSQUERY_SRC_VERSION
+  fi
+  mkdir /home/"$OSQUERY_BUILD_USER"/osquery
+  cp -r /osquery/ /home/"$OSQUERY_BUILD_USER"/
+  mkdir -p /usr/local/osquery/
+  chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/
+  chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
+  
+  export SKIP_TESTS=1
+  cd /home/"$OSQUERY_BUILD_USER"/osquery 
+  sudo -u "$OSQUERY_BUILD_USER" make sysprep
+  sudo -u "$OSQUERY_BUILD_USER" sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp
+  sudo -u "$OSQUERY_BUILD_USER" make deps
+  sudo -u "$OSQUERY_BUILD_USER" make
+  sudo -u "$OSQUERY_BUILD_USER" make strip
+  cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery/osqueryi
+  cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd
+  mkdir -p /opt/osquery/lenses
+  cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses
+fi
+chown -R root. /opt/osquery
+chmod -R 500 /opt/osquery/*
+chmod -R 400 /opt/osquery/lenses/*
+ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version

--- a/pkg/dev/coreos/Dockerfile
+++ b/pkg/dev/coreos/Dockerfile
@@ -1,36 +1,16 @@
 # This Dockerfile aims to make building Hubble v2 packages easier.
 # To build an image: 1. copy pkg/scripts/pyinstaller-requirements.txt to directory with this Dockerfile
-#                    2. docker build -t <image_name> . --build-arg=HUBBLE_GIT_URL=<git_repo_url>
-#                                                      --build-arg=HUBBLE_CHECKOUT=<branch/tag/commit>
+#                    2. copy osquerybuilder.sh to this directory. This is needed to bundle osquery with Hubble
+#                    3. docker build -t <image_name> .
 # The resulting image is ready to run the pyinstaller on container start and drop hubble<version>-coreos.tar.gz
 # in the /data directory. Mount /data volume into a directory on the host to access the package.
 # To run the container:  docker run -it --rm -v `pwd`:/data <image_name>
 # Requires docker 17.05 or higher
 
-ARG OSQUERY_BUILD_ENV=remote
-
-#--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
-FROM alpine as osquery_local
-ONBUILD COPY osquery /osquery
-ONBUILD RUN echo "Copying osquery from local folder"
-
-
-
-#--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
-FROM alpine/git as osquery_remote
-ENV OSQUERY_SRC_VERSION=3.3.2
-ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
-ONBUILD RUN cd / \
- && git clone "$OSQUERY_GIT_URL" \
- && cd osquery/ \
- && git checkout "$OSQUERY_SRC_VERSION" \
- && echo "Fetching osquery from git"
-
-
-#--------------- TEMP CONTAINER FOR OSQUERY ( BASED UPON FLAG)  ----------------
-FROM osquery_"$OSQUERY_BUILD_ENV" as osquery
-
-
+#Hubble builds can have the following 3 combinations wrt osquery:
+# 1. Package already built osquery. (BUILD_OSQUERY=false)
+# 2. Build osquery from https://git.corp.adobe.com/hubblestack/osquery. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM debian:9
 
@@ -58,36 +38,21 @@ RUN mkdir -p "$PATCHELF_TEMP" \
 #osquery build start
 #osquery should be built first since requirements for other packages can interfere with osquery dependencies
 #to build, osquery scripts want sudo and a user to sudo with.
-#to pin to a different version change the following envirnment variable
 ENV OSQUERY_BUILD_USER=osquerybuilder
+ARG BUILD_OSQUERY=true
+ARG BUILD_OSQUERY_LOCALLY=false
+ARG OSQUERY_SRC_VERSION=osquery_3.3.2_tob
+COPY osquery /osquery
+ENV OSQUERY_TAR_FILENAME=$OSQUERY_SRC_VERSION"_coreos.tar"
+COPY $OSQUERY_TAR_FILENAME /
 RUN apt-get -y install git make python ruby sudo curl
 RUN useradd --shell /bin/bash --create-home --user-group --groups sudo "$OSQUERY_BUILD_USER" \
  && sed -i 's/^%sudo.*/%sudo\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
-COPY --from=osquery /osquery /home/"$OSQUERY_BUILD_USER"/osquery
-RUN mkdir -p /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
-USER $OSQUERY_BUILD_USER
-ENV SKIP_TESTS=1
-RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
- && make sysprep \
-#have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
- && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \
- && make deps \
- && make \
- && make strip
-USER root
-RUN cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery \
- && cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd \
- && chown -R root. /opt/osquery \
- && chmod -R 500 /opt/osquery/* \
-#put augeas lenses into the default directory that we changed earlier
- && mkdir -p /opt/osquery/lenses \
- && cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses \
- && chmod -R 400 /opt/osquery/lenses/*
-RUN ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version
+ADD osquerybuilder.sh /osquerybuilder.sh
+RUN sh /osquerybuilder.sh "$BUILD_OSQUERY" "$BUILD_OSQUERY_LOCALLY"
 
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
+USER root
 RUN apt-get -y install  \
                python-dev libffi-dev libssl-dev libyaml-dev libssh2-1 libssh2-1-dev autoconf automake libtool \
                libxml2-dev libxslt1-dev python-cffi \
@@ -161,9 +126,9 @@ RUN pip -v install -r pyinstaller-requirements.txt
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
-ARG HUBBLE_CHECKOUT=3.0
-ARG HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
-ENV HUBBLE_VERSION=3.0_branch
+ENV HUBBLE_CHECKOUT=v3.0.12
+ENV HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
+ENV HUBBLE_VERSION=3.0.12
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_SRC_PATH=/hubble_src
 ENV _HOOK_DIR="./pkg/"
@@ -198,5 +163,5 @@ CMD [ "if [ -f /data/hubble_buildinfo ] ; then echo \"\" >> /hubble_build/hubble
     && cp /usr/lib/x86_64-linux-gnu/libssh2.so.1 /opt/hubble/hubble-libs \
     && mkdir -p /etc/systemd/system \
     && cp -f /hubble_build/pkg/hubble.service /etc/systemd/system \
-    && tar -cPvzf /data/hubblestack-${HUBBLE_VERSION}-${HUBBLE_ITERATION}-coreos.tar.gz /etc/hubble /opt/hubble /opt/osquery /etc/profile.d/hubble-profile.sh /etc/systemd/system /var/log/hubble_osquery/backuplogs \
-    && openssl dgst -sha256 /data/hubblestack-${HUBBLE_VERSION}-${HUBBLE_ITERATION}-coreos.tar.gz > /data/hubblestack-${HUBBLE_VERSION}-${HUBBLE_ITERATION}-coreos.tar.gz.sha256" ]
+    && tar -cPvzf /data/hubblestack-${HUBBLE_VERSION}-${HUBBLE_ITERATION}.coreos.tar.gz /etc/hubble /opt/hubble /opt/osquery /etc/profile.d/hubble-profile.sh /etc/systemd/system /var/log/hubble_osquery/backuplogs \
+    && openssl dgst -sha256 /data/hubblestack-${HUBBLE_VERSION}-${HUBBLE_ITERATION}.coreos.tar.gz > /data/hubblestack-${HUBBLE_VERSION}-${HUBBLE_ITERATION}.coreos.tar.gz.sha256" ]

--- a/pkg/dev/coreos/Dockerfile
+++ b/pkg/dev/coreos/Dockerfile
@@ -126,9 +126,9 @@ RUN pip -v install -r pyinstaller-requirements.txt
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
-ENV HUBBLE_CHECKOUT=v3.0.12
+ENV HUBBLE_CHECKOUT=v3.0.13
 ENV HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
-ENV HUBBLE_VERSION=3.0.12
+ENV HUBBLE_VERSION=3.0.13
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_SRC_PATH=/hubble_src
 ENV _HOOK_DIR="./pkg/"

--- a/pkg/dev/coreos/Dockerfile
+++ b/pkg/dev/coreos/Dockerfile
@@ -8,8 +8,8 @@
 # Requires docker 17.05 or higher
 
 #Hubble builds can have the following 3 combinations wrt osquery:
-# 1. Package already built osquery. (BUILD_OSQUERY=false)
-# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 1. Package already built osquery. (BUILD_OSQUERY=false). Keep the osquery tar file besides this Dockerfile.
+# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true). Keep the osquery source code besides this Dockerfile.
 # 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM debian:9

--- a/pkg/dev/coreos/Dockerfile
+++ b/pkg/dev/coreos/Dockerfile
@@ -9,7 +9,7 @@
 
 #Hubble builds can have the following 3 combinations wrt osquery:
 # 1. Package already built osquery. (BUILD_OSQUERY=false)
-# 2. Build osquery from https://git.corp.adobe.com/hubblestack/osquery. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
 # 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM debian:9

--- a/pkg/dev/coreos/osquerybuilder.sh
+++ b/pkg/dev/coreos/osquerybuilder.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+build_osquery=$1
+build_osquery_locally=$2
+
+if [ $build_osquery != true ]
+then
+  mkdir -p /opt/osquery/
+  cp /osqueryi /opt/osquery/osqueryi
+  cp /osqueryd /opt/osquery/hubble_osqueryd
+  echo $build_osquery
+else
+  echo $build_osquery_locally
+  if [ $build_osquery_locally == true ]
+  then
+    echo "Building osquery from local folder"
+  else
+    rm -rf /osquery
+    OSQUERY_SRC_VERSION=3.3.2
+    OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
+    cd /
+    git clone "$OSQUERY_GIT_URL"
+    cd osquery/
+    git checkout "$OSQUERY_SRC_VERSION"
+    echo "Fetching osquery from git"
+    echo $OSQUERY_SRC_VERSION
+  fi
+  mkdir /home/"$OSQUERY_BUILD_USER"/osquery
+  cp -r /osquery/ /home/"$OSQUERY_BUILD_USER"/
+  mkdir -p /usr/local/osquery/
+  chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/
+  chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
+  
+  export SKIP_TESTS=1
+  cd /home/"$OSQUERY_BUILD_USER"/osquery 
+  sudo -u "$OSQUERY_BUILD_USER" make sysprep
+  sudo -u "$OSQUERY_BUILD_USER" sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp
+  sudo -u "$OSQUERY_BUILD_USER" make deps
+  sudo -u "$OSQUERY_BUILD_USER" make
+  sudo -u "$OSQUERY_BUILD_USER" make strip
+  cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery/osqueryi
+  cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd
+  mkdir -p /opt/osquery/lenses
+  cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses
+fi
+chown -R root. /opt/osquery
+chmod -R 500 /opt/osquery/*
+chmod -R 400 /opt/osquery/lenses/*
+ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version

--- a/pkg/dev/coreos/osquerybuilder.sh
+++ b/pkg/dev/coreos/osquerybuilder.sh
@@ -5,9 +5,7 @@ build_osquery_locally=$2
 
 if [ $build_osquery != true ]
 then
-  mkdir -p /opt/osquery/
-  cp /osqueryi /opt/osquery/osqueryi
-  cp /osqueryd /opt/osquery/hubble_osqueryd
+  tar -C /opt/ -zxvf osquery_*_tob_coreos.tar
   echo $build_osquery
 else
   echo $build_osquery_locally

--- a/pkg/dev/debian10/Dockerfile
+++ b/pkg/dev/debian10/Dockerfile
@@ -9,7 +9,7 @@
 
 #Hubble builds can have the following 3 combinations wrt osquery:
 # 1. Package already built osquery. (BUILD_OSQUERY=false)
-# 2. Build osquery from https://git.corp.adobe.com/hubblestack/osquery. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
 # 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM debian:10

--- a/pkg/dev/debian10/Dockerfile
+++ b/pkg/dev/debian10/Dockerfile
@@ -1,36 +1,16 @@
 # This Dockerfile aims to make building Hubble v2 packages easier.
 # To build an image: 1. copy pkg/scripts/pyinstaller-requirements.txt to directory with this Dockerfile
-#                    2. docker build -t <image_name> . --build-arg=HUBBLE_GIT_URL=<git_repo_url>
-#                                                      --build-arg=HUBBLE_CHECKOUT=<branch/tag/commit>
+#                    2. copy osquerybuilder.sh to this directory. This is needed to bundle osquery with Hubble
+#                    3. docker build -t <image_name> .
 # The resulting image is ready to run the pyinstaller on container start and drop hubble<version>-coreos.tar.gz
 # in the /data directory. Mount /data volume into a directory on the host to access the package.
 # To run the container:  docker run -it --rm -v `pwd`:/data <image_name>
 # Requires docker 17.05 or higher
 
-ARG OSQUERY_BUILD_ENV=remote
-
-#--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
-FROM alpine as osquery_local
-ONBUILD COPY osquery /osquery
-ONBUILD RUN echo "Copying osquery from local folder"
-
-
-
-#--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
-FROM alpine/git as osquery_remote
-ENV OSQUERY_SRC_VERSION=3.3.2
-ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
-ONBUILD RUN cd / \
- && git clone "$OSQUERY_GIT_URL" \
- && cd osquery/ \
- && git checkout "$OSQUERY_SRC_VERSION" \
- && echo "Fetching osquery from git"
-
-
-#--------------- TEMP CONTAINER FOR OSQUERY ( BASED UPON FLAG)  ----------------
-FROM osquery_"$OSQUERY_BUILD_ENV" as osquery
-
-
+#Hubble builds can have the following 3 combinations wrt osquery:
+# 1. Package already built osquery. (BUILD_OSQUERY=false)
+# 2. Build osquery from https://git.corp.adobe.com/hubblestack/osquery. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM debian:10
 
@@ -58,36 +38,21 @@ RUN mkdir -p "$PATCHELF_TEMP" \
 #osquery build start
 #osquery should be built first since requirements for other packages can interfere with osquery dependencies
 #to build, osquery scripts want sudo and a user to sudo with.
-#to pin to a different version change the following envirnment variable
 ENV OSQUERY_BUILD_USER=osquerybuilder
+ARG BUILD_OSQUERY=true
+ARG BUILD_OSQUERY_LOCALLY=false
+ARG OSQUERY_SRC_VERSION=osquery_3.3.2_tob
+COPY osquery /osquery
+ENV OSQUERY_TAR_FILENAME=$OSQUERY_SRC_VERSION"_debian10.tar"
+COPY $OSQUERY_TAR_FILENAME /
 RUN apt-get -y install git make python ruby sudo curl
 RUN useradd --shell /bin/bash --create-home --user-group --groups sudo "$OSQUERY_BUILD_USER" \
  && sed -i 's/^%sudo.*/%sudo\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
-COPY --from=osquery /osquery /home/"$OSQUERY_BUILD_USER"/osquery
-RUN mkdir -p /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
-USER $OSQUERY_BUILD_USER
-ENV SKIP_TESTS=1
-RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
- && make sysprep \
-#have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
- && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \
- && make deps \
- && make \
- && make strip
-USER root
-RUN cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery \
- && cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd \
- && chown -R root. /opt/osquery \
- && chmod -R 500 /opt/osquery/* \
-#put augeas lenses into the default directory that we changed earlier
- && mkdir -p /opt/osquery/lenses \
- && cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses \
- && chmod -R 400 /opt/osquery/lenses/*
-RUN ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version
+ADD osquerybuilder.sh /osquerybuilder.sh
+RUN sh /osquerybuilder.sh "$BUILD_OSQUERY" "$BUILD_OSQUERY_LOCALLY"
 
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
+USER root
 RUN apt-get -y install  \
                python-dev libffi-dev libssl-dev libyaml-dev libssh2-1 libssh2-1-dev autoconf automake libtool \
                libxml2-dev libxslt1-dev python-cffi \
@@ -165,9 +130,9 @@ RUN apt-get install -y ruby ruby-dev rubygems gcc make \
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
-ARG HUBBLE_CHECKOUT=3.0
-ARG HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
-ENV HUBBLE_VERSION=3.0-branch
+ENV HUBBLE_CHECKOUT=v3.0.12
+ENV HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
+ENV HUBBLE_VERSION=3.0.12
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_URL=https://github.com/hubblestack/hubble
 ENV HUBBLE_SRC_PATH=/hubble_src
@@ -175,9 +140,9 @@ ENV _HOOK_DIR="./pkg/"
 ENV _BINARY_LOG_LEVEL="INFO"
 ENV _INCLUDE_PATH=""
 ENV LD_LIBRARY_PATH=/opt/hubble/lib:/lib:/lib64:/usr/lib:/usr/lib64:/usr/local/lib:/usr/local/lib64
-RUN git clone ${HUBBLE_GIT_URL} "$HUBBLE_SRC_PATH" \
+RUN git clone "$HUBBLE_GIT_URL" "$HUBBLE_SRC_PATH" \
  && cd "$HUBBLE_SRC_PATH" \
- && git checkout ${HUBBLE_CHECKOUT} \
+ && git checkout "$HUBBLE_CHECKOUT" \
  && cp -rf "$HUBBLE_SRC_PATH" /hubble_build \
  && sed -i "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT}/g" /hubble_build/hubblestack/__init__.py \
  && sed -i "s/COMMIT_NOT_SET/`git describe`/g" /hubble_build/hubblestack/__init__.py
@@ -226,6 +191,6 @@ CMD [ "if [ -f /data/hubble_buildinfo ] ; then echo \"\" >> /hubble_build/hubble
        --after-upgrade /hubble_build/conf/afterupgrade.sh \
        --before-remove /hubble_build/conf/beforeremove.sh \
        etc/hubble etc/init.d opt usr /var/log/hubble_osquery/backuplogs \
-    && cp hubblestack_${HUBBLE_VERSION}-${HUBBLE_ITERATION}_amd64.deb /data/hubblestack_${HUBBLE_VERSION}-${HUBBLE_ITERATION}deb10_amd64.deb \
-    && openssl dgst -sha256 /data/hubblestack_${HUBBLE_VERSION}-${HUBBLE_ITERATION}deb10_amd64.deb \
-                          > /data/hubblestack_${HUBBLE_VERSION}-${HUBBLE_ITERATION}deb10_amd64.deb.sha256" ]
+    && cp hubblestack_${HUBBLE_VERSION}-${HUBBLE_ITERATION}_amd64.deb /data/hubblestack-${HUBBLE_VERSION}-${HUBBLE_ITERATION}.deb10.amd64.deb \
+    && openssl dgst -sha256 /data/hubblestack-${HUBBLE_VERSION}-${HUBBLE_ITERATION}.deb10.amd64.deb \
+                          > /data/hubblestack-${HUBBLE_VERSION}-${HUBBLE_ITERATION}.deb10.amd64.deb.sha256" ]

--- a/pkg/dev/debian10/Dockerfile
+++ b/pkg/dev/debian10/Dockerfile
@@ -8,8 +8,8 @@
 # Requires docker 17.05 or higher
 
 #Hubble builds can have the following 3 combinations wrt osquery:
-# 1. Package already built osquery. (BUILD_OSQUERY=false)
-# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 1. Package already built osquery. (BUILD_OSQUERY=false). Keep the osquery tar file besides this Dockerfile.
+# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true). Keep the osquery source code besides this Dockerfile.
 # 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM debian:10

--- a/pkg/dev/debian10/Dockerfile
+++ b/pkg/dev/debian10/Dockerfile
@@ -130,9 +130,9 @@ RUN apt-get install -y ruby ruby-dev rubygems gcc make \
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
-ENV HUBBLE_CHECKOUT=v3.0.12
+ENV HUBBLE_CHECKOUT=v3.0.13
 ENV HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
-ENV HUBBLE_VERSION=3.0.12
+ENV HUBBLE_VERSION=3.0.13
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_URL=https://github.com/hubblestack/hubble
 ENV HUBBLE_SRC_PATH=/hubble_src

--- a/pkg/dev/debian10/osquerybuilder.sh
+++ b/pkg/dev/debian10/osquerybuilder.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+build_osquery=$1
+build_osquery_locally=$2
+
+if [ $build_osquery != true ]
+then
+  mkdir -p /opt/osquery/
+  cp /osqueryi /opt/osquery/osqueryi
+  cp /osqueryd /opt/osquery/hubble_osqueryd
+  echo $build_osquery
+else
+  echo $build_osquery_locally
+  if [ $build_osquery_locally == true ]
+  then
+    echo "Building osquery from local folder"
+  else
+    rm -rf /osquery
+    OSQUERY_SRC_VERSION=3.3.2
+    OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
+    cd /
+    git clone "$OSQUERY_GIT_URL"
+    cd osquery/
+    git checkout "$OSQUERY_SRC_VERSION"
+    echo "Fetching osquery from git"
+    echo $OSQUERY_SRC_VERSION
+  fi
+  mkdir /home/"$OSQUERY_BUILD_USER"/osquery
+  cp -r /osquery/ /home/"$OSQUERY_BUILD_USER"/
+  mkdir -p /usr/local/osquery/
+  chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/
+  chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
+  echo "LC_ALL=en_US.UTF-8" >> /etc/default/locale
+  sed -i '/en_US.UTF-8\ UTF-8/s/^#//' /etc/locale.gen
+  locale-gen
+  
+  export SKIP_TESTS=1
+  cd /home/"$OSQUERY_BUILD_USER"/osquery 
+  sudo -u "$OSQUERY_BUILD_USER" make sysprep
+  sudo -u "$OSQUERY_BUILD_USER" sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp
+  sudo -u "$OSQUERY_BUILD_USER" make deps
+  sudo -u "$OSQUERY_BUILD_USER" make
+  sudo -u "$OSQUERY_BUILD_USER" make strip
+  cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery/osqueryi
+  cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd
+  mkdir -p /opt/osquery/lenses
+  cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses
+fi
+chown -R root. /opt/osquery
+chmod -R 500 /opt/osquery/*
+chmod -R 400 /opt/osquery/lenses/*
+ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version

--- a/pkg/dev/debian10/osquerybuilder.sh
+++ b/pkg/dev/debian10/osquerybuilder.sh
@@ -5,9 +5,7 @@ build_osquery_locally=$2
 
 if [ $build_osquery != true ]
 then
-  mkdir -p /opt/osquery/
-  cp /osqueryi /opt/osquery/osqueryi
-  cp /osqueryd /opt/osquery/hubble_osqueryd
+  tar -C /opt/ -zxvf osquery_*_tob_debian10.tar
   echo $build_osquery
 else
   echo $build_osquery_locally

--- a/pkg/dev/debian8/Dockerfile
+++ b/pkg/dev/debian8/Dockerfile
@@ -1,36 +1,16 @@
 # This Dockerfile aims to make building Hubble v2 packages easier.
 # To build an image: 1. copy pkg/scripts/pyinstaller-requirements.txt to directory with this Dockerfile
-#                    2. docker build -t <image_name> . --build-arg=HUBBLE_GIT_URL=<git_repo_url>
-#                                                      --build-arg=HUBBLE_CHECKOUT=<branch/tag/commit>
+#                    2. copy osquerybuilder.sh to this directory. This is needed to bundle osquery with Hubble
+#                    3. docker build -t <image_name> .
 # The resulting image is ready to run the pyinstaller on container start and drop hubble<version>-coreos.tar.gz
 # in the /data directory. Mount /data volume into a directory on the host to access the package.
 # To run the container:  docker run -it --rm -v `pwd`:/data <image_name>
 # Requires docker 17.05 or higher
 
-ARG OSQUERY_BUILD_ENV=remote
-
-#--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
-FROM alpine as osquery_local
-ONBUILD COPY osquery /osquery
-ONBUILD RUN echo "Copying osquery from local folder"
-
-
-
-#--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
-FROM alpine/git as osquery_remote
-ENV OSQUERY_SRC_VERSION=3.3.2
-ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
-ONBUILD RUN cd / \
- && git clone "$OSQUERY_GIT_URL" \
- && cd osquery/ \
- && git checkout "$OSQUERY_SRC_VERSION" \
- && echo "Fetching osquery from git"
-
-
-#--------------- TEMP CONTAINER FOR OSQUERY ( BASED UPON FLAG)  ----------------
-FROM osquery_"$OSQUERY_BUILD_ENV" as osquery
-
-
+#Hubble builds can have the following 3 combinations wrt osquery:
+# 1. Package already built osquery. (BUILD_OSQUERY=false)
+# 2. Build osquery from https://git.corp.adobe.com/hubblestack/osquery. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM debian:8
 
@@ -58,39 +38,22 @@ RUN mkdir -p "$PATCHELF_TEMP" \
 #osquery build start
 #osquery should be built first since requirements for other packages can interfere with osquery dependencies
 #to build, osquery scripts want sudo and a user to sudo with.
-#to pin to a different version change the following envirnment variable
 ENV OSQUERY_BUILD_USER=osquerybuilder
+ARG BUILD_OSQUERY=true
+ARG BUILD_OSQUERY_LOCALLY=false
+ARG OSQUERY_SRC_VERSION=osquery_3.3.2_tob
+COPY osquery /osquery
+ENV OSQUERY_TAR_FILENAME=$OSQUERY_SRC_VERSION"_debian8.tar"
+COPY $OSQUERY_TAR_FILENAME /
+
 RUN apt-get -y install git make python ruby sudo locales curl xz-utils
 RUN useradd --shell /bin/bash --create-home --user-group --groups sudo "$OSQUERY_BUILD_USER" \
  && sed -i 's/^%sudo.*/%sudo\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
-COPY --from=osquery /osquery /home/"$OSQUERY_BUILD_USER"/osquery
-RUN mkdir -p /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery \
- && echo "LC_ALL=en_US.UTF-8" >> /etc/default/locale \
- && sed -i '/en_US.UTF-8\ UTF-8/s/^#//' /etc/locale.gen \
- && locale-gen
-USER $OSQUERY_BUILD_USER
-ENV SKIP_TESTS=1
-RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
- && make sysprep \
-#have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
- && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \
- && make deps \
- && make \
- && make strip
-USER root
-RUN cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery \
- && cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd \
- && chown -R root. /opt/osquery \
- && chmod -R 500 /opt/osquery/* \
-#put augeas lenses into the default directory that we changed earlier
- && mkdir -p /opt/osquery/lenses \
- && cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses \
- && chmod -R 400 /opt/osquery/lenses/*
-RUN ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version
+ADD osquerybuilder.sh /osquerybuilder.sh
+RUN sh /osquerybuilder.sh "$BUILD_OSQUERY" "$BUILD_OSQUERY_LOCALLY"
 
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
+USER root
 RUN apt-get -y install  \
                python-dev libffi-dev libssl-dev libyaml-dev libssh2-1 libssh2-1-dev autoconf automake libtool \
                libxml2-dev libxslt1-dev zlib1g-dev cmake python-setuptools \
@@ -170,18 +133,18 @@ RUN apt-get install -y ruby ruby-dev rubygems gcc make \
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
-ARG HUBBLE_CHECKOUT=3.0
-ARG HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
-ENV HUBBLE_VERSION=3.0-branch
+ENV HUBBLE_CHECKOUT=v3.0.12
+ENV HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
+ENV HUBBLE_VERSION=3.0.12
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_URL=https://github.com/hubblestack/hubble
 ENV HUBBLE_SRC_PATH=/hubble_src
 ENV _HOOK_DIR="./pkg/"
 ENV _BINARY_LOG_LEVEL="INFO"
 ENV _INCLUDE_PATH=""
-RUN git clone ${HUBBLE_GIT_URL} "$HUBBLE_SRC_PATH" \
+RUN git clone "$HUBBLE_GIT_URL" "$HUBBLE_SRC_PATH" \
  && cd "$HUBBLE_SRC_PATH" \
- && git checkout ${HUBBLE_CHECKOUT} \
+ && git checkout "$HUBBLE_CHECKOUT" \
  && cp -rf "$HUBBLE_SRC_PATH" /hubble_build \
  && sed -i "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT}/g" /hubble_build/hubblestack/__init__.py \
  && sed -i "s/COMMIT_NOT_SET/`git describe`/g" /hubble_build/hubblestack/__init__.py
@@ -230,6 +193,6 @@ CMD [ "if [ -f /data/hubble_buildinfo ] ; then echo \"\" >> /hubble_build/hubble
        --after-upgrade /hubble_build/conf/afterupgrade.sh \
        --before-remove /hubble_build/conf/beforeremove.sh \
        etc/hubble etc/init.d opt usr /var/log/hubble_osquery/backuplogs \
-    && cp hubblestack_${HUBBLE_VERSION}-${HUBBLE_ITERATION}_amd64.deb /data/hubblestack_${HUBBLE_VERSION}-${HUBBLE_ITERATION}deb8_amd64.deb \
-    && openssl dgst -sha256 /data/hubblestack_${HUBBLE_VERSION}-${HUBBLE_ITERATION}deb8_amd64.deb \
-                          > /data/hubblestack_${HUBBLE_VERSION}-${HUBBLE_ITERATION}deb8_amd64.deb.sha256" ]
+    && cp hubblestack_${HUBBLE_VERSION}-${HUBBLE_ITERATION}_amd64.deb /data/hubblestack-${HUBBLE_VERSION}-${HUBBLE_ITERATION}.deb8.amd64.deb \
+    && openssl dgst -sha256 /data/hubblestack-${HUBBLE_VERSION}-${HUBBLE_ITERATION}.deb8.amd64.deb \
+                          > /data/hubblestack-${HUBBLE_VERSION}-${HUBBLE_ITERATION}.deb8.amd64.deb.sha256" ]

--- a/pkg/dev/debian8/Dockerfile
+++ b/pkg/dev/debian8/Dockerfile
@@ -133,9 +133,9 @@ RUN apt-get install -y ruby ruby-dev rubygems gcc make \
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
-ENV HUBBLE_CHECKOUT=v3.0.12
+ENV HUBBLE_CHECKOUT=v3.0.13
 ENV HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
-ENV HUBBLE_VERSION=3.0.12
+ENV HUBBLE_VERSION=3.0.13
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_URL=https://github.com/hubblestack/hubble
 ENV HUBBLE_SRC_PATH=/hubble_src

--- a/pkg/dev/debian8/Dockerfile
+++ b/pkg/dev/debian8/Dockerfile
@@ -9,7 +9,7 @@
 
 #Hubble builds can have the following 3 combinations wrt osquery:
 # 1. Package already built osquery. (BUILD_OSQUERY=false)
-# 2. Build osquery from https://git.corp.adobe.com/hubblestack/osquery. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
 # 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM debian:8

--- a/pkg/dev/debian8/Dockerfile
+++ b/pkg/dev/debian8/Dockerfile
@@ -8,8 +8,8 @@
 # Requires docker 17.05 or higher
 
 #Hubble builds can have the following 3 combinations wrt osquery:
-# 1. Package already built osquery. (BUILD_OSQUERY=false)
-# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 1. Package already built osquery. (BUILD_OSQUERY=false). Keep the osquery tar file besides this Dockerfile.
+# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true). Keep the osquery source code besides this Dockerfile.
 # 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM debian:8

--- a/pkg/dev/debian8/osquerybuilder.sh
+++ b/pkg/dev/debian8/osquerybuilder.sh
@@ -5,9 +5,7 @@ build_osquery_locally=$2
 
 if [ $build_osquery != true ]
 then
-  mkdir -p /opt/osquery/
-  cp /osqueryi /opt/osquery/osqueryi
-  cp /osqueryd /opt/osquery/hubble_osqueryd
+  tar -C /opt/ -zxvf osquery_*_tob_debian8.tar
   echo $build_osquery
 else
   echo $build_osquery_locally

--- a/pkg/dev/debian8/osquerybuilder.sh
+++ b/pkg/dev/debian8/osquerybuilder.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+build_osquery=$1
+build_osquery_locally=$2
+
+if [ $build_osquery != true ]
+then
+  mkdir -p /opt/osquery/
+  cp /osqueryi /opt/osquery/osqueryi
+  cp /osqueryd /opt/osquery/hubble_osqueryd
+  echo $build_osquery
+else
+  echo $build_osquery_locally
+  if [ $build_osquery_locally == true ]
+  then
+    echo "Building osquery from local folder"
+  else
+    rm -rf /osquery
+    OSQUERY_SRC_VERSION=3.3.2
+    OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
+    cd /
+    git clone "$OSQUERY_GIT_URL"
+    cd osquery/
+    git checkout "$OSQUERY_SRC_VERSION"
+    echo "Fetching osquery from git"
+    echo $OSQUERY_SRC_VERSION
+  fi
+  mkdir /home/"$OSQUERY_BUILD_USER"/osquery
+  cp -r /osquery/ /home/"$OSQUERY_BUILD_USER"/
+  mkdir -p /usr/local/osquery/
+  chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/
+  chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
+  echo "LC_ALL=en_US.UTF-8" >> /etc/default/locale
+  sed -i '/en_US.UTF-8\ UTF-8/s/^#//' /etc/locale.gen
+  locale-gen
+  
+  export SKIP_TESTS=1
+  cd /home/"$OSQUERY_BUILD_USER"/osquery 
+  sudo -u "$OSQUERY_BUILD_USER" make sysprep
+  sudo -u "$OSQUERY_BUILD_USER" sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp
+  sudo -u "$OSQUERY_BUILD_USER" make deps
+  sudo -u "$OSQUERY_BUILD_USER" make
+  sudo -u "$OSQUERY_BUILD_USER" make strip
+  cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery/osqueryi
+  cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd
+  mkdir -p /opt/osquery/lenses
+  cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses
+fi
+chown -R root. /opt/osquery
+chmod -R 500 /opt/osquery/*
+chmod -R 400 /opt/osquery/lenses/*
+ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version

--- a/pkg/dev/debian9/Dockerfile
+++ b/pkg/dev/debian9/Dockerfile
@@ -1,36 +1,16 @@
 # This Dockerfile aims to make building Hubble v2 packages easier.
 # To build an image: 1. copy pkg/scripts/pyinstaller-requirements.txt to directory with this Dockerfile
-#                    2. docker build -t <image_name> . --build-arg=HUBBLE_GIT_URL=<git_repo_url>
-#                                                      --build-arg=HUBBLE_CHECKOUT=<branch/tag/commit>
+#                    2. copy osquerybuilder.sh to this directory. This is needed to bundle osquery with Hubble
+#                    3. docker build -t <image_name> .
 # The resulting image is ready to run the pyinstaller on container start and drop hubble<version>-coreos.tar.gz
 # in the /data directory. Mount /data volume into a directory on the host to access the package.
 # To run the container:  docker run -it --rm -v `pwd`:/data <image_name>
 # Requires docker 17.05 or higher
 
-ARG OSQUERY_BUILD_ENV=remote
-
-#--------------- TEMP CONTAINER FOR LOCAL OSQUERY -------------------------
-FROM alpine as osquery_local
-ONBUILD COPY osquery /osquery
-ONBUILD RUN echo "Copying osquery from local folder"
-
-
-
-#--------------- TEMP CONTAINER FOR GIT OSQUERY ----------------------------
-FROM alpine/git as osquery_remote
-ENV OSQUERY_SRC_VERSION=3.3.2
-ENV OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
-ONBUILD RUN cd / \
- && git clone "$OSQUERY_GIT_URL" \
- && cd osquery/ \
- && git checkout "$OSQUERY_SRC_VERSION" \
- && echo "Fetching osquery from git"
-
-
-#--------------- TEMP CONTAINER FOR OSQUERY ( BASED UPON FLAG)  ----------------
-FROM osquery_"$OSQUERY_BUILD_ENV" as osquery
-
-
+#Hubble builds can have the following 3 combinations wrt osquery:
+# 1. Package already built osquery. (BUILD_OSQUERY=false)
+# 2. Build osquery from https://git.corp.adobe.com/hubblestack/osquery. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM debian:9
 
@@ -58,36 +38,21 @@ RUN mkdir -p "$PATCHELF_TEMP" \
 #osquery build start
 #osquery should be built first since requirements for other packages can interfere with osquery dependencies
 #to build, osquery scripts want sudo and a user to sudo with.
-#to pin to a different version change the following envirnment variable
 ENV OSQUERY_BUILD_USER=osquerybuilder
+ARG BUILD_OSQUERY=true
+ARG BUILD_OSQUERY_LOCALLY=false
+ARG OSQUERY_SRC_VERSION=osquery_3.3.2_tob
+COPY osquery /osquery
+ENV OSQUERY_TAR_FILENAME=$OSQUERY_SRC_VERSION"_debian9.tar"
+COPY $OSQUERY_TAR_FILENAME /
 RUN apt-get -y install git make python ruby sudo curl
 RUN useradd --shell /bin/bash --create-home --user-group --groups sudo "$OSQUERY_BUILD_USER" \
  && sed -i 's/^%sudo.*/%sudo\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
-COPY --from=osquery /osquery /home/"$OSQUERY_BUILD_USER"/osquery
-RUN mkdir -p /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/ \
- && chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
-USER $OSQUERY_BUILD_USER
-ENV SKIP_TESTS=1
-RUN cd /home/"$OSQUERY_BUILD_USER"/osquery \
- && make sysprep \
-#have the default augeas lenses directory point to /opt/osquery/lenses, must be done after sysprep
- && sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp \
- && make deps \
- && make \
- && make strip
-USER root
-RUN cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery \
- && cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd \
- && chown -R root. /opt/osquery \
- && chmod -R 500 /opt/osquery/* \
-#put augeas lenses into the default directory that we changed earlier
- && mkdir -p /opt/osquery/lenses \
- && cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses \
- && chmod -R 400 /opt/osquery/lenses/*
-RUN ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version
+ADD osquerybuilder.sh /osquerybuilder.sh
+RUN sh /osquerybuilder.sh "$BUILD_OSQUERY" "$BUILD_OSQUERY_LOCALLY"
 
 #install packages that should be needed for ligbit2 compilation and successful pyinstaller run
+USER root
 RUN apt-get -y install  \
                python-dev libffi-dev libssl-dev libyaml-dev libssh2-1 libssh2-1-dev autoconf automake libtool \
                libxml2-dev libxslt1-dev python-cffi \
@@ -165,9 +130,9 @@ RUN apt-get install -y ruby ruby-dev rubygems gcc make \
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
-ARG HUBBLE_CHECKOUT=3.0
-ARG HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
-ENV HUBBLE_VERSION=3.0-branch
+ENV HUBBLE_CHECKOUT=v3.0.12
+ENV HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
+ENV HUBBLE_VERSION=3.0.12
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_URL=https://github.com/hubblestack/hubble
 ENV HUBBLE_SRC_PATH=/hubble_src
@@ -175,9 +140,9 @@ ENV _HOOK_DIR="./pkg/"
 ENV _BINARY_LOG_LEVEL="INFO"
 ENV _INCLUDE_PATH=""
 ENV LD_LIBRARY_PATH=/opt/hubble/lib:/lib:/lib64:/usr/lib:/usr/lib64:/usr/local/lib:/usr/local/lib64
-RUN git clone ${HUBBLE_GIT_URL} "$HUBBLE_SRC_PATH" \
+RUN git clone "$HUBBLE_GIT_URL" "$HUBBLE_SRC_PATH" \
  && cd "$HUBBLE_SRC_PATH" \
- && git checkout ${HUBBLE_CHECKOUT} \
+ && git checkout "$HUBBLE_CHECKOUT" \
  && cp -rf "$HUBBLE_SRC_PATH" /hubble_build \
  && sed -i "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT}/g" /hubble_build/hubblestack/__init__.py \
  && sed -i "s/COMMIT_NOT_SET/`git describe`/g" /hubble_build/hubblestack/__init__.py
@@ -226,6 +191,6 @@ CMD [ "if [ -f /data/hubble_buildinfo ] ; then echo \"\" >> /hubble_build/hubble
        --after-upgrade /hubble_build/conf/afterupgrade.sh \
        --before-remove /hubble_build/conf/beforeremove.sh \
        etc/hubble etc/init.d opt usr /var/log/hubble_osquery/backuplogs \
-    && cp hubblestack_${HUBBLE_VERSION}-${HUBBLE_ITERATION}_amd64.deb /data/hubblestack_${HUBBLE_VERSION}-${HUBBLE_ITERATION}deb9_amd64.deb \
-    && openssl dgst -sha256 /data/hubblestack_${HUBBLE_VERSION}-${HUBBLE_ITERATION}deb9_amd64.deb \
-                          > /data/hubblestack_${HUBBLE_VERSION}-${HUBBLE_ITERATION}deb9_amd64.deb.sha256" ]
+    && cp hubblestack_${HUBBLE_VERSION}-${HUBBLE_ITERATION}_amd64.deb /data/hubblestack-${HUBBLE_VERSION}-${HUBBLE_ITERATION}.deb9.amd64.deb \
+    && openssl dgst -sha256 /data/hubblestack-${HUBBLE_VERSION}-${HUBBLE_ITERATION}.deb9.amd64.deb \
+                          > /data/hubblestack-${HUBBLE_VERSION}-${HUBBLE_ITERATION}.deb9.amd64.deb.sha256" ]

--- a/pkg/dev/debian9/Dockerfile
+++ b/pkg/dev/debian9/Dockerfile
@@ -8,8 +8,8 @@
 # Requires docker 17.05 or higher
 
 #Hubble builds can have the following 3 combinations wrt osquery:
-# 1. Package already built osquery. (BUILD_OSQUERY=false)
-# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 1. Package already built osquery. (BUILD_OSQUERY=false). Keep the osquery tar file besides this Dockerfile.
+# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true). Keep the osquery source code besides this Dockerfile.
 # 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM debian:9

--- a/pkg/dev/debian9/Dockerfile
+++ b/pkg/dev/debian9/Dockerfile
@@ -9,7 +9,7 @@
 
 #Hubble builds can have the following 3 combinations wrt osquery:
 # 1. Package already built osquery. (BUILD_OSQUERY=false)
-# 2. Build osquery from https://git.corp.adobe.com/hubblestack/osquery. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
+# 2. Build osquery from local git repo. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=true)
 # 3. Build osquery from https://github.com/facebook/osquery.git. (BUILD_OSQUERY=true BUILD_OSQUERY_LOCALLY=false)
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM debian:9

--- a/pkg/dev/debian9/Dockerfile
+++ b/pkg/dev/debian9/Dockerfile
@@ -130,9 +130,9 @@ RUN apt-get install -y ruby ruby-dev rubygems gcc make \
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
-ENV HUBBLE_CHECKOUT=v3.0.12
+ENV HUBBLE_CHECKOUT=v3.0.13
 ENV HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
-ENV HUBBLE_VERSION=3.0.12
+ENV HUBBLE_VERSION=3.0.13
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_URL=https://github.com/hubblestack/hubble
 ENV HUBBLE_SRC_PATH=/hubble_src

--- a/pkg/dev/debian9/osquerybuilder.sh
+++ b/pkg/dev/debian9/osquerybuilder.sh
@@ -5,9 +5,7 @@ build_osquery_locally=$2
 
 if [ $build_osquery != true ]
 then
-  mkdir -p /opt/osquery/
-  cp /osqueryi /opt/osquery/osqueryi
-  cp /osqueryd /opt/osquery/hubble_osqueryd
+  tar -C /opt/ -zxvf osquery_*_tob_debian9.tar
   echo $build_osquery
 else
   echo $build_osquery_locally

--- a/pkg/dev/debian9/osquerybuilder.sh
+++ b/pkg/dev/debian9/osquerybuilder.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+build_osquery=$1
+build_osquery_locally=$2
+
+if [ $build_osquery != true ]
+then
+  mkdir -p /opt/osquery/
+  cp /osqueryi /opt/osquery/osqueryi
+  cp /osqueryd /opt/osquery/hubble_osqueryd
+  echo $build_osquery
+else
+  echo $build_osquery_locally
+  if [ $build_osquery_locally == true ]
+  then
+    echo "Building osquery from local folder"
+  else
+    rm -rf /osquery
+    OSQUERY_SRC_VERSION=3.3.2
+    OSQUERY_GIT_URL=https://github.com/facebook/osquery.git
+    cd /
+    git clone "$OSQUERY_GIT_URL"
+    cd osquery/
+    git checkout "$OSQUERY_SRC_VERSION"
+    echo "Fetching osquery from git"
+    echo $OSQUERY_SRC_VERSION
+  fi
+  mkdir /home/"$OSQUERY_BUILD_USER"/osquery
+  cp -r /osquery/ /home/"$OSQUERY_BUILD_USER"/
+  mkdir -p /usr/local/osquery/
+  chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /usr/local/osquery/
+  chown "$OSQUERY_BUILD_USER":"$OSQUERY_BUILD_USER" -R /home/"$OSQUERY_BUILD_USER"/osquery
+  
+  export SKIP_TESTS=1
+  cd /home/"$OSQUERY_BUILD_USER"/osquery 
+  sudo -u "$OSQUERY_BUILD_USER" make sysprep
+  sudo -u "$OSQUERY_BUILD_USER" sed -i '/augeas_lenses,/,/\"Directory\ that\ contains\ augeas\ lenses\ files\"\\)\;/ s/\/usr\/share\/osquery\/lenses/\/opt\/osquery\/lenses/' osquery/tables/system/posix/augeas.cpp
+  sudo -u "$OSQUERY_BUILD_USER" make deps
+  sudo -u "$OSQUERY_BUILD_USER" make
+  sudo -u "$OSQUERY_BUILD_USER" make strip
+  cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryi /opt/osquery/osqueryi
+  cp -pr /home/"$OSQUERY_BUILD_USER"/osquery/build/linux/osquery/osqueryd /opt/osquery/hubble_osqueryd
+  mkdir -p /opt/osquery/lenses
+  cp -r /usr/local/osquery/share/augeas/lenses/dist/* /opt/osquery/lenses
+fi
+chown -R root. /opt/osquery
+chmod -R 500 /opt/osquery/*
+chmod -R 400 /opt/osquery/lenses/*
+ls -lahR /opt/osquery/ && /opt/osquery/osqueryi --version


### PR DESCRIPTION
All dockerfiles (dev and prod) have been modified to support the usage of pre-build osquery.