### PR TITLE
Change in permissions for windows config file

### DIFF
--- a/pkg/windows/hubble_config_permissions.ps1
+++ b/pkg/windows/hubble_config_permissions.ps1
@@ -1,5 +1,6 @@
 $hubble_path = $args[0]
-$hubble_conf_path = $hubble_path + "\etc\hubble\"
+$hubble_conf_path = $hubble_path + "\etc\hubble"
+$hubble_conf_file_path = $hubble_conf_path + "\hubble.conf"
 Write-Host $hubble_conf_path
 $acl = Get-Acl $hubble_conf_path
 
@@ -8,7 +9,7 @@ foreach ($access in $acl.Access) {
   $acl.RemoveAccessRule($access)
 }
 Set-Acl $hubble_conf_path $acl
-Write-Host "Succesfully removed all permissions from file"
+Write-Host "Successfully removed all permissions from file"
 
 $acl = Get-Acl $hubble_conf_path
 $inheritanceFlag = [System.Security.AccessControl.InheritanceFlags]::ContainerInherit -bor [System.Security.AccessControl.InheritanceFlags]::ObjectInherit
@@ -33,3 +34,20 @@ foreach ($accnt in $permGroups) {
     }
 $acl.SetOwner($adminsGroup)
 Set-Acl $hubble_conf_path $acl
+
+$items = Get-ChildItem -Recurse -Path $hubble_conf_path
+foreach ($item in $items) {
+  $acl = Get-Acl -Path $item.FullName
+  $acl.SetOwner($adminsGroup)
+  Set-Acl $item.FullName $acl
+}
+
+$acl1 = Get-Acl $hubble_conf_file_path
+foreach ($accnt in $permGroups) {
+  $permission = $accnt.Value, $grantedPerm, 'None', $propagationFlag, $permType
+  $accessRule = New-Object System.Security.AccessControl.FileSystemAccessRule $permission
+  Write-Host $accessRule
+  $acl1.SetAccessRule($accessRule)
+    }
+$acl1.SetOwner($adminsGroup)
+Set-Acl $hubble_conf_file_path $acl1

--- a/pkg/windows/hubble_config_permissions.ps1
+++ b/pkg/windows/hubble_config_permissions.ps1
@@ -42,12 +42,12 @@ foreach ($item in $items) {
   Set-Acl $item.FullName $acl
 }
 
-$acl1 = Get-Acl $hubble_conf_file_path
+$file_acl = Get-Acl $hubble_conf_file_path
 foreach ($accnt in $permGroups) {
   $permission = $accnt.Value, $grantedPerm, 'None', $propagationFlag, $permType
   $accessRule = New-Object System.Security.AccessControl.FileSystemAccessRule $permission
   Write-Host $accessRule
-  $acl1.SetAccessRule($accessRule)
+  $file_acl.SetAccessRule($accessRule)
     }
-$acl1.SetOwner($adminsGroup)
-Set-Acl $hubble_conf_file_path $acl1
+$file_acl.SetOwner($adminsGroup)
+Set-Acl $hubble_conf_file_path $file_acl


### PR DESCRIPTION
- Earlier the permissions were set on '/etc/hubble' folder and they were making the effective permissions of 'hubble.conf' as 0. Changed the logic to have 'hubble.conf' same permissions as '/etc/hubble'.