### PR TITLE
Salt-less Hubble Changes for 6 more libraries

### DIFF
--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -23,12 +23,12 @@ from datetime import datetime
 
 import salt.fileserver
 import salt.fileserver.gitfs
-import salt.modules.cmdmod
+import hubblestack.modules.cmdmod
 import salt.utils
 import hubblestack.utils.platform
 import salt.utils.jid
 import salt.utils.gitfs
-import salt.utils.path
+import hubblestack.utils.path
 from croniter import croniter
 
 import hubblestack.utils.signing
@@ -544,8 +544,8 @@ def _setup_cached_uuid():
         # Prefer our /opt/osquery/osqueryi if present
         osqueryipaths = ('/opt/osquery/osqueryi', 'osqueryi', '/usr/bin/osqueryi')
         for path in osqueryipaths:
-            if salt.utils.path.which(path):
-                live_uuid = salt.modules.cmdmod.run_stdout('{0} {1}'.format(path, query),
+            if hubblestack.utils.path.which(path):
+                live_uuid = hubblestack.modules.cmdmod.run_stdout('{0} {1}'.format(path, query),
                                                            output_loglevel='quiet')
                 live_uuid = str(live_uuid).upper()
                 if len(live_uuid) == 36:

--- a/hubblestack/extmods/fileserver/azurefs.py
+++ b/hubblestack/extmods/fileserver/azurefs.py
@@ -56,6 +56,8 @@ import os
 import os.path
 import shutil
 
+import hubblestack.utils.files
+
 # Import salt libs
 import salt.fileserver
 import salt.utils
@@ -163,7 +165,7 @@ def serve_file(load, fnd):
     ret['dest'] = fnd['rel']
     gzip = load.get('gzip', None)
     fpath = os.path.normpath(fnd['path'])
-    with salt.utils.files.fopen(fpath, 'rb') as fp_:
+    with hubblestack.utils.files.fopen(fpath, 'rb') as fp_:
         fp_.seek(load['loc'])
         data = fp_.read(__opts__['file_buffer_size'])
         if data and six.PY3 and not salt.utils.is_bin_file(fpath):
@@ -265,7 +267,7 @@ def update():
                 # Lock writes
                 lk_fn = fname + '.lk'
                 salt.fileserver.wait_lock(lk_fn, fname)
-                with salt.utils.files.fopen(lk_fn, 'w+') as fp_:
+                with hubblestack.utils.files.fopen(lk_fn, 'w+') as fp_:
                     fp_.write('')
 
                 try:
@@ -303,9 +305,9 @@ def update():
         container_list = path + '.list'
         lk_fn = container_list + '.lk'
         salt.fileserver.wait_lock(lk_fn, container_list)
-        with salt.utils.files.fopen(lk_fn, 'w+') as fp_:
+        with hubblestack.utils.files.fopen(lk_fn, 'w+') as fp_:
             fp_.write('')
-        with salt.utils.files.fopen(container_list, 'w') as fp_:
+        with hubblestack.utils.files.fopen(container_list, 'w') as fp_:
             fp_.write(json.dumps(blob_names))
         try:
             os.unlink(lk_fn)
@@ -330,7 +332,7 @@ def file_hash(load, fnd):
     relpath = fnd['rel']
     path = fnd['path']
     hash_cachedir = os.path.join(__opts__['cachedir'], 'azurefs', 'hashes')
-    hashdest = salt.utils.path.join(hash_cachedir,
+    hashdest = hubblestack.utils.path.join(hash_cachedir,
                                     load['saltenv'],
                                     '{0}.hash.{1}'.format(relpath,
                                                           __opts__['hash_type']))
@@ -338,11 +340,11 @@ def file_hash(load, fnd):
         if not os.path.exists(os.path.dirname(hashdest)):
             os.makedirs(os.path.dirname(hashdest))
         ret['hsum'] = salt.utils.hashutils.get_hash(path, __opts__['hash_type'])
-        with salt.utils.files.fopen(hashdest, 'w+') as fp_:
+        with hubblestack.utils.files.fopen(hashdest, 'w+') as fp_:
             fp_.write(ret['hsum'])
         return ret
     else:
-        with salt.utils.files.fopen(hashdest, 'rb') as fp_:
+        with hubblestack.utils.files.fopen(hashdest, 'rb') as fp_:
             ret['hsum'] = fp_.read()
         return ret
 
@@ -361,7 +363,7 @@ def file_list(load):
             salt.fileserver.wait_lock(lk, container_list, 5)
             if not os.path.exists(container_list):
                 continue
-            with salt.utils.files.fopen(container_list, 'r') as fp_:
+            with hubblestack.utils.files.fopen(container_list, 'r') as fp_:
                 ret.update(set(json.load(fp_)))
     except Exception as exc:
         log.error('azurefs: an error ocurred retrieving file lists. '

--- a/hubblestack/extmods/fileserver/roots.py
+++ b/hubblestack/extmods/fileserver/roots.py
@@ -25,12 +25,12 @@ import logging
 # Import salt libs
 import salt.fileserver
 import salt.utils.event
-import salt.utils.files
+import hubblestack.utils.files
 import salt.utils.gzip_util
 import salt.utils.hashutils
-import salt.utils.path
+import hubblestack.utils.path
 import hubblestack.utils.platform
-import salt.utils.stringutils
+import hubblestack.utils.stringutils
 import salt.utils.versions
 from salt.ext import six
 
@@ -128,7 +128,7 @@ def serve_file(load, fnd):
     ret['dest'] = fnd['rel']
     gzip = load.get('gzip', None)
     fpath = os.path.normpath(fnd['path'])
-    with salt.utils.files.fopen(fpath, 'rb') as fp_:
+    with hubblestack.utils.files.fopen(fpath, 'rb') as fp_:
         fp_.seek(load['loc'])
         data = fp_.read(__opts__['file_buffer_size'])
         if gzip and data:
@@ -163,9 +163,9 @@ def update():
     old_mtime_map = {}
     # if you have an old map, load that
     if os.path.exists(mtime_map_path):
-        with salt.utils.files.fopen(mtime_map_path, 'rb') as fp_:
+        with hubblestack.utils.files.fopen(mtime_map_path, 'rb') as fp_:
             for line in fp_:
-                line = salt.utils.stringutils.to_unicode(line)
+                line = hubblestack.utils.stringutils.to_unicode(line)
                 try:
                     file_path, mtime = line.replace('\n', '').split(':', 1)
                     old_mtime_map[file_path] = mtime
@@ -191,10 +191,10 @@ def update():
     mtime_map_path_dir = os.path.dirname(mtime_map_path)
     if not os.path.exists(mtime_map_path_dir):
         os.makedirs(mtime_map_path_dir)
-    with salt.utils.files.fopen(mtime_map_path, 'wb') as fp_:
+    with hubblestack.utils.files.fopen(mtime_map_path, 'wb') as fp_:
         for file_path, mtime in six.iteritems(new_mtime_map):
             fp_.write(
-                salt.utils.stringutils.to_bytes(
+                hubblestack.utils.stringutils.to_bytes(
                     '{0}:{1}\n'.format(file_path, mtime)
                 )
             )
@@ -242,9 +242,9 @@ def file_hash(load, fnd):
     # if we have a cache, serve that if the mtime hasn't changed
     if os.path.exists(cache_path):
         try:
-            with salt.utils.files.fopen(cache_path, 'rb') as fp_:
+            with hubblestack.utils.files.fopen(cache_path, 'rb') as fp_:
                 try:
-                    hsum, mtime = salt.utils.stringutils.to_unicode(fp_.read()).split(':')
+                    hsum, mtime = hubblestack.utils.stringutils.to_unicode(fp_.read()).split(':')
                 except ValueError:
                     log.debug('Fileserver attempted to read incomplete cache file. Retrying.')
                     # Delete the file since its incomplete (either corrupted or incomplete)
@@ -282,7 +282,7 @@ def file_hash(load, fnd):
                 raise
     # save the cache object "hash:mtime"
     cache_object = '{0}:{1}'.format(ret['hsum'], os.path.getmtime(path))
-    with salt.utils.files.flopen(cache_path, 'w') as fp_:
+    with hubblestack.utils.files.flopen(cache_path, 'w') as fp_:
         fp_.write(cache_object)
     return ret
 
@@ -334,7 +334,7 @@ def _file_lists(load, form):
             for item in items:
                 abs_path = os.path.join(parent_dir, item)
                 log.trace('roots: Processing %s', abs_path)
-                is_link = salt.utils.path.islink(abs_path)
+                is_link = hubblestack.utils.path.islink(abs_path)
                 log.trace(
                     'roots: %s is %sa link',
                     abs_path, 'not ' if not is_link else ''
@@ -355,7 +355,7 @@ def _file_lists(load, form):
                     # WindowsError on Windows.
                     pass
                 if is_link:
-                    link_dest = salt.utils.path.readlink(abs_path)
+                    link_dest = hubblestack.utils.path.readlink(abs_path)
                     log.trace(
                         'roots: %s symlink destination is %s',
                         abs_path, link_dest
@@ -393,7 +393,7 @@ def _file_lists(load, form):
                         ret['links'][rel_path] = link_dest
 
         for path in __opts__['file_roots'][load['saltenv']]:
-            for root, dirs, files in salt.utils.path.os_walk(
+            for root, dirs, files in hubblestack.utils.path.os_walk(
                     path,
                     followlinks=__opts__['fileserver_followsymlinks']):
                 _add_to(ret['dirs'], path, root, dirs)

--- a/hubblestack/extmods/fileserver/s3fs.py
+++ b/hubblestack/extmods/fileserver/s3fs.py
@@ -89,7 +89,7 @@ import logging
 # Import salt libs
 import salt.fileserver as fs
 import salt.modules
-import salt.utils.files
+import hubblestack.utils.files
 import salt.utils.gzip_util
 import salt.utils.hashutils
 import salt.utils.versions
@@ -245,10 +245,10 @@ def serve_file(load, fnd):
 
     ret['dest'] = _trim_env_off_path([fnd['path']], load['saltenv'])[0]
 
-    with salt.utils.files.fopen(cached_file_path, 'rb') as fp_:
+    with hubblestack.utils.files.fopen(cached_file_path, 'rb') as fp_:
         fp_.seek(load['loc'])
         data = fp_.read(__opts__['file_buffer_size'])
-        if data and six.PY3 and not salt.utils.files.is_binary(cached_file_path):
+        if data and six.PY3 and not hubblestack.utils.files.is_binary(cached_file_path):
             data = data.decode(__salt_system_encoding__)
         if gzip and data:
             data = salt.utils.gzip_util.compress(data, gzip)
@@ -560,7 +560,7 @@ def _refresh_buckets_cache_file(cache_file):
 
     log.debug('Writing buckets cache file')
 
-    with salt.utils.files.fopen(cache_file, 'wb') as fp_:
+    with hubblestack.utils.files.fopen(cache_file, 'wb') as fp_:
         pickle.dump(metadata, fp_)
 
     return metadata
@@ -572,7 +572,7 @@ def _read_buckets_cache_file(cache_file):
     """
     log.debug('Reading buckets cache file')
 
-    with salt.utils.files.fopen(cache_file, 'rb') as fp_:
+    with hubblestack.utils.files.fopen(cache_file, 'rb') as fp_:
         try:
             data = pickle.load(fp_)
             # check for 'corrupted' cache data ex: {u'base':[]}

--- a/hubblestack/extmods/modules/nebula_osquery.py
+++ b/hubblestack/extmods/modules/nebula_osquery.py
@@ -37,7 +37,7 @@ from hashlib import md5
 import yaml
 
 import salt.utils
-import salt.utils.files
+import hubblestack.utils.files
 import hubblestack.utils.platform
 
 from hubblestack.utils.exceptions import CommandExecutionError
@@ -1459,7 +1459,7 @@ def _perform_log_rotation(path_to_logfile,
                         :len(list_of_backup_log_files) -
                         backup_log_files_count + 1]
                     for dfile in list_of_backup_log_files:
-                        salt.utils.files.remove(dfile)
+                        hubblestack.utils.files.remove(dfile)
                     log.info("Successfully deleted extra backup log files")
 
             residue_events = []
@@ -1467,7 +1467,7 @@ def _perform_log_rotation(path_to_logfile,
 
             backup_log_file = os.path.normpath(os.path.join(backup_log_dir, log_filename) +
                                                "-" + str(time.time()))
-            salt.utils.files.rename(path_to_logfile, backup_log_file)
+            hubblestack.utils.files.rename(path_to_logfile, backup_log_file)
 
             if read_residue_events:
                 residue_events = _read_residue_logs(backup_log_file, offset)

--- a/hubblestack/extmods/modules/nova_loader.py
+++ b/hubblestack/extmods/modules/nova_loader.py
@@ -35,7 +35,7 @@ import hubblestack.utils.exceptions
 
 # Solve the Chicken and egg problem where grains need to run before any
 # of the modules are loaded and are generally available for any usage.
-import salt.modules.cmdmod
+import hubblestack.modules.cmdmod
 
 # Import 3rd-party libs
 import salt.ext.six as six
@@ -47,7 +47,7 @@ except ImportError:
     HAS_PKG_RESOURCES = False
 
 __salt__ = {
-    'cmd.run': salt.modules.cmdmod._run_quiet
+    'cmd.run': hubblestack.modules.cmdmod._run_quiet
 }
 log = logging.getLogger(__name__)
 

--- a/hubblestack/extmods/utils/gitfs.py
+++ b/hubblestack/extmods/utils/gitfs.py
@@ -24,14 +24,14 @@ from datetime import datetime
 
 # Import salt libs
 import salt.utils.configparser
-import salt.utils.data
-import salt.utils.files
+import hubblestack.utils.data
+import hubblestack.utils.files
 import salt.utils.gzip_util
 import salt.utils.hashutils
 import salt.utils.itertools
-import salt.utils.path
+import hubblestack.utils.path
 import hubblestack.utils.platform
-import salt.utils.stringutils
+import hubblestack.utils.stringutils
 import salt.utils.url
 import salt.utils.user
 import salt.utils.versions
@@ -223,7 +223,7 @@ class GitProvider(object):
                  override_params, cache_root, role='gitfs'):
         self.opts = opts
         self.role = role
-        self.global_saltenv = salt.utils.data.repack_dictlist(
+        self.global_saltenv = hubblestack.utils.data.repack_dictlist(
             self.opts.get('{0}_saltenv'.format(self.role), []),
             strict=True,
             recurse=True,
@@ -259,7 +259,7 @@ class GitProvider(object):
             self.id = next(iter(remote))
             self.get_url()
 
-            per_remote_conf = salt.utils.data.repack_dictlist(
+            per_remote_conf = hubblestack.utils.data.repack_dictlist(
                 remote[self.id],
                 strict=True,
                 recurse=True,
@@ -437,8 +437,8 @@ class GitProvider(object):
         else:
             self.hash = hash_type(self.id).hexdigest()
         self.cachedir_basename = getattr(self, 'name', self.hash)
-        self.cachedir = salt.utils.path.join(cache_root, self.cachedir_basename)
-        self.linkdir = salt.utils.path.join(cache_root,
+        self.cachedir = hubblestack.utils.path.join(cache_root, self.cachedir_basename)
+        self.linkdir = hubblestack.utils.path.join(cache_root,
                                             'links',
                                             self.cachedir_basename)
 
@@ -476,11 +476,11 @@ class GitProvider(object):
         use_tags = 'tag' in self.ref_types
 
         ret = set()
-        if salt.utils.stringutils.is_hex(self.base):
+        if hubblestack.utils.stringutils.is_hex(self.base):
             # gitfs_base or per-saltenv 'base' may point to a commit ID, which
             # would not show up in the refs. Make sure we include it.
             ret.add('base')
-        for ref in salt.utils.data.decode(refs):
+        for ref in hubblestack.utils.data.decode(refs):
             if ref.startswith('refs/'):
                 ref = ref[5:]
             rtype, rname = ref.split('/', 1)
@@ -494,7 +494,7 @@ class GitProvider(object):
         return ret
 
     def _get_lock_file(self, lock_type='update'):
-        return salt.utils.path.join(self.gitdir, lock_type + '.lk')
+        return hubblestack.utils.path.join(self.gitdir, lock_type + '.lk')
 
     @classmethod
     def add_conf_overlay(cls, name):
@@ -569,7 +569,7 @@ class GitProvider(object):
         # No need to pass an environment to self.root() here since per-saltenv
         # configuration is a gitfs-only feature and check_root() is not used
         # for gitfs.
-        root_dir = salt.utils.path.join(self.cachedir, self.root()).rstrip(os.sep)
+        root_dir = hubblestack.utils.path.join(self.cachedir, self.root()).rstrip(os.sep)
         if os.path.isdir(root_dir):
             return root_dir
         log.error(
@@ -745,7 +745,7 @@ class GitProvider(object):
 
             # Write changes, if necessary
             if conf_changed:
-                with salt.utils.files.fopen(git_config, 'w') as fp_:
+                with hubblestack.utils.files.fopen(git_config, 'w') as fp_:
                     conf.write(fp_)
                     log.debug(
                         'Config updates for %s remote \'%s\' written to %s',
@@ -790,12 +790,12 @@ class GitProvider(object):
                           os.O_CREAT | os.O_EXCL | os.O_WRONLY)
             with os.fdopen(fh_, 'wb'):
                 # Write the lock file and close the filehandle
-                os.write(fh_, salt.utils.stringutils.to_bytes(six.text_type(os.getpid())))
+                os.write(fh_, hubblestack.utils.stringutils.to_bytes(six.text_type(os.getpid())))
         except (OSError, IOError) as exc:
             if exc.errno == errno.EEXIST:
-                with salt.utils.files.fopen(self._get_lock_file(lock_type), 'r') as fd_:
+                with hubblestack.utils.files.fopen(self._get_lock_file(lock_type), 'r') as fd_:
                     try:
-                        pid = int(salt.utils.stringutils.to_unicode(fd_.readline()).rstrip())
+                        pid = int(hubblestack.utils.stringutils.to_unicode(fd_.readline()).rstrip())
                     except ValueError:
                         # Lock file is empty, set pid to 0 so it evaluates as
                         # False.
@@ -958,7 +958,7 @@ class GitProvider(object):
         Check if an environment is exposed by comparing it against a whitelist
         and blacklist.
         '''
-        return salt.utils.stringutils.check_whitelist_blacklist(
+        return hubblestack.utils.stringutils.check_whitelist_blacklist(
             tgt_env,
             whitelist=self.saltenv_whitelist,
             blacklist=self.saltenv_blacklist,
@@ -1076,7 +1076,7 @@ class GitProvider(object):
                     except IndexError:
                         dirs = []
                     self._linkdir_walk.append((
-                        salt.utils.path.join(self.linkdir, *parts[:idx + 1]),
+                        hubblestack.utils.path.join(self.linkdir, *parts[:idx + 1]),
                         dirs,
                         []
                     ))
@@ -1205,7 +1205,7 @@ class GitPython(GitProvider):
                 log.error(_INVALID_REPO, self.cachedir, self.url, self.role)
                 return new
 
-        self.gitdir = salt.utils.path.join(self.repo.working_dir, '.git')
+        self.gitdir = hubblestack.utils.path.join(self.repo.working_dir, '.git')
         self.enforce_git_config()
 
         return new
@@ -1226,7 +1226,7 @@ class GitPython(GitProvider):
             relpath = lambda path: os.path.relpath(path, self.root(tgt_env))
         else:
             relpath = lambda path: path
-        add_mountpoint = lambda path: salt.utils.path.join(
+        add_mountpoint = lambda path: hubblestack.utils.path.join(
             self.mountpoint(tgt_env), path, use_posixpath=True)
         for blob in tree.traverse():
             if isinstance(blob, git.Tree):
@@ -1299,7 +1299,7 @@ class GitPython(GitProvider):
             relpath = lambda path: os.path.relpath(path, self.root(tgt_env))
         else:
             relpath = lambda path: path
-        add_mountpoint = lambda path: salt.utils.path.join(
+        add_mountpoint = lambda path: hubblestack.utils.path.join(
             self.mountpoint(tgt_env), path, use_posixpath=True)
         for file_blob in tree.traverse():
             if not isinstance(file_blob, git.Blob):
@@ -1342,7 +1342,7 @@ class GitPython(GitProvider):
                     stream.seek(0)
                     link_tgt = stream.read()
                     stream.close()
-                    path = salt.utils.path.join(
+                    path = hubblestack.utils.path.join(
                         os.path.dirname(path), link_tgt, use_posixpath=True)
                 else:
                     blob = file_blob
@@ -1394,7 +1394,7 @@ class GitPython(GitProvider):
         '''
         Using the blob object, write the file to the destination path
         '''
-        with salt.utils.files.fopen(dest, 'wb+') as fp_:
+        with hubblestack.utils.files.fopen(dest, 'wb+') as fp_:
             blob.stream_data(fp_)
 
 
@@ -1651,7 +1651,7 @@ class Pygit2(GitProvider):
                 log.error(_INVALID_REPO, self.cachedir, self.url, self.role)
                 return new
 
-        self.gitdir = salt.utils.path.join(self.repo.workdir, '.git')
+        self.gitdir = hubblestack.utils.path.join(self.repo.workdir, '.git')
         self.enforce_git_config()
         git_config = os.path.join(self.gitdir, 'config')
         if os.path.exists(git_config) and PYGIT2_VERSION >= _LooseVersion('0.28.0'):
@@ -1676,11 +1676,11 @@ class Pygit2(GitProvider):
                 if not isinstance(blob, pygit2.Tree):
                     continue
                 blobs.append(
-                    salt.utils.path.join(prefix, entry.name, use_posixpath=True)
+                    hubblestack.utils.path.join(prefix, entry.name, use_posixpath=True)
                 )
                 if len(blob):
                     _traverse(
-                        blob, blobs, salt.utils.path.join(
+                        blob, blobs, hubblestack.utils.path.join(
                             prefix, entry.name, use_posixpath=True)
                     )
 
@@ -1702,7 +1702,7 @@ class Pygit2(GitProvider):
         blobs = []
         if len(tree):
             _traverse(tree, blobs, self.root(tgt_env))
-        add_mountpoint = lambda path: salt.utils.path.join(
+        add_mountpoint = lambda path: hubblestack.utils.path.join(
             self.mountpoint(tgt_env), path, use_posixpath=True)
         for blob in blobs:
             ret.add(add_mountpoint(relpath(blob)))
@@ -1798,7 +1798,7 @@ class Pygit2(GitProvider):
                     continue
                 obj = self.repo[entry.oid]
                 if isinstance(obj, pygit2.Blob):
-                    repo_path = salt.utils.path.join(
+                    repo_path = hubblestack.utils.path.join(
                         prefix, entry.name, use_posixpath=True)
                     blobs.setdefault('files', []).append(repo_path)
                     if stat.S_ISLNK(tree[entry.name].filemode):
@@ -1806,7 +1806,7 @@ class Pygit2(GitProvider):
                         blobs.setdefault('symlinks', {})[repo_path] = link_tgt
                 elif isinstance(obj, pygit2.Tree):
                     _traverse(
-                        obj, blobs, salt.utils.path.join(
+                        obj, blobs, hubblestack.utils.path.join(
                             prefix, entry.name, use_posixpath=True)
                     )
 
@@ -1832,7 +1832,7 @@ class Pygit2(GitProvider):
         blobs = {}
         if len(tree):
             _traverse(tree, blobs, self.root(tgt_env))
-        add_mountpoint = lambda path: salt.utils.path.join(
+        add_mountpoint = lambda path: hubblestack.utils.path.join(
             self.mountpoint(tgt_env), path, use_posixpath=True)
         for repo_path in blobs.get('files', []):
             files.add(add_mountpoint(relpath(repo_path)))
@@ -1865,7 +1865,7 @@ class Pygit2(GitProvider):
                     # the symlink and set path to the location indicated
                     # in the blob data.
                     link_tgt = self.repo[entry.oid].data
-                    path = salt.utils.path.join(
+                    path = hubblestack.utils.path.join(
                         os.path.dirname(path), link_tgt, use_posixpath=True)
                 else:
                     blob = self.repo[entry.oid]
@@ -2060,7 +2060,7 @@ class Pygit2(GitProvider):
         '''
         Using the blob object, write the file to the destination path
         '''
-        with salt.utils.files.fopen(dest, 'wb+') as fp_:
+        with hubblestack.utils.files.fopen(dest, 'wb+') as fp_:
             fp_.write(blob.data)
 
 
@@ -2123,12 +2123,12 @@ class GitBase(object):
         if cache_root is not None:
             self.cache_root = self.remote_root = cache_root
         else:
-            self.cache_root = salt.utils.path.join(self.opts['cachedir'],
+            self.cache_root = hubblestack.utils.path.join(self.opts['cachedir'],
                                                    self.role)
-            self.remote_root = salt.utils.path.join(self.cache_root, 'remotes')
-        self.env_cache = salt.utils.path.join(self.cache_root, 'envs.p')
-        self.hash_cachedir = salt.utils.path.join(self.cache_root, 'hash')
-        self.file_list_cachedir = salt.utils.path.join(
+            self.remote_root = hubblestack.utils.path.join(self.cache_root, 'remotes')
+        self.env_cache = hubblestack.utils.path.join(self.cache_root, 'envs.p')
+        self.hash_cachedir = hubblestack.utils.path.join(self.cache_root, 'hash')
+        self.file_list_cachedir = hubblestack.utils.path.join(
             self.opts['cachedir'], 'file_lists', self.role)
         if init_remotes:
             self.init_remotes(
@@ -2280,7 +2280,7 @@ class GitBase(object):
         for item in cachedir_ls:
             if item in ('hash', 'refs'):
                 continue
-            path = salt.utils.path.join(self.cache_root, item)
+            path = hubblestack.utils.path.join(self.cache_root, item)
             if os.path.isdir(path):
                 to_remove.append(path)
         failed = []
@@ -2428,7 +2428,7 @@ class GitBase(object):
         if refresh_env_cache:
             new_envs = self.envs(ignore_cache=True)
             serial = salt.payload.Serial(self.opts)
-            with salt.utils.files.fopen(self.env_cache, 'wb+') as fp_:
+            with hubblestack.utils.files.fopen(self.env_cache, 'wb+') as fp_:
                 fp_.write(serial.dumps(new_envs))
                 log.trace('Wrote env cache data to %s', self.env_cache)
 
@@ -2533,7 +2533,7 @@ class GitBase(object):
                     GITPYTHON_VERSION
                 )
             )
-        if not salt.utils.path.which('git'):
+        if not hubblestack.utils.path.which('git'):
             errors.append(
                 'The git command line utility is required when using the '
                 '\'gitpython\' {0}_provider.'.format(self.role)
@@ -2590,7 +2590,7 @@ class GitBase(object):
                 )
             )
         if not getattr(pygit2, 'GIT_FETCH_PRUNE', False) \
-                and not salt.utils.path.which('git'):
+                and not hubblestack.utils.path.which('git'):
             errors.append(
                 'The git command line utility is required when using the '
                 '\'pygit2\' {0}_provider.'.format(self.role)
@@ -2611,9 +2611,9 @@ class GitBase(object):
         '''
         Write the remote_map.txt
         '''
-        remote_map = salt.utils.path.join(self.cache_root, 'remote_map.txt')
+        remote_map = hubblestack.utils.path.join(self.cache_root, 'remote_map.txt')
         try:
-            with salt.utils.files.fopen(remote_map, 'w+') as fp_:
+            with hubblestack.utils.files.fopen(remote_map, 'w+') as fp_:
                 timestamp = \
                     datetime.now().strftime('%d %b %Y %H:%M:%S.%f')
                 fp_.write(
@@ -2624,7 +2624,7 @@ class GitBase(object):
                 )
                 for repo in self.remotes:
                     fp_.write(
-                        salt.utils.stringutils.to_str(
+                        hubblestack.utils.stringutils.to_str(
                             '{0} = {1}\n'.format(
                                 repo.cachedir_basename,
                                 repo.id
@@ -2753,17 +2753,17 @@ class GitFS(GitBase):
         fnd = {'path': '',
                'rel': ''}
         if os.path.isabs(path) or \
-                (not salt.utils.stringutils.is_hex(tgt_env) and tgt_env not in self.envs()):
+                (not hubblestack.utils.stringutils.is_hex(tgt_env) and tgt_env not in self.envs()):
             return fnd
 
-        dest = salt.utils.path.join(self.cache_root, 'refs', tgt_env, path)
-        hashes_glob = salt.utils.path.join(self.hash_cachedir,
+        dest = hubblestack.utils.path.join(self.cache_root, 'refs', tgt_env, path)
+        hashes_glob = hubblestack.utils.path.join(self.hash_cachedir,
                                            tgt_env,
                                            '{0}.hash.*'.format(path))
-        blobshadest = salt.utils.path.join(self.hash_cachedir,
+        blobshadest = hubblestack.utils.path.join(self.hash_cachedir,
                                            tgt_env,
                                            '{0}.hash.blob_sha1'.format(path))
-        lk_fn = salt.utils.path.join(self.hash_cachedir,
+        lk_fn = hubblestack.utils.path.join(self.hash_cachedir,
                                      tgt_env,
                                      '{0}.lk'.format(path))
         destdir = os.path.dirname(dest)
@@ -2789,7 +2789,7 @@ class GitFS(GitBase):
                 continue
             repo_path = path[len(repo.mountpoint(tgt_env)):].lstrip(os.sep)
             if repo.root(tgt_env):
-                repo_path = salt.utils.path.join(repo.root(tgt_env), repo_path)
+                repo_path = hubblestack.utils.path.join(repo.root(tgt_env), repo_path)
 
             blob, blob_hexsha, blob_mode = repo.find_file(repo_path, tgt_env)
             if blob is None:
@@ -2811,8 +2811,8 @@ class GitFS(GitBase):
 
             salt.fileserver.wait_lock(lk_fn, dest)
             try:
-                with salt.utils.files.fopen(blobshadest, 'r') as fp_:
-                    sha = salt.utils.stringutils.to_unicode(fp_.read())
+                with hubblestack.utils.files.fopen(blobshadest, 'r') as fp_:
+                    sha = hubblestack.utils.stringutils.to_unicode(fp_.read())
                     if sha == blob_hexsha:
                         fnd['rel'] = path
                         fnd['path'] = dest
@@ -2821,7 +2821,7 @@ class GitFS(GitBase):
                 if exc.errno != errno.ENOENT:
                     raise exc
 
-            with salt.utils.files.fopen(lk_fn, 'w'):
+            with hubblestack.utils.files.fopen(lk_fn, 'w'):
                 pass
 
             for filename in glob.glob(hashes_glob):
@@ -2831,7 +2831,7 @@ class GitFS(GitBase):
                     pass
             # Write contents of file to their destination in the FS cache
             repo.write_file(blob, dest)
-            with salt.utils.files.fopen(blobshadest, 'w+') as fp_:
+            with hubblestack.utils.files.fopen(blobshadest, 'w+') as fp_:
                 fp_.write(blob_hexsha)
             try:
                 os.remove(lk_fn)
@@ -2867,10 +2867,10 @@ class GitFS(GitBase):
         ret['dest'] = fnd['rel']
         gzip = load.get('gzip', None)
         fpath = os.path.normpath(fnd['path'])
-        with salt.utils.files.fopen(fpath, 'rb') as fp_:
+        with hubblestack.utils.files.fopen(fpath, 'rb') as fp_:
             fp_.seek(load['loc'])
             data = fp_.read(self.opts['file_buffer_size'])
-            if data and six.PY3 and not salt.utils.files.is_binary(fpath):
+            if data and six.PY3 and not hubblestack.utils.files.is_binary(fpath):
                 data = data.decode(__salt_system_encoding__)
             if gzip and data:
                 data = salt.utils.gzip_util.compress(data, gzip)
@@ -2891,12 +2891,12 @@ class GitFS(GitBase):
         ret = {'hash_type': self.opts['hash_type']}
         relpath = fnd['rel']
         path = fnd['path']
-        hashdest = salt.utils.path.join(self.hash_cachedir,
+        hashdest = hubblestack.utils.path.join(self.hash_cachedir,
                                         load['saltenv'],
                                         '{0}.hash.{1}'.format(relpath,
                                                               self.opts['hash_type']))
         try:
-            with salt.utils.files.fopen(hashdest, 'rb') as fp_:
+            with hubblestack.utils.files.fopen(hashdest, 'rb') as fp_:
                 ret['hsum'] = fp_.read()
             return ret
         except IOError as exc:
@@ -2910,7 +2910,7 @@ class GitFS(GitBase):
                 raise exc
 
         ret['hsum'] = salt.utils.hashutils.get_hash(path, self.opts['hash_type'])
-        with salt.utils.files.fopen(hashdest, 'w+') as fp_:
+        with hubblestack.utils.files.fopen(hashdest, 'w+') as fp_:
             fp_.write(ret['hsum'])
         return ret
 
@@ -2928,11 +2928,11 @@ class GitFS(GitBase):
             except os.error:
                 log.error('Unable to make cachedir %s', self.file_list_cachedir)
                 return []
-        list_cache = salt.utils.path.join(
+        list_cache = hubblestack.utils.path.join(
             self.file_list_cachedir,
             '{0}.p'.format(load['saltenv'].replace(os.path.sep, '_|-'))
         )
-        w_lock = salt.utils.path.join(
+        w_lock = hubblestack.utils.path.join(
             self.file_list_cachedir,
             '.{0}.w'.format(load['saltenv'].replace(os.path.sep, '_|-'))
         )
@@ -2944,7 +2944,7 @@ class GitFS(GitBase):
             return cache_match
         if refresh_cache:
             ret = {'files': set(), 'symlinks': {}, 'dirs': set()}
-            if salt.utils.stringutils.is_hex(load['saltenv']) \
+            if hubblestack.utils.stringutils.is_hex(load['saltenv']) \
                     or load['saltenv'] in self.envs():
                 for repo in self.remotes:
                     repo_files, repo_symlinks = repo.file_list(load['saltenv'])
@@ -2987,7 +2987,7 @@ class GitFS(GitBase):
             # "env" is not supported; Use "saltenv".
             load.pop('env')
 
-        if not salt.utils.stringutils.is_hex(load['saltenv']) \
+        if not hubblestack.utils.stringutils.is_hex(load['saltenv']) \
                 and load['saltenv'] not in self.envs():
             return {}
         if 'prefix' in load:
@@ -3040,8 +3040,8 @@ class GitPillar(GitBase):
         Ensure that the mountpoint is present in the correct location and
         points at the correct path
         '''
-        lcachelink = salt.utils.path.join(repo.linkdir, repo._mountpoint)
-        lcachedest = salt.utils.path.join(repo.cachedir, repo.root()).rstrip(os.sep)
+        lcachelink = hubblestack.utils.path.join(repo.linkdir, repo._mountpoint)
+        lcachedest = hubblestack.utils.path.join(repo.cachedir, repo.root()).rstrip(os.sep)
         wipe_linkdir = False
         create_link = False
         try:
@@ -3056,7 +3056,7 @@ class GitPillar(GitBase):
                     log.debug('Expected results: %s', repo.linkdir_walk)
                     wipe_linkdir = True
                 else:
-                    if not all(not salt.utils.path.islink(x[0])
+                    if not all(not hubblestack.utils.path.islink(x[0])
                                and os.path.isdir(x[0])
                                for x in walk_results[:-1]):
                         log.debug(
@@ -3064,11 +3064,11 @@ class GitPillar(GitBase):
                             lcachelink
                         )
                         wipe_linkdir = True
-                    elif not salt.utils.path.islink(lcachelink):
+                    elif not hubblestack.utils.path.islink(lcachelink):
                         wipe_linkdir = True
                     else:
                         try:
-                            ldest = salt.utils.path.readlink(lcachelink)
+                            ldest = hubblestack.utils.path.readlink(lcachelink)
                         except Exception:
                             log.debug(
                                 'Failed to read destination of %s', lcachelink

--- a/hubblestack/extmods/utils/s3.py
+++ b/hubblestack/extmods/utils/s3.py
@@ -19,7 +19,7 @@ except ImportError:
 # Import Salt libs
 import os
 import salt.utils.aws
-import salt.utils.files
+import hubblestack.utils.files
 import salt.utils.hashutils
 import salt.utils.xmlutil as xml
 import time
@@ -173,7 +173,7 @@ def query(key, keyid, method='GET', params=None, headers=None,
     try:
         if method == 'PUT':
             if local_file:
-                fh = salt.utils.files.fopen(local_file, 'rb')  # pylint: disable=resource-leakage
+                fh = hubblestack.utils.files.fopen(local_file, 'rb')  # pylint: disable=resource-leakage
                 data = fh.read()  # pylint: disable=resource-leakage
             result = requests.request(method,
                                       requesturl,
@@ -274,7 +274,7 @@ def query(key, keyid, method='GET', params=None, headers=None,
                 'Failed to get file=%s. {0}: {1}'.format(path, err_code, err_msg))
 
         log.debug('Saving to local file: %s', local_file)
-        with salt.utils.files.fopen(local_file, 'wb') as out:
+        with hubblestack.utils.files.fopen(local_file, 'wb') as out:
             for chunk in result.iter_content(chunk_size=chunk_size):
                 out.write(chunk)
         return 'Saved to local file: {0}'.format(local_file)

--- a/hubblestack/files/hubblestack_nova/firewall.py
+++ b/hubblestack/files/hubblestack_nova/firewall.py
@@ -82,7 +82,7 @@ import fnmatch
 import copy
 import salt.utils
 import hubblestack.utils.platform
-import salt.utils.path
+import hubblestack.utils.path
 
 log = logging.getLogger(__name__)
 
@@ -93,7 +93,7 @@ __data__ = None
 def __virtual__():
     if hubblestack.utils.platform.is_windows():
         return False, 'This audit module only runs on linux'
-    if not salt.utils.path.which('iptables'):
+    if not hubblestack.utils.path.which('iptables'):
         return (False, 'The iptables execution module cannot be loaded: iptables not installed.')
     return True
 

--- a/hubblestack/grains/custom_grains_pillar.py
+++ b/hubblestack/grains/custom_grains_pillar.py
@@ -6,12 +6,13 @@ salt-call
 """
 
 import logging
-import salt.modules.cmdmod
+import salt.modules.config
+import hubblestack.modules.cmdmod
 
 log = logging.getLogger(__name__)
 
 __salt__ = {
-    'cmd.run': salt.modules.cmdmod._run_quiet,
+    'cmd.run': hubblestack.modules.cmdmod._run_quiet,
     'config.get': salt.modules.config.get,
 }
 

--- a/hubblestack/grains/default_gw.py
+++ b/hubblestack/grains/default_gw.py
@@ -20,11 +20,11 @@ List of grains:
 import logging
 
 import salt.utils
-import salt.utils.path
+import hubblestack.utils.path
 
-import salt.modules.cmdmod
+import hubblestack.modules.cmdmod
 
-__salt__ = {'cmd.run': salt.modules.cmdmod._run_quiet}
+__salt__ = {'cmd.run': hubblestack.modules.cmdmod._run_quiet}
 log = logging.getLogger(__name__)
 
 
@@ -45,7 +45,7 @@ def default_gateway():
         ip_gw: True   # True if either of the above is True, False otherwise
     """
     grains = {}
-    if not salt.utils.path.which('ip'):
+    if not hubblestack.utils.path.which('ip'):
         return {}
     grains['ip_gw'] = False
     grains['ip4_gw'] = False

--- a/hubblestack/grains/disks.py
+++ b/hubblestack/grains/disks.py
@@ -10,17 +10,17 @@ import logging
 import re
 
 # Import salt libs
-import salt.utils.files
-import salt.utils.path
+import hubblestack.utils.files
+import hubblestack.utils.path
 import hubblestack.utils.platform
 
 # Solve the Chicken and egg problem where grains need to run before any
 # of the modules are loaded and are generally available for any usage.
-import salt.modules.cmdmod
+import hubblestack.modules.cmdmod
 
 __salt__ = {
-    'cmd.run': salt.modules.cmdmod._run_quiet,
-    'cmd.run_all': salt.modules.cmdmod._run_all_quiet
+    'cmd.run': hubblestack.modules.cmdmod._run_quiet,
+    'cmd.run_all': hubblestack.modules.cmdmod._run_all_quiet
 }
 
 log = logging.getLogger(__name__)
@@ -92,7 +92,7 @@ _geom_attribs = [_geomconsts.__dict__[key] for key in
 
 
 def _freebsd_geom():
-    geom = salt.utils.path.which('geom')
+    geom = hubblestack.utils.path.which('geom')
     ret = {'disks': {}, 'SSDs': []}
 
     devices = __salt__['cmd.run']('{0} disk list'.format(geom))
@@ -133,7 +133,7 @@ def _linux_disks():
 
     for entry in glob.glob('/sys/block/*/queue/rotational'):
         try:
-            with salt.utils.files.fopen(entry) as entry_fp:
+            with hubblestack.utils.files.fopen(entry) as entry_fp:
                 device = entry.split('/')[3]
                 flag = entry_fp.read(1)
                 if flag == '0':
@@ -153,7 +153,7 @@ def _linux_disks():
 
 
 def _windows_disks():
-    wmic = salt.utils.path.which('wmic')
+    wmic = hubblestack.utils.path.which('wmic')
 
     namespace = r'\\root\microsoft\windows\storage'
     path = 'MSFT_PhysicalDisk'

--- a/hubblestack/grains/extra.py
+++ b/hubblestack/grains/extra.py
@@ -9,8 +9,8 @@ import os
 import logging
 
 # Import salt libs
-import salt.utils.data
-import salt.utils.files
+import hubblestack.utils.data
+import hubblestack.utils.files
 import hubblestack.utils.platform
 import salt.utils.yaml
 
@@ -68,9 +68,9 @@ def config():
                     )
     if os.path.isfile(gfn):
         log.debug('Loading static grains from %s', gfn)
-        with salt.utils.files.fopen(gfn, 'rb') as fp_:
+        with hubblestack.utils.files.fopen(gfn, 'rb') as fp_:
             try:
-                return salt.utils.data.decode(salt.utils.yaml.safe_load(fp_))
+                return hubblestack.utils.data.decode(salt.utils.yaml.safe_load(fp_))
             except Exception:
                 log.warning("Bad syntax in grains file! Skipping.")
                 return {}

--- a/hubblestack/grains/fqdn.py
+++ b/hubblestack/grains/fqdn.py
@@ -3,12 +3,12 @@
 Custom grains around fqdn
 """
 import hubblestack.grains.hubble_core
-import salt.modules.cmdmod
+import hubblestack.modules.cmdmod
 import salt.utils
 import hubblestack.utils.platform
 
-__salt__ = {'cmd.run': salt.modules.cmdmod._run_quiet,
-            'cmd.run_all': salt.modules.cmdmod.run_all}
+__salt__ = {'cmd.run': hubblestack.modules.cmdmod._run_quiet,
+            'cmd.run_all': hubblestack.modules.cmdmod.run_all}
 
 
 def fqdn():

--- a/hubblestack/grains/hubble_core.py
+++ b/hubblestack/grains/hubble_core.py
@@ -56,12 +56,12 @@ except ImportError:
 import hubblestack.utils.exceptions
 import salt.log
 import salt.utils.dns
-import salt.utils.files
+import hubblestack.utils.files
 import salt.utils.network
-import salt.utils.path
+import hubblestack.utils.path
 import salt.utils.pkg.rpm
 import hubblestack.utils.platform
-import salt.utils.stringutils
+import hubblestack.utils.stringutils
 from salt.ext import six
 from salt.ext.six.moves import range
 
@@ -70,13 +70,13 @@ if hubblestack.utils.platform.is_windows():
 
 # Solve the Chicken and egg problem where grains need to run before any
 # of the modules are loaded and are generally available for any usage.
-import salt.modules.cmdmod
+import hubblestack.modules.cmdmod
 import salt.modules.smbios
 
 __salt__ = {
-    'cmd.run': salt.modules.cmdmod._run_quiet,
-    'cmd.retcode': salt.modules.cmdmod._retcode_quiet,
-    'cmd.run_all': salt.modules.cmdmod._run_all_quiet,
+    'cmd.run': hubblestack.modules.cmdmod._run_quiet,
+    'cmd.retcode': hubblestack.modules.cmdmod._retcode_quiet,
+    'cmd.run_all': hubblestack.modules.cmdmod._run_all_quiet,
     'smbios.records': salt.modules.smbios.records,
     'smbios.get': salt.modules.smbios.get,
 }
@@ -139,7 +139,7 @@ def _linux_cpudata():
     cpuinfo = '/proc/cpuinfo'
     # Parse over the cpuinfo file
     if os.path.isfile(cpuinfo):
-        with salt.utils.files.fopen(cpuinfo, 'r') as _fp:
+        with hubblestack.utils.files.fopen(cpuinfo, 'r') as _fp:
             for line in _fp:
                 comps = line.split(':')
                 if not len(comps) > 1:
@@ -193,7 +193,7 @@ def _linux_gpu_data():
     if __opts__.get('enable_gpu_grains', True) is False:
         return {}
 
-    lspci = salt.utils.path.which('lspci')
+    lspci = hubblestack.utils.path.which('lspci')
     if not lspci:
         log.debug(
             'The `lspci` binary is not available on the system. GPU grains '
@@ -324,8 +324,8 @@ def _bsd_cpudata(osdata):
     #   num_cpus
     #   cpu_model
     #   cpu_flags
-    sysctl = salt.utils.path.which('sysctl')
-    arch = salt.utils.path.which('arch')
+    sysctl = hubblestack.utils.path.which('sysctl')
+    arch = hubblestack.utils.path.which('arch')
     cmds = {}
 
     if sysctl:
@@ -358,7 +358,7 @@ def _bsd_cpudata(osdata):
     if osdata['kernel'] == 'FreeBSD' and os.path.isfile('/var/run/dmesg.boot'):
         grains['cpu_flags'] = []
         # TODO: at least it needs to be tested for BSD other then FreeBSD
-        with salt.utils.files.fopen('/var/run/dmesg.boot', 'r') as _fp:
+        with hubblestack.utils.files.fopen('/var/run/dmesg.boot', 'r') as _fp:
             cpu_here = False
             for line in _fp:
                 if line.startswith('CPU: '):
@@ -421,7 +421,7 @@ def _aix_cpudata():
     #   cpu_model
     #   cpu_flags
     grains = {}
-    cmd = salt.utils.path.which('prtconf')
+    cmd = hubblestack.utils.path.which('prtconf')
     if cmd:
         data = __salt__['cmd.run']('{0}'.format(cmd)) + os.linesep
         for dest, regstring in (('cpuarch', r'(?im)^\s*Processor\s+Type:\s+(\S+)'),
@@ -445,7 +445,7 @@ def _linux_memdata():
 
     meminfo = '/proc/meminfo'
     if os.path.isfile(meminfo):
-        with salt.utils.files.fopen(meminfo, 'r') as ifile:
+        with hubblestack.utils.files.fopen(meminfo, 'r') as ifile:
             for line in ifile:
                 comps = line.rstrip('\n').split(':')
                 if not len(comps) > 1:
@@ -465,7 +465,7 @@ def _osx_memdata():
     '''
     grains = {'mem_total': 0, 'swap_total': 0}
 
-    sysctl = salt.utils.path.which('sysctl')
+    sysctl = hubblestack.utils.path.which('sysctl')
     if sysctl:
         mem = __salt__['cmd.run']('{0} -n hw.memsize'.format(sysctl))
         swap_total = __salt__['cmd.run']('{0} -n vm.swapusage'.format(sysctl)).split()[2].replace(',', '.')
@@ -488,7 +488,7 @@ def _bsd_memdata(osdata):
     '''
     grains = {'mem_total': 0, 'swap_total': 0}
 
-    sysctl = salt.utils.path.which('sysctl')
+    sysctl = hubblestack.utils.path.which('sysctl')
     if sysctl:
         mem = __salt__['cmd.run']('{0} -n hw.physmem'.format(sysctl))
         if osdata['kernel'] == 'NetBSD' and mem.startswith('-'):
@@ -496,7 +496,7 @@ def _bsd_memdata(osdata):
         grains['mem_total'] = int(mem) // 1024 // 1024
 
         if osdata['kernel'] in ['OpenBSD', 'NetBSD']:
-            swapctl = salt.utils.path.which('swapctl')
+            swapctl = hubblestack.utils.path.which('swapctl')
             swap_data = __salt__['cmd.run']('{0} -sk'.format(swapctl))
             if swap_data == 'no swap devices configured':
                 swap_total = 0
@@ -520,7 +520,7 @@ def _sunos_memdata():
         if comps[0].strip() == 'Memory' and comps[1].strip() == 'size:':
             grains['mem_total'] = int(comps[2].strip())
 
-    swap_cmd = salt.utils.path.which('swap')
+    swap_cmd = hubblestack.utils.path.which('swap')
     swap_data = __salt__['cmd.run']('{0} -s'.format(swap_cmd)).split()
     try:
         swap_avail = int(swap_data[-2][:-1])
@@ -537,7 +537,7 @@ def _aix_memdata():
     Return the memory information for AIX systems
     '''
     grains = {'mem_total': 0, 'swap_total': 0}
-    prtconf = salt.utils.path.which('prtconf')
+    prtconf = hubblestack.utils.path.which('prtconf')
     if prtconf:
         for line in __salt__['cmd.run'](prtconf, python_shell=True).splitlines():
             comps = [x for x in line.strip().split(' ') if x]
@@ -547,7 +547,7 @@ def _aix_memdata():
     else:
         log.error('The \'prtconf\' binary was not found in $PATH.')
 
-    swap_cmd = salt.utils.path.which('swap')
+    swap_cmd = hubblestack.utils.path.which('swap')
     if swap_cmd:
         swap_data = __salt__['cmd.run']('{0} -s'.format(swap_cmd)).split()
         try:
@@ -600,7 +600,7 @@ def _aix_get_machine_id():
     Parse the output of lsattr -El sys0 for os_uuid
     '''
     grains = {}
-    cmd = salt.utils.path.which('lsattr')
+    cmd = hubblestack.utils.path.which('lsattr')
     if cmd:
         data = __salt__['cmd.run']('{0} -El sys0'.format(cmd)) + os.linesep
         uuid_regexes = [re.compile(r'(?im)^\s*os_uuid\s+(\S+)\s+(.*)')]
@@ -692,7 +692,7 @@ def _virtual(osdata):
     # test first for virt-what, which covers most of the desired functionality
     # on most platforms
     if not hubblestack.utils.platform.is_windows() and osdata['kernel'] not in skip_cmds:
-        if salt.utils.path.which('virt-what'):
+        if hubblestack.utils.path.which('virt-what'):
             _cmds = ['virt-what']
 
     # Check if enable_lspci is True or False
@@ -718,7 +718,7 @@ def _virtual(osdata):
             command = 'system_profiler'
             args = ['SPDisplaysDataType']
         elif osdata['kernel'] == 'SunOS':
-            virtinfo = salt.utils.path.which('virtinfo')
+            virtinfo = hubblestack.utils.path.which('virtinfo')
             if virtinfo:
                 try:
                     ret = __salt__['cmd.run_all']('{0} -a'.format(virtinfo))
@@ -733,7 +733,7 @@ def _virtual(osdata):
             else:
                 command = 'prtdiag'
 
-        cmd = salt.utils.path.which(command)
+        cmd = hubblestack.utils.path.which(command)
 
         if not cmd:
             continue
@@ -881,7 +881,7 @@ def _virtual(osdata):
 
     choices = ('Linux', 'HP-UX')
     isdir = os.path.isdir
-    sysctl = salt.utils.path.which('sysctl')
+    sysctl = hubblestack.utils.path.which('sysctl')
     if osdata['kernel'] in choices:
         if os.path.isdir('/proc'):
             try:
@@ -901,7 +901,7 @@ def _virtual(osdata):
                 failed_commands.discard('dmidecode')
         # Provide additional detection for OpenVZ
         if os.path.isfile('/proc/self/status'):
-            with salt.utils.files.fopen('/proc/self/status') as status_file:
+            with hubblestack.utils.files.fopen('/proc/self/status') as status_file:
                 vz_re = re.compile(r'^envID:\s+(\d+)$')
                 for line in status_file:
                     vz_match = vz_re.match(line.rstrip('\n'))
@@ -921,7 +921,7 @@ def _virtual(osdata):
                     grains['virtual_subtype'] = 'Xen HVM DomU'
                 elif os.path.isfile('/proc/xen/capabilities') and \
                         os.access('/proc/xen/capabilities', os.R_OK):
-                    with salt.utils.files.fopen('/proc/xen/capabilities') as fhr:
+                    with hubblestack.utils.files.fopen('/proc/xen/capabilities') as fhr:
                         if 'control_d' not in fhr.read():
                             # Tested on CentOS 5.5 / 2.6.18-194.3.1.el5xen
                             grains['virtual_subtype'] = 'Xen PV DomU'
@@ -942,7 +942,7 @@ def _virtual(osdata):
         # Check container type after hypervisors, to avoid variable overwrite on containers running in virtual environment.
         if os.path.isfile('/proc/1/cgroup'):
             try:
-                with salt.utils.files.fopen('/proc/1/cgroup', 'r') as fhr:
+                with hubblestack.utils.files.fopen('/proc/1/cgroup', 'r') as fhr:
                     fhr_contents = fhr.read()
                 if ':/lxc/' in fhr_contents:
                     grains['virtual_subtype'] = 'LXC'
@@ -958,13 +958,13 @@ def _virtual(osdata):
             except IOError:
                 pass
         if os.path.isfile('/proc/cpuinfo'):
-            with salt.utils.files.fopen('/proc/cpuinfo', 'r') as fhr:
+            with hubblestack.utils.files.fopen('/proc/cpuinfo', 'r') as fhr:
                 if 'QEMU Virtual CPU' in fhr.read():
                     grains['virtual'] = 'kvm'
         if os.path.isfile('/sys/devices/virtual/dmi/id/product_name'):
             try:
-                with salt.utils.files.fopen('/sys/devices/virtual/dmi/id/product_name', 'r') as fhr:
-                    output = salt.utils.stringutils.to_unicode(fhr.read(), errors='replace')
+                with hubblestack.utils.files.fopen('/sys/devices/virtual/dmi/id/product_name', 'r') as fhr:
+                    output = hubblestack.utils.stringutils.to_unicode(fhr.read(), errors='replace')
                     if 'VirtualBox' in output:
                         grains['virtual'] = 'VirtualBox'
                     elif 'RHEV Hypervisor' in output:
@@ -980,7 +980,7 @@ def _virtual(osdata):
             except IOError:
                 pass
     elif osdata['kernel'] == 'FreeBSD':
-        kenv = salt.utils.path.which('kenv')
+        kenv = hubblestack.utils.path.which('kenv')
         if kenv:
             product = __salt__['cmd.run'](
                 '{0} smbios.system.product'.format(kenv)
@@ -1031,7 +1031,7 @@ def _virtual(osdata):
                 grains['virtual_subtype'] = roles
         else:
             # Check if it's a "regular" zone. (i.e. Solaris 10/11 zone)
-            zonename = salt.utils.path.which('zonename')
+            zonename = hubblestack.utils.path.which('zonename')
             if zonename:
                 zone = __salt__['cmd.run']('{0}'.format(zonename))
                 if zone != 'global':
@@ -1083,8 +1083,8 @@ def _virtual_hv(osdata):
     try:
         version = {}
         for fn in ('major', 'minor', 'extra'):
-            with salt.utils.files.fopen('/sys/hypervisor/version/{}'.format(fn), 'r') as fhr:
-                version[fn] = salt.utils.stringutils.to_unicode(fhr.read().strip())
+            with hubblestack.utils.files.fopen('/sys/hypervisor/version/{}'.format(fn), 'r') as fhr:
+                version[fn] = hubblestack.utils.stringutils.to_unicode(fhr.read().strip())
         grains['virtual_hv_version'] = '{}.{}{}'.format(version['major'], version['minor'], version['extra'])
         grains['virtual_hv_version_info'] = [version['major'], version['minor'], version['extra']]
     except (IOError, OSError, KeyError):
@@ -1108,8 +1108,8 @@ def _virtual_hv(osdata):
                         13: 'memory_op_vnode_supported',
                         14: 'ARM_SMCCC_supported'}
     try:
-        with salt.utils.files.fopen('/sys/hypervisor/properties/features', 'r') as fhr:
-            features = salt.utils.stringutils.to_unicode(fhr.read().strip())
+        with hubblestack.utils.files.fopen('/sys/hypervisor/properties/features', 'r') as fhr:
+            features = hubblestack.utils.stringutils.to_unicode(fhr.read().strip())
         enabled_features = []
         for bit, feat in six.iteritems(xen_feature_table):
             if int(features, 16) & (1 << bit):
@@ -1544,7 +1544,7 @@ def _parse_lsb_release():
     ret = {}
     try:
         log.trace('Attempting to parse /etc/lsb-release')
-        with salt.utils.files.fopen('/etc/lsb-release') as ifile:
+        with hubblestack.utils.files.fopen('/etc/lsb-release') as ifile:
             for line in ifile:
                 try:
                     key, value = _LSB_REGEX.match(line.rstrip('\n')).groups()[:2]
@@ -1568,7 +1568,7 @@ def _parse_os_release(*os_release_files):
     ret = {}
     for filename in os_release_files:
         try:
-            with salt.utils.files.fopen(filename) as ifile:
+            with hubblestack.utils.files.fopen(filename) as ifile:
                 regex = re.compile('^([\\w]+)=(?:\'|")?(.*?)(?:\'|")?$')
                 for line in ifile:
                     match = regex.match(line.strip())
@@ -1709,13 +1709,13 @@ def os_data():
             grains['init'] = 'systemd'
         except (OSError, IOError):
             try:
-                with salt.utils.files.fopen('/proc/1/cmdline') as fhr:
+                with hubblestack.utils.files.fopen('/proc/1/cmdline') as fhr:
                     init_cmdline = fhr.read().replace('\x00', ' ').split()
             except (IOError, OSError):
                 pass
             else:
                 try:
-                    init_bin = salt.utils.path.which(init_cmdline[0])
+                    init_bin = hubblestack.utils.path.which(init_cmdline[0])
                 except IndexError:
                     # Emtpy init_cmdline
                     init_bin = None
@@ -1729,7 +1729,7 @@ def os_data():
                         # Default to the value of file_buffer_size for the minion
                         buf_size = 262144
                     try:
-                        with salt.utils.files.fopen(init_bin, 'rb') as fp_:
+                        with hubblestack.utils.files.fopen(init_bin, 'rb') as fp_:
                             edge = b''
                             buf = fp_.read(buf_size).lower()
                             while buf:
@@ -1748,12 +1748,12 @@ def os_data():
                             'Unable to read from init_bin (%s): %s',
                             init_bin, exc
                         )
-                elif salt.utils.path.which('supervisord') in init_cmdline:
+                elif hubblestack.utils.path.which('supervisord') in init_cmdline:
                     grains['init'] = 'supervisord'
-                elif salt.utils.path.which('dumb-init') in init_cmdline:
+                elif hubblestack.utils.path.which('dumb-init') in init_cmdline:
                     # https://github.com/Yelp/dumb-init
                     grains['init'] = 'dumb-init'
-                elif salt.utils.path.which('tini') in init_cmdline:
+                elif hubblestack.utils.path.which('tini') in init_cmdline:
                     # https://github.com/krallin/tini
                     grains['init'] = 'tini'
                 elif init_cmdline == ['runit']:
@@ -1836,7 +1836,7 @@ def os_data():
                     grains['lsb_distrib_id'] = 'SUSE'
                     version = ''
                     patch = ''
-                    with salt.utils.files.fopen('/etc/SuSE-release') as fhr:
+                    with hubblestack.utils.files.fopen('/etc/SuSE-release') as fhr:
                         for line in fhr:
                             if 'enterprise' in line.lower():
                                 grains['lsb_distrib_id'] = 'SLES'
@@ -1857,7 +1857,7 @@ def os_data():
                     log.trace('Parsing distrib info from /etc/altlinux-release')
                     # ALT Linux
                     grains['lsb_distrib_id'] = 'altlinux'
-                    with salt.utils.files.fopen('/etc/altlinux-release') as ifile:
+                    with hubblestack.utils.files.fopen('/etc/altlinux-release') as ifile:
                         # This file is symlinked to from:
                         #     /etc/fedora-release
                         #     /etc/redhat-release
@@ -1873,7 +1873,7 @@ def os_data():
                     log.trace('Parsing distrib info from /etc/centos-release')
                     # CentOS Linux
                     grains['lsb_distrib_id'] = 'CentOS'
-                    with salt.utils.files.fopen('/etc/centos-release') as ifile:
+                    with hubblestack.utils.files.fopen('/etc/centos-release') as ifile:
                         for line in ifile:
                             # Need to pull out the version and codename
                             # in the case of custom content in /etc/centos-release
@@ -1891,7 +1891,7 @@ def os_data():
                     log.trace(
                         'Parsing Synology distrib info from /etc/.defaults/VERSION'
                     )
-                    with salt.utils.files.fopen('/etc.defaults/VERSION', 'r') as fp_:
+                    with hubblestack.utils.files.fopen('/etc.defaults/VERSION', 'r') as fp_:
                         synoinfo = {}
                         for line in fp_:
                             try:
@@ -1971,7 +1971,7 @@ def os_data():
             # store a untouched copy of the timestamp in osrelease_stamp
             grains['osrelease_stamp'] = uname_v
         elif os.path.isfile('/etc/release'):
-            with salt.utils.files.fopen('/etc/release', 'r') as fp_:
+            with hubblestack.utils.files.fopen('/etc/release', 'r') as fp_:
                 rel_data = fp_.read()
                 try:
                     release_re = re.compile(
@@ -2399,7 +2399,7 @@ def get_machine_id():
     if not existing_locations:
         return {}
     else:
-        with salt.utils.files.fopen(existing_locations[0]) as machineid:
+        with hubblestack.utils.files.fopen(existing_locations[0]) as machineid:
             return {'machine_id': machineid.read().strip()}
 
 
@@ -2518,8 +2518,8 @@ def _hw_data(osdata):
             contents_file = os.path.join('/sys/class/dmi/id', fw_file)
             if os.path.exists(contents_file):
                 try:
-                    with salt.utils.files.fopen(contents_file, 'r') as ifile:
-                        grains[key] = salt.utils.stringutils.to_unicode(ifile.read().strip(), errors='replace')
+                    with hubblestack.utils.files.fopen(contents_file, 'r') as ifile:
+                        grains[key] = hubblestack.utils.stringutils.to_unicode(ifile.read().strip(), errors='replace')
                         if key == 'uuid':
                             grains['uuid'] = grains['uuid'].lower()
                 except (IOError, OSError) as err:
@@ -2528,7 +2528,7 @@ def _hw_data(osdata):
                     if err.errno == EACCES or err.errno == EPERM:
                         # Skip the grain if non-root user has no access to the file.
                         pass
-    elif salt.utils.path.which_bin(['dmidecode', 'smbios']) is not None and not (
+    elif hubblestack.utils.path.which_bin(['dmidecode', 'smbios']) is not None and not (
             hubblestack.utils.platform.is_smartos() or
             (  # SunOS on SPARC - 'smbios: failed to load SMBIOS: System does not export an SMBIOS table'
                 osdata['kernel'] == 'SunOS' and
@@ -2552,7 +2552,7 @@ def _hw_data(osdata):
             if serial is not None:
                 grains['serialnumber'] = serial
                 break
-    elif salt.utils.path.which_bin(['fw_printenv']) is not None:
+    elif hubblestack.utils.path.which_bin(['fw_printenv']) is not None:
         # ARM Linux devices expose UBOOT env variables via fw_printenv
         hwdata = {
             'manufacturer': 'manufacturer',
@@ -2567,7 +2567,7 @@ def _hw_data(osdata):
     elif osdata['kernel'] == 'FreeBSD':
         # On FreeBSD /bin/kenv (already in base system)
         # can be used instead of dmidecode
-        kenv = salt.utils.path.which('kenv')
+        kenv = hubblestack.utils.path.which('kenv')
         if kenv:
             # In theory, it will be easier to add new fields to this later
             fbsd_hwdata = {
@@ -2582,7 +2582,7 @@ def _hw_data(osdata):
                 value = __salt__['cmd.run']('{0} {1}'.format(kenv, val))
                 grains[key] = _clean_value(key, value)
     elif osdata['kernel'] == 'OpenBSD':
-        sysctl = salt.utils.path.which('sysctl')
+        sysctl = hubblestack.utils.path.which('sysctl')
         hwdata = {'biosversion': 'hw.version',
                   'manufacturer': 'hw.vendor',
                   'productname': 'hw.product',
@@ -2593,7 +2593,7 @@ def _hw_data(osdata):
             if not value.endswith(' value is not available'):
                 grains[key] = _clean_value(key, value)
     elif osdata['kernel'] == 'NetBSD':
-        sysctl = salt.utils.path.which('sysctl')
+        sysctl = hubblestack.utils.path.which('sysctl')
         nbsd_hwdata = {
             'biosversion': 'machdep.dmi.board-version',
             'manufacturer': 'machdep.dmi.system-vendor',
@@ -2608,7 +2608,7 @@ def _hw_data(osdata):
                 grains[key] = _clean_value(key, result['stdout'])
     elif osdata['kernel'] == 'Darwin':
         grains['manufacturer'] = 'Apple Inc.'
-        sysctl = salt.utils.path.which('sysctl')
+        sysctl = hubblestack.utils.path.which('sysctl')
         hwdata = {'productname': 'hw.model'}
         for key, oid in hwdata.items():
             value = __salt__['cmd.run']('{0} -b {1}'.format(sysctl, oid))
@@ -2620,7 +2620,7 @@ def _hw_data(osdata):
         # commands and attempt various lookups.
         data = ""
         for (cmd, args) in (('/usr/sbin/prtdiag', '-v'), ('/usr/sbin/prtconf', '-vp'), ('/usr/sbin/virtinfo', '-a')):
-            if salt.utils.path.which(cmd):  # Also verifies that cmd is executable
+            if hubblestack.utils.path.which(cmd):  # Also verifies that cmd is executable
                 data += __salt__['cmd.run']('{0} {1}'.format(cmd, args))
                 data += '\n'
 
@@ -2734,7 +2734,7 @@ def _hw_data(osdata):
                     grains['productname'] = t_productname
                     break
     elif osdata['kernel'] == 'AIX':
-        cmd = salt.utils.path.which('prtconf')
+        cmd = hubblestack.utils.path.which('prtconf')
         if cmd:
             data = __salt__['cmd.run']('{0}'.format(cmd)) + os.linesep
             for dest, regstring in (('serialnumber', r'(?im)^\s*Machine\s+Serial\s+Number:\s+(\S+)'),
@@ -2754,7 +2754,7 @@ def _hw_data(osdata):
             log.error('The \'prtconf\' binary was not found in $PATH.')
 
     elif osdata['kernel'] == 'AIX':
-        cmd = salt.utils.path.which('prtconf')
+        cmd = hubblestack.utils.path.which('prtconf')
         if data:
             data = __salt__['cmd.run']('{0}'.format(cmd)) + os.linesep
             for dest, regstring in (('serialnumber', r'(?im)^\s*Machine\s+Serial\s+Number:\s+(\S+)'),
@@ -2842,7 +2842,7 @@ def default_gateway():
         ip_gw: True   # True if either of the above is True, False otherwise
     '''
     grains = {}
-    ip_bin = salt.utils.path.which('ip')
+    ip_bin = hubblestack.utils.path.which('ip')
     if not ip_bin:
         return {}
     grains['ip_gw'] = False

--- a/hubblestack/grains/mdadm.py
+++ b/hubblestack/grains/mdadm.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 import logging
 
 # Import salt libs
-import salt.utils.files
+import hubblestack.utils.files
 
 log = logging.getLogger(__name__)
 
@@ -19,9 +19,9 @@ def mdadm():
     '''
     devices = set()
     try:
-        with salt.utils.files.fopen('/proc/mdstat', 'r') as mdstat:
+        with hubblestack.utils.files.fopen('/proc/mdstat', 'r') as mdstat:
             for line in mdstat:
-                line = salt.utils.stringutils.to_unicode(line)
+                line = hubblestack.utils.stringutils.to_unicode(line)
                 if line.startswith('Personalities : '):
                     continue
                 if line.startswith('unused devices:'):

--- a/hubblestack/grains/osqueryinfo.py
+++ b/hubblestack/grains/osqueryinfo.py
@@ -2,10 +2,10 @@
 """ Handle metadata about osquery: return version and path as grains """
 
 import salt.utils
-import salt.utils.path
-import salt.modules.cmdmod
+import hubblestack.utils.path
+import hubblestack.modules.cmdmod
 
-__salt__ = {'cmd.run': salt.modules.cmdmod._run_quiet}
+__salt__ = {'cmd.run': hubblestack.modules.cmdmod._run_quiet}
 
 
 def osquerygrain():
@@ -21,11 +21,11 @@ def osquerygrain():
     # Prefer our /opt/osquery/osqueryi if present
     osqueryipaths = ('/opt/osquery/osqueryi', 'osqueryi', '/usr/bin/osqueryi')
     for path in osqueryipaths:
-        if salt.utils.path.which(path):
+        if hubblestack.utils.path.which(path):
             for item in __salt__['cmd.run']('{0} {1}'.format(path, option)).split():
                 if item[:1].isdigit():
                     grains['osqueryversion'] = item
-                    grains['osquerybinpath'] = salt.utils.path.which(path)
+                    grains['osquerybinpath'] = hubblestack.utils.path.which(path)
                     break
             break
     return grains

--- a/hubblestack/grains/systemuuid.py
+++ b/hubblestack/grains/systemuuid.py
@@ -4,10 +4,10 @@ Gather the system uuid via osquery
 """
 import logging
 import os
-import salt.utils.path
-import salt.modules.cmdmod
+import hubblestack.utils.path
+import hubblestack.modules.cmdmod
 
-__salt__ = {'cmd.run_stdout': salt.modules.cmdmod.run_stdout}
+__salt__ = {'cmd.run_stdout': hubblestack.modules.cmdmod.run_stdout}
 log = logging.getLogger(__name__)
 
 
@@ -82,7 +82,7 @@ def _get_uuid_from_system():
     # Prefer our /opt/osquery/osqueryi if present
     osqueryipaths = ('/opt/osquery/osqueryi', 'osqueryi', '/usr/bin/osqueryi')
     for path in osqueryipaths:
-        if salt.utils.path.which(path):
+        if hubblestack.utils.path.which(path):
             first_run = __salt__['cmd.run_stdout']('{0} {1}'.format(path, query),
                                                    output_loglevel='quiet')
             first_run = str(first_run).upper()

--- a/hubblestack/grains/zfs.py
+++ b/hubblestack/grains/zfs.py
@@ -17,17 +17,17 @@ import logging
 
 # Import salt libs
 import salt.utils.dictupdate
-import salt.utils.path
+import hubblestack.utils.path
 import hubblestack.utils.platform
 
 # Solve the Chicken and egg problem where grains need to run before any
 # of the modules are loaded and are generally available for any usage.
-import salt.modules.cmdmod
+import hubblestack.modules.cmdmod
 import salt.utils.zfs
 
 __virtualname__ = 'zfs'
 __salt__ = {
-    'cmd.run': salt.modules.cmdmod.run,
+    'cmd.run': hubblestack.modules.cmdmod.run,
 }
 __utils__ = {
     'zfs.is_supported': salt.utils.zfs.is_supported,

--- a/hubblestack/modules/cmdmod.py
+++ b/hubblestack/modules/cmdmod.py
@@ -1,0 +1,1640 @@
+# -*- coding: utf-8 -*-
+'''
+A module for shelling out.
+
+Keep in mind that this module is insecure, in that it can give whomever has
+access to the master root execution access to all salt minions.
+'''
+
+# Import python libs
+import functools
+import glob
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import time
+import traceback
+import fnmatch
+import base64
+import re
+import tempfile
+
+# Import salt libs
+import hubblestack.utils.args
+import hubblestack.utils.data
+import hubblestack.utils.files
+import hubblestack.utils.path
+import hubblestack.utils.platform
+import hubblestack.utils.stringutils
+import hubblestack.utils.timed_subprocess
+import hubblestack.grains.extra
+import salt.utils.user
+import hubblestack.grains.extra
+from hubblestack.utils.exceptions import CommandExecutionError, TimedProcTimeoutError, \
+    HubbleInvocationError
+from salt.log import LOG_LEVELS
+
+# Only available on POSIX systems, nonfatal on windows
+try:
+    import pwd
+    import grp
+except ImportError:
+    pass
+
+if hubblestack.utils.platform.is_windows():
+    from salt.utils.win_runas import runas as win_runas
+    from salt.utils.win_functions import escape_argument as _cmd_quote
+    HAS_WIN_RUNAS = True
+else:
+    from shlex import quote as _cmd_quote
+    HAS_WIN_RUNAS = False
+
+# Define the module's virtual name
+__virtualname__ = 'cmd'
+
+# Set up logging
+log = logging.getLogger(__name__)
+
+DEFAULT_SHELL = hubblestack.grains.extra.shell()['shell']
+
+
+# Overwriting the cmd python module makes debugging modules with pdb a bit
+# harder so lets do it this way instead.
+def __virtual__():
+    return __virtualname__
+
+def run_stdout(cmd,
+               cwd=None,
+               stdin=None,
+               runas=None,
+               group=None,
+               shell=DEFAULT_SHELL,
+               python_shell=None,
+               env=None,
+               clean_env=False,
+               rstrip=True,
+               umask=None,
+               output_encoding=None,
+               output_loglevel='debug',
+               log_callback=None,
+               hide_output=False,
+               timeout=None,
+               reset_system_locale=True,
+               ignore_retcode=False,
+               saltenv='base',
+               password=None,
+               prepend_path=None,
+               success_retcodes=None,
+               **kwargs):
+    '''
+    Execute a command, and only return the standard out
+
+    :param str cmd: The command to run. ex: ``ls -lart /home``
+
+    :param str cwd: The directory from which to execute the command. Defaults
+        to the home directory of the user specified by ``runas`` (or the user
+        under which Salt is running if ``runas`` is not specified).
+
+    :param str stdin: A string of standard input can be specified for the
+        command to be run using the ``stdin`` parameter. This can be useful in
+        cases where sensitive information must be read from standard input.
+
+    :param str runas: Specify an alternate user to run the command. The default
+        behavior is to run as the user under which Salt is running. If running
+        on a Windows minion you must also use the ``password`` argument, and
+        the target user account must be in the Administrators group.
+
+        .. warning::
+
+            For versions 2018.3.3 and above on macosx while using runas,
+            to pass special characters to the command you need to escape
+            the characters on the shell.
+
+            Example:
+
+            .. code-block:: bash
+
+                cmd.run_stdout 'echo '\\''h=\\"baz\\"'\\\''' runas=macuser
+
+    :param str password: Windows only. Required when specifying ``runas``. This
+        parameter will be ignored on non-Windows platforms.
+
+        .. versionadded:: 2016.3.0
+
+    :param str group: Group to run command as. Not currently supported
+      on Windows.
+
+    :param str shell: Specify an alternate shell. Defaults to the system's
+        default shell.
+
+    :param bool python_shell: If False, let python handle the positional
+        arguments. Set to True to use shell features, such as pipes or
+        redirection.
+
+    :param dict env: Environment variables to be set prior to execution.
+
+        .. note::
+            When passing environment variables on the CLI, they should be
+            passed as the string representation of a dictionary.
+
+            .. code-block:: bash
+
+                salt myminion cmd.run_stdout 'some command' env='{"FOO": "bar"}'
+
+    :param bool clean_env: Attempt to clean out all other shell environment
+        variables and set only those provided in the 'env' argument to this
+        function.
+
+    :param str prepend_path: $PATH segment to prepend (trailing ':' not necessary)
+        to $PATH
+
+        .. versionadded:: 2018.3.0
+
+    :param bool rstrip: Strip all whitespace off the end of output before it is
+        returned.
+
+    :param str umask: The umask (in octal) to use when running the command.
+
+    :param str output_encoding: Control the encoding used to decode the
+        command's output.
+
+        .. note::
+            This should not need to be used in most cases. By default, Salt
+            will try to use the encoding detected from the system locale, and
+            will fall back to UTF-8 if this fails. This should only need to be
+            used in cases where the output of the command is encoded in
+            something other than the system locale or UTF-8.
+
+            To see the encoding Salt has detected from the system locale, check
+            the `locale` line in the output of :py:func:`test.versions_report
+            <salt.modules.test.versions_report>`.
+
+        .. versionadded:: 2018.3.0
+
+    :param str output_loglevel: Control the loglevel at which the output from
+        the command is logged to the minion log.
+
+        .. note::
+            The command being run will still be logged at the ``debug``
+            loglevel regardless, unless ``quiet`` is used for this value.
+
+    :param bool ignore_retcode: If the exit code of the command is nonzero,
+        this is treated as an error condition, and the output from the command
+        will be logged to the minion log. However, there are some cases where
+        programs use the return code for signaling and a nonzero exit code
+        doesn't necessarily mean failure. Pass this argument as ``True`` to
+        skip logging the output if the command has a nonzero exit code.
+
+    :param bool hide_output: If ``True``, suppress stdout and stderr in the
+        return data.
+
+        .. note::
+            This is separate from ``output_loglevel``, which only handles how
+            Salt logs to the minion log.
+
+        .. versionadded:: 2018.3.0
+
+    :param int timeout: A timeout in seconds for the executed process to
+        return.
+
+    :param list success_retcodes: This parameter will be allow a list of
+        non-zero return codes that should be considered a success.  If the
+        return code returned from the run matches any in the provided list,
+        the return code will be overridden with zero.
+
+      .. versionadded:: 2019.2.0
+
+    :param bool stdin_raw_newlines: False
+        If ``True``, Salt will not automatically convert the characters ``\\n``
+        present in the ``stdin`` value to newlines.
+
+      .. versionadded:: 2019.2.0
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' cmd.run_stdout "ls -l | awk '/foo/{print \\$2}'"
+
+    A string of standard input can be specified for the command to be run using
+    the ``stdin`` parameter. This can be useful in cases where sensitive
+    information must be read from standard input.
+
+    .. code-block:: bash
+
+        salt '*' cmd.run_stdout "grep f" stdin='one\\ntwo\\nthree\\nfour\\nfive\\n'
+    '''
+    python_shell = _python_shell_default(python_shell,
+                                         kwargs.get('__pub_jid', ''))
+    ret = _run(cmd,
+               runas=runas,
+               group=group,
+               cwd=cwd,
+               stdin=stdin,
+               shell=shell,
+               python_shell=python_shell,
+               env=env,
+               clean_env=clean_env,
+               prepend_path=prepend_path,
+               rstrip=rstrip,
+               umask=umask,
+               output_encoding=output_encoding,
+               output_loglevel=output_loglevel,
+               log_callback=log_callback,
+               timeout=timeout,
+               reset_system_locale=reset_system_locale,
+               ignore_retcode=ignore_retcode,
+               saltenv=saltenv,
+               password=password,
+               success_retcodes=success_retcodes,
+               **kwargs)
+
+    return ret['stdout'] if not hide_output else ''
+
+def _python_shell_default(python_shell, __pub_jid):
+    '''
+    Set python_shell default based on remote execution and __opts__['cmd_safe']
+    '''
+    try:
+        # Default to python_shell=True when run directly from remote execution
+        # system. Cross-module calls won't have a jid.
+        if __pub_jid and python_shell is None:
+            return True
+        elif __opts__.get('cmd_safe', True) is False and python_shell is None:
+            # Override-switch for python_shell
+            return True
+    except NameError:
+        pass
+    return python_shell
+
+def _is_valid_shell(shell):
+    '''
+    Attempts to search for valid shells on a system and
+    see if a given shell is in the list
+    '''
+    if hubblestack.utils.platform.is_windows():
+        return True  # Don't even try this for Windows
+    shells = '/etc/shells'
+    available_shells = []
+    if os.path.exists(shells):
+        try:
+            with hubblestack.utils.files.fopen(shells, 'r') as shell_fp:
+                lines = [hubblestack.utils.stringutils.to_unicode(x)
+                         for x in shell_fp.read().splitlines()]
+            for line in lines:
+                if line.startswith('#'):
+                    continue
+                else:
+                    available_shells.append(line)
+        except OSError:
+            return True
+    else:
+        # No known method of determining available shells
+        return None
+    if shell in available_shells:
+        return True
+    else:
+        return False
+
+def _check_loglevel(level='info'):
+    '''
+    Retrieve the level code for use in logging.Logger.log().
+    '''
+    try:
+        level = level.lower()
+        if level == 'quiet':
+            return None
+        else:
+            return LOG_LEVELS[level]
+    except (AttributeError, KeyError):
+        log.error(
+            'Invalid output_loglevel \'%s\'. Valid levels are: %s. Falling '
+            'back to \'info\'.',
+            level, ', '.join(sorted(LOG_LEVELS, reverse=True))
+        )
+        return LOG_LEVELS['info']
+
+def _check_cb(cb_):
+    '''
+    If the callback is None or is not callable, return a lambda that returns
+    the value passed.
+    '''
+    if cb_ is not None:
+        if hasattr(cb_, '__call__'):
+            return cb_
+        else:
+            log.error('log_callback is not callable, ignoring')
+    return lambda x: x
+
+def _check_avail(cmd):
+    '''
+    Check to see if the given command can be run
+    '''
+    if isinstance(cmd, list):
+        cmd = ' '.join([str(x) if not isinstance(x, str) else x
+                        for x in cmd])
+    bret = True
+    wret = False
+    if __salt__['config.get']('cmd_blacklist_glob'):
+        blist = __salt__['config.get']('cmd_blacklist_glob', [])
+        for comp in blist:
+            if fnmatch.fnmatch(cmd, comp):
+                # BAD! you are blacklisted
+                bret = False
+    if __salt__['config.get']('cmd_whitelist_glob', []):
+        blist = __salt__['config.get']('cmd_whitelist_glob', [])
+        for comp in blist:
+            if fnmatch.fnmatch(cmd, comp):
+                # GOOD! You are whitelisted
+                wret = True
+                break
+    else:
+        # If no whitelist set then alls good!
+        wret = True
+    return bret and wret
+
+def _parse_env(env):
+    if not env:
+        env = {}
+    if isinstance(env, list):
+        env = hubblestack.utils.data.repack_dictlist(env)
+    if not isinstance(env, dict):
+        env = {}
+    return env
+
+def _run(cmd,
+         cwd=None,
+         stdin=None,
+         stdout=subprocess.PIPE,
+         stderr=subprocess.PIPE,
+         output_encoding=None,
+         output_loglevel='debug',
+         log_callback=None,
+         runas=None,
+         group=None,
+         shell=DEFAULT_SHELL,
+         python_shell=False,
+         env=None,
+         clean_env=False,
+         prepend_path=None,
+         rstrip=True,
+         umask=None,
+         timeout=None,
+         with_communicate=True,
+         reset_system_locale=True,
+         ignore_retcode=False,
+         saltenv='base',
+         pillarenv=None,
+         pillar_override=None,
+         password=None,
+         bg=False,
+         encoded_cmd=False,
+         success_retcodes=None,
+         **kwargs):
+    '''
+    Do the DRY thing and only call subprocess.Popen() once
+    '''
+    if 'pillar' in kwargs and not pillar_override:
+        pillar_override = kwargs['pillar']
+    if output_loglevel != 'quiet' and _is_valid_shell(shell) is False:
+        log.warning(
+            'Attempt to run a shell command with what may be an invalid shell! '
+            'Check to ensure that the shell <%s> is valid for this user.',
+            shell
+        )
+
+    output_loglevel = _check_loglevel(output_loglevel)
+    log_callback = _check_cb(log_callback)
+    use_sudo = False
+
+    if runas is None and '__context__' in globals():
+        runas = __context__.get('runas')
+
+    if password is None and '__context__' in globals():
+        password = __context__.get('runas_password')
+
+    # Set the default working directory to the home directory of the user
+    # salt-minion is running as. Defaults to home directory of user under which
+    # the minion is running.
+    if not cwd:
+        cwd = os.path.expanduser('~{0}'.format('' if not runas else runas))
+
+        # make sure we can access the cwd
+        # when run from sudo or another environment where the euid is
+        # changed ~ will expand to the home of the original uid and
+        # the euid might not have access to it. See issue #1844
+        if not os.access(cwd, os.R_OK):
+            cwd = '/'
+            if hubblestack.utils.platform.is_windows():
+                cwd = os.path.abspath(os.sep)
+    else:
+        # Handle edge cases where numeric/other input is entered, and would be
+        # yaml-ified into non-string types
+        cwd = str(cwd)
+
+    if bg:
+        ignore_retcode = True
+
+    if not hubblestack.utils.platform.is_windows():
+        if not os.path.isfile(shell) or not os.access(shell, os.X_OK):
+            msg = 'The shell {0} is not available'.format(shell)
+            raise CommandExecutionError(msg)
+
+    if shell.lower().strip() == 'powershell':
+        # Strip whitespace
+        if isinstance(cmd, str):
+            cmd = cmd.strip()
+
+        # If we were called by script(), then fakeout the Windows
+        # shell to run a Powershell script.
+        # Else just run a Powershell command.
+        stack = traceback.extract_stack(limit=2)
+
+        # extract_stack() returns a list of tuples.
+        # The last item in the list [-1] is the current method.
+        # The third item[2] in each tuple is the name of that method.
+        if stack[-2][2] == 'script':
+            cmd = 'Powershell -NonInteractive -NoProfile -ExecutionPolicy Bypass -File ' + cmd
+        elif encoded_cmd:
+            cmd = 'Powershell -NonInteractive -EncodedCommand {0}'.format(cmd)
+        else:
+            cmd = 'Powershell -NonInteractive -NoProfile "{0}"'.format(cmd.replace('"', '\\"'))
+
+    ret = {}
+
+    # If the pub jid is here then this is a remote ex or salt call command and needs to be
+    # checked if blacklisted
+    if '__pub_jid' in kwargs:
+        if not _check_avail(cmd):
+            raise CommandExecutionError(
+                'The shell command "{0}" is not permitted'.format(cmd)
+            )
+
+    env = _parse_env(env)
+
+    for bad_env_key in (x for x, y in iter(env.items()) if y is None):
+        log.error('Environment variable \'%s\' passed without a value. '
+                  'Setting value to an empty string', bad_env_key)
+        env[bad_env_key] = ''
+
+    def _get_stripped(cmd):
+        # Return stripped command string copies to improve logging.
+        if isinstance(cmd, list):
+            return [x.strip() if isinstance(x, str) else x for x in cmd]
+        elif isinstance(cmd, str):
+            return cmd.strip()
+        else:
+            return cmd
+
+    if output_loglevel is not None:
+        # Always log the shell commands at INFO unless quiet logging is
+        # requested. The command output is what will be controlled by the
+        # 'loglevel' parameter.
+        msg = (
+            'Executing command {0}{1}{0} {2}{3}in directory \'{4}\'{5}'.format(
+                '\'' if not isinstance(cmd, list) else '',
+                _get_stripped(cmd),
+                'as user \'{0}\' '.format(runas) if runas else '',
+                'in group \'{0}\' '.format(group) if group else '',
+                cwd,
+                '. Executing command in the background, no output will be '
+                'logged.' if bg else ''
+            )
+        )
+        log.info(log_callback(msg))
+
+    if runas and hubblestack.utils.platform.is_windows():
+        if not HAS_WIN_RUNAS:
+            msg = 'missing salt/utils/win_runas.py'
+            raise CommandExecutionError(msg)
+
+        if isinstance(cmd, (list, tuple)):
+            cmd = ' '.join(cmd)
+
+        return win_runas(cmd, runas, password, cwd)
+
+    if runas and hubblestack.utils.platform.is_darwin():
+        # We need to insert the user simulation into the command itself and not
+        # just run it from the environment on macOS as that method doesn't work
+        # properly when run as root for certain commands.
+        if isinstance(cmd, (list, tuple)):
+            cmd = ' '.join(map(_cmd_quote, cmd))
+
+        # Ensure directory is correct before running command
+        cmd = 'cd -- {dir} && {{ {cmd}\n }}'.format(dir=_cmd_quote(cwd), cmd=cmd)
+
+        # Ensure environment is correct for a newly logged-in user by running
+        # the command under bash as a login shell
+        cmd = '/bin/bash -l -c {cmd}'.format(cmd=_cmd_quote(cmd))
+
+        # Ensure the login is simulated correctly (note: su runs sh, not bash,
+        # which causes the environment to be initialised incorrectly, which is
+        # fixed by the previous line of code)
+        cmd = 'su -l {0} -c {1}'.format(_cmd_quote(runas), _cmd_quote(cmd))
+
+        # Set runas to None, because if you try to run `su -l` after changing
+        # user, su will prompt for the password of the user and cause salt to
+        # hang.
+        runas = None
+
+    if runas:
+        # Save the original command before munging it
+        try:
+            pwd.getpwnam(runas)
+        except KeyError:
+            raise CommandExecutionError(
+                'User \'{0}\' is not available'.format(runas)
+            )
+
+    if group:
+        if hubblestack.utils.platform.is_windows():
+            msg = 'group is not currently available on Windows'
+            raise HubbleInvocationError(msg)
+        if not hubblestack.utils.path.which_bin(['sudo']):
+            msg = 'group argument requires sudo but not found'
+            raise CommandExecutionError(msg)
+        try:
+            grp.getgrnam(group)
+        except KeyError:
+            raise CommandExecutionError(
+                'Group \'{0}\' is not available'.format(runas)
+            )
+        else:
+            use_sudo = True
+
+    if runas or group:
+        try:
+            # Getting the environment for the runas user
+            # Use markers to thwart any stdout noise
+            # There must be a better way to do this.
+            import uuid
+            marker = '<<<' + str(uuid.uuid4()) + '>>>'
+            marker_b = marker.encode(__salt_system_encoding__)
+            py_code = (
+                'import sys, os, itertools; '
+                'sys.stdout.write(\"' + marker + '\"); '
+                'sys.stdout.write(\"\\0\".join(itertools.chain(*os.environ.items()))); '
+                'sys.stdout.write(\"' + marker + '\");'
+            )
+
+            if use_sudo:
+                env_cmd = ['sudo']
+                # runas is optional if use_sudo is set.
+                if runas:
+                    env_cmd.extend(['-u', runas])
+                if group:
+                    env_cmd.extend(['-g', group])
+                if shell != DEFAULT_SHELL:
+                    env_cmd.extend(['-s', '--', shell, '-c'])
+                else:
+                    env_cmd.extend(['-i', '--'])
+                env_cmd.extend([sys.executable])
+            elif __grains__['os'] in ['FreeBSD']:
+                env_cmd = ('su', '-', runas, '-c',
+                           "{0} -c {1}".format(shell, sys.executable))
+            else:
+                env_cmd = ('su', '-s', shell, '-', runas, '-c', sys.executable)
+            msg = 'env command: {0}'.format(env_cmd)
+            log.debug(log_callback(msg))
+
+            env_bytes, env_encoded_err = subprocess.Popen(
+                env_cmd,
+                stderr=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stdin=subprocess.PIPE
+            ).communicate(hubblestack.utils.stringutils.to_bytes(py_code))
+            marker_count = env_bytes.count(marker_b)
+            if marker_count == 0:
+                # Possibly PAM prevented the login
+                log.error(
+                    'Environment could not be retrieved for user \'%s\': '
+                    'stderr=%r stdout=%r',
+                    runas, env_encoded_err, env_bytes
+                )
+                # Ensure that we get an empty env_runas dict below since we
+                # were not able to get the environment.
+                env_bytes = b''
+            elif marker_count != 2:
+                raise CommandExecutionError(
+                    'Environment could not be retrieved for user \'{0}\'',
+                    info={'stderr': repr(env_encoded_err),
+                          'stdout': repr(env_bytes)}
+                )
+            else:
+                # Strip the marker
+                env_bytes = env_bytes.split(marker_b)[1]
+
+            env_runas = dict(list(zip(*[iter(env_bytes.split(b'\0'))]*2)))
+
+            env_runas = dict(
+                (hubblestack.utils.stringutils.to_str(k),
+                 hubblestack.utils.stringutils.to_str(v))
+                for k, v in iter(env_runas.items())
+            )
+            env_runas.update(env)
+
+            # Fix platforms like Solaris that don't set a USER env var in the
+            # user's default environment as obtained above.
+            if env_runas.get('USER') != runas:
+                env_runas['USER'] = runas
+
+            # Fix some corner cases where shelling out to get the user's
+            # environment returns the wrong home directory.
+            runas_home = os.path.expanduser('~{0}'.format(runas))
+            if env_runas.get('HOME') != runas_home:
+                env_runas['HOME'] = runas_home
+
+            env = env_runas
+        except ValueError as exc:
+            log.exception('Error raised retrieving environment for user %s', runas)
+            raise CommandExecutionError(
+                'Environment could not be retrieved for user \'{0}\': {1}'.format(
+                    runas, exc
+                )
+            )
+
+    if reset_system_locale is True:
+        if not hubblestack.utils.platform.is_windows():
+            # Default to C!
+            # Salt only knows how to parse English words
+            # Don't override if the user has passed LC_ALL
+            env.setdefault('LC_CTYPE', 'C')
+            env.setdefault('LC_NUMERIC', 'C')
+            env.setdefault('LC_TIME', 'C')
+            env.setdefault('LC_COLLATE', 'C')
+            env.setdefault('LC_MONETARY', 'C')
+            env.setdefault('LC_MESSAGES', 'C')
+            env.setdefault('LC_PAPER', 'C')
+            env.setdefault('LC_NAME', 'C')
+            env.setdefault('LC_ADDRESS', 'C')
+            env.setdefault('LC_TELEPHONE', 'C')
+            env.setdefault('LC_MEASUREMENT', 'C')
+            env.setdefault('LC_IDENTIFICATION', 'C')
+            env.setdefault('LANGUAGE', 'C')
+        else:
+            # On Windows set the codepage to US English.
+            if python_shell:
+                cmd = 'chcp 437 > nul & ' + cmd
+
+    if clean_env:
+        run_env = env
+    else:
+        if hubblestack.utils.platform.is_windows():
+            import nt
+            run_env = nt.environ.copy()
+        else:
+            run_env = os.environ.copy()
+        run_env.update(env)
+
+    if prepend_path:
+        run_env['PATH'] = ':'.join((prepend_path, run_env['PATH']))
+
+    if python_shell is None:
+        python_shell = False
+
+    new_kwargs = {'cwd': cwd,
+                  'shell': python_shell,
+                  'env': run_env,
+                  'stdin': str(stdin) if stdin is not None else stdin,
+                  'stdout': stdout,
+                  'stderr': stderr,
+                  'with_communicate': with_communicate,
+                  'timeout': timeout,
+                  'bg': bg,
+                  }
+
+    if 'stdin_raw_newlines' in kwargs:
+        new_kwargs['stdin_raw_newlines'] = kwargs['stdin_raw_newlines']
+
+    if umask is not None:
+        _umask = str(umask).lstrip('0')
+
+        if _umask == '':
+            msg = 'Zero umask is not allowed.'
+            raise CommandExecutionError(msg)
+
+        try:
+            _umask = int(_umask, 8)
+        except ValueError:
+            raise CommandExecutionError("Invalid umask: '{0}'".format(umask))
+    else:
+        _umask = None
+
+    if runas or group or umask:
+        new_kwargs['preexec_fn'] = functools.partial(
+                salt.utils.user.chugid_and_umask,
+                runas,
+                _umask,
+                group)
+
+    if not hubblestack.utils.platform.is_windows():
+        # close_fds is not supported on Windows platforms if you redirect
+        # stdin/stdout/stderr
+        if new_kwargs['shell'] is True:
+            new_kwargs['executable'] = shell
+        new_kwargs['close_fds'] = True
+
+    if not os.path.isabs(cwd) or not os.path.isdir(cwd):
+        raise CommandExecutionError(
+            'Specified cwd \'{0}\' either not absolute or does not exist'
+            .format(cwd)
+        )
+
+    if python_shell is not True \
+            and not hubblestack.utils.platform.is_windows() \
+            and not isinstance(cmd, list):
+        cmd = hubblestack.utils.args.shlex_split(cmd)
+
+    if success_retcodes is None:
+        success_retcodes = [0]
+    else:
+        try:
+            success_retcodes = [int(i) for i in
+                                hubblestack.utils.args.split_input(
+                                    success_retcodes
+                                )]
+        except ValueError:
+            raise HubbleInvocationError(
+                'success_retcodes must be a list of integers'
+            )
+
+    # This is where the magic happens
+    try:
+        proc = hubblestack.utils.timed_subprocess.TimedProc(cmd, **new_kwargs)
+    except (OSError, IOError) as exc:
+        msg = (
+            'Unable to run command \'{0}\' with the context \'{1}\', '
+            'reason: '.format(
+                cmd if output_loglevel is not None else 'REDACTED',
+                new_kwargs
+            )
+        )
+        try:
+            if exc.filename is None:
+                msg += 'command not found'
+            else:
+                msg += '{0}: {1}'.format(exc, exc.filename)
+        except AttributeError:
+            # Both IOError and OSError have the filename attribute, so this
+            # is a precaution in case the exception classes in the previous
+            # try/except are changed.
+            msg += 'unknown'
+        raise CommandExecutionError(msg)
+
+    try:
+        proc.run()
+    except TimedProcTimeoutError as exc:
+        ret['stdout'] = str(exc)
+        ret['stderr'] = ''
+        ret['retcode'] = None
+        ret['pid'] = proc.process.pid
+        # ok return code for timeouts?
+        ret['retcode'] = 1
+        return ret
+
+    if output_loglevel != 'quiet' and output_encoding is not None:
+        log.debug('Decoding output from command %s using %s encoding',
+                    cmd, output_encoding)
+
+    try:
+        out = hubblestack.utils.stringutils.to_unicode(
+            proc.stdout,
+            encoding=output_encoding)
+    except TypeError:
+        # stdout is None
+        out = ''
+    except UnicodeDecodeError:
+        out = hubblestack.utils.stringutils.to_unicode(
+            proc.stdout,
+            encoding=output_encoding,
+            errors='replace')
+        if output_loglevel != 'quiet':
+            log.error(
+                'Failed to decode stdout from command %s, non-decodable '
+                'characters have been replaced', cmd
+            )
+
+    try:
+        err = hubblestack.utils.stringutils.to_unicode(
+            proc.stderr,
+            encoding=output_encoding)
+    except TypeError:
+        # stderr is None
+        err = ''
+    except UnicodeDecodeError:
+        err = hubblestack.utils.stringutils.to_unicode(
+            proc.stderr,
+            encoding=output_encoding,
+            errors='replace')
+        if output_loglevel != 'quiet':
+            log.error(
+                'Failed to decode stderr from command %s, non-decodable '
+                'characters have been replaced', cmd
+            )
+
+    if rstrip:
+        if out is not None:
+            out = out.rstrip()
+        if err is not None:
+            err = err.rstrip()
+    ret['pid'] = proc.process.pid
+    ret['retcode'] = proc.process.returncode
+    if ret['retcode'] in success_retcodes:
+        ret['retcode'] = 0
+    ret['stdout'] = out
+    ret['stderr'] = err
+    
+    try:
+        if ignore_retcode:
+            __context__['retcode'] = 0
+        else:
+            __context__['retcode'] = ret['retcode']
+    except NameError:
+        # Ignore the context error during grain generation
+        pass
+
+    # Log the output
+    if output_loglevel is not None:
+        if not ignore_retcode and ret['retcode'] != 0:
+            if output_loglevel < LOG_LEVELS['error']:
+                output_loglevel = LOG_LEVELS['error']
+            msg = (
+                'Command \'{0}\' failed with return code: {1}'.format(
+                    cmd,
+                    ret['retcode']
+                )
+            )
+            log.error(log_callback(msg))
+        if ret['stdout']:
+            log.log(output_loglevel, 'stdout: {0}'.format(log_callback(ret['stdout'])))
+        if ret['stderr']:
+            log.log(output_loglevel, 'stderr: {0}'.format(log_callback(ret['stderr'])))
+        if ret['retcode']:
+            log.log(output_loglevel, 'retcode: {0}'.format(ret['retcode']))
+
+    return ret
+
+def _run_quiet(cmd,
+               cwd=None,
+               stdin=None,
+               output_encoding=None,
+               runas=None,
+               shell=DEFAULT_SHELL,
+               python_shell=False,
+               env=None,
+               umask=None,
+               timeout=None,
+               reset_system_locale=True,
+               saltenv='base',
+               pillarenv=None,
+               pillar_override=None,
+               success_retcodes=None):
+    '''
+    Helper for running commands quietly for minion startup
+    '''
+    return _run(cmd,
+                runas=runas,
+                cwd=cwd,
+                stdin=stdin,
+                stderr=subprocess.STDOUT,
+                output_encoding=output_encoding,
+                output_loglevel='quiet',
+                log_callback=None,
+                shell=shell,
+                python_shell=python_shell,
+                env=env,
+                umask=umask,
+                timeout=timeout,
+                reset_system_locale=reset_system_locale,
+                saltenv=saltenv,
+                pillarenv=pillarenv,
+                pillar_override=pillar_override,
+                success_retcodes=success_retcodes)['stdout']
+
+
+def _run_all_quiet(cmd,
+                   cwd=None,
+                   stdin=None,
+                   runas=None,
+                   shell=DEFAULT_SHELL,
+                   python_shell=False,
+                   env=None,
+                   umask=None,
+                   timeout=None,
+                   reset_system_locale=True,
+                   saltenv='base',
+                   pillarenv=None,
+                   pillar_override=None,
+                   output_encoding=None,
+                   success_retcodes=None):
+
+    '''
+    Helper for running commands quietly for minion startup.
+    Returns a dict of return data.
+
+    output_loglevel argument is ignored. This is here for when we alias
+    cmd.run_all directly to _run_all_quiet in certain chicken-and-egg
+    situations where modules need to work both before and after
+    the __salt__ dictionary is populated (cf dracr.py)
+    '''
+    return _run(cmd,
+                runas=runas,
+                cwd=cwd,
+                stdin=stdin,
+                shell=shell,
+                python_shell=python_shell,
+                env=env,
+                output_encoding=output_encoding,
+                output_loglevel='quiet',
+                log_callback=None,
+                umask=umask,
+                timeout=timeout,
+                reset_system_locale=reset_system_locale,
+                saltenv=saltenv,
+                pillarenv=pillarenv,
+                pillar_override=pillar_override,
+                success_retcodes=success_retcodes)
+
+def run_all(cmd,
+            cwd=None,
+            stdin=None,
+            runas=None,
+            group=None,
+            shell=DEFAULT_SHELL,
+            python_shell=None,
+            env=None,
+            clean_env=False,
+            rstrip=True,
+            umask=None,
+            output_encoding=None,
+            output_loglevel='debug',
+            log_callback=None,
+            hide_output=False,
+            timeout=None,
+            reset_system_locale=True,
+            ignore_retcode=False,
+            saltenv='base',
+            redirect_stderr=False,
+            password=None,
+            encoded_cmd=False,
+            prepend_path=None,
+            success_retcodes=None,
+            **kwargs):
+    '''
+    Execute the passed command and return a dict of return data
+
+    :param str cmd: The command to run. ex: ``ls -lart /home``
+
+    :param str cwd: The directory from which to execute the command. Defaults
+        to the home directory of the user specified by ``runas`` (or the user
+        under which Salt is running if ``runas`` is not specified).
+
+    :param str stdin: A string of standard input can be specified for the
+        command to be run using the ``stdin`` parameter. This can be useful in
+        cases where sensitive information must be read from standard input.
+
+    :param str runas: Specify an alternate user to run the command. The default
+        behavior is to run as the user under which Salt is running. If running
+        on a Windows minion you must also use the ``password`` argument, and
+        the target user account must be in the Administrators group.
+
+        .. warning::
+
+            For versions 2018.3.3 and above on macosx while using runas,
+            to pass special characters to the command you need to escape
+            the characters on the shell.
+
+            Example:
+
+            .. code-block:: bash
+
+                cmd.run_all 'echo '\\''h=\\"baz\\"'\\\''' runas=macuser
+
+    :param str password: Windows only. Required when specifying ``runas``. This
+        parameter will be ignored on non-Windows platforms.
+
+        .. versionadded:: 2016.3.0
+
+    :param str group: Group to run command as. Not currently supported
+      on Windows.
+
+    :param str shell: Specify an alternate shell. Defaults to the system's
+        default shell.
+
+    :param bool python_shell: If False, let python handle the positional
+        arguments. Set to True to use shell features, such as pipes or
+        redirection.
+
+    :param dict env: Environment variables to be set prior to execution.
+
+        .. note::
+            When passing environment variables on the CLI, they should be
+            passed as the string representation of a dictionary.
+
+            .. code-block:: bash
+
+                salt myminion cmd.run_all 'some command' env='{"FOO": "bar"}'
+
+    :param bool clean_env: Attempt to clean out all other shell environment
+        variables and set only those provided in the 'env' argument to this
+        function.
+
+    :param str prepend_path: $PATH segment to prepend (trailing ':' not
+        necessary) to $PATH
+
+        .. versionadded:: 2018.3.0
+
+    :param bool rstrip: Strip all whitespace off the end of output before it is
+        returned.
+
+    :param str umask: The umask (in octal) to use when running the command.
+
+    :param str output_encoding: Control the encoding used to decode the
+        command's output.
+
+        .. note::
+            This should not need to be used in most cases. By default, Salt
+            will try to use the encoding detected from the system locale, and
+            will fall back to UTF-8 if this fails. This should only need to be
+            used in cases where the output of the command is encoded in
+            something other than the system locale or UTF-8.
+
+            To see the encoding Salt has detected from the system locale, check
+            the `locale` line in the output of :py:func:`test.versions_report
+            <salt.modules.test.versions_report>`.
+
+        .. versionadded:: 2018.3.0
+
+    :param str output_loglevel: Control the loglevel at which the output from
+        the command is logged to the minion log.
+
+        .. note::
+            The command being run will still be logged at the ``debug``
+            loglevel regardless, unless ``quiet`` is used for this value.
+
+    :param bool ignore_retcode: If the exit code of the command is nonzero,
+        this is treated as an error condition, and the output from the command
+        will be logged to the minion log. However, there are some cases where
+        programs use the return code for signaling and a nonzero exit code
+        doesn't necessarily mean failure. Pass this argument as ``True`` to
+        skip logging the output if the command has a nonzero exit code.
+
+    :param bool hide_output: If ``True``, suppress stdout and stderr in the
+        return data.
+
+        .. note::
+            This is separate from ``output_loglevel``, which only handles how
+            Salt logs to the minion log.
+
+        .. versionadded:: 2018.3.0
+
+    :param int timeout: A timeout in seconds for the executed process to
+        return.
+
+    :param bool encoded_cmd: Specify if the supplied command is encoded.
+       Only applies to shell 'powershell'.
+
+       .. versionadded:: 2018.3.0
+
+    :param bool redirect_stderr: If set to ``True``, then stderr will be
+        redirected to stdout. This is helpful for cases where obtaining both
+        the retcode and output is desired, but it is not desired to have the
+        output separated into both stdout and stderr.
+
+        .. versionadded:: 2015.8.2
+
+    :param str password: Windows only. Required when specifying ``runas``. This
+        parameter will be ignored on non-Windows platforms.
+
+          .. versionadded:: 2016.3.0
+
+    :param bool bg: If ``True``, run command in background and do not await or
+        deliver its results
+
+        .. versionadded:: 2016.3.6
+
+    :param list success_retcodes: This parameter will be allow a list of
+        non-zero return codes that should be considered a success.  If the
+        return code returned from the run matches any in the provided list,
+        the return code will be overridden with zero.
+
+      .. versionadded:: 2019.2.0
+
+    :param bool stdin_raw_newlines: False
+        If ``True``, Salt will not automatically convert the characters ``\\n``
+        present in the ``stdin`` value to newlines.
+
+      .. versionadded:: 2019.2.0
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' cmd.run_all "ls -l | awk '/foo/{print \\$2}'"
+
+    A string of standard input can be specified for the command to be run using
+    the ``stdin`` parameter. This can be useful in cases where sensitive
+    information must be read from standard input.
+
+    .. code-block:: bash
+
+        salt '*' cmd.run_all "grep f" stdin='one\\ntwo\\nthree\\nfour\\nfive\\n'
+    '''
+    python_shell = _python_shell_default(python_shell,
+                                         kwargs.get('__pub_jid', ''))
+    stderr = subprocess.STDOUT if redirect_stderr else subprocess.PIPE
+    ret = _run(cmd,
+               runas=runas,
+               group=group,
+               cwd=cwd,
+               stdin=stdin,
+               stderr=stderr,
+               shell=shell,
+               python_shell=python_shell,
+               env=env,
+               clean_env=clean_env,
+               prepend_path=prepend_path,
+               rstrip=rstrip,
+               umask=umask,
+               output_encoding=output_encoding,
+               output_loglevel=output_loglevel,
+               log_callback=log_callback,
+               timeout=timeout,
+               reset_system_locale=reset_system_locale,
+               ignore_retcode=ignore_retcode,
+               saltenv=saltenv,
+               password=password,
+               encoded_cmd=encoded_cmd,
+               success_retcodes=success_retcodes,
+               **kwargs)
+
+    if hide_output:
+        ret['stdout'] = ret['stderr'] = ''
+    return ret
+
+def _retcode_quiet(cmd,
+                   cwd=None,
+                   stdin=None,
+                   runas=None,
+                   group=None,
+                   shell=DEFAULT_SHELL,
+                   python_shell=False,
+                   env=None,
+                   clean_env=False,
+                   umask=None,
+                   output_encoding=None,
+                   log_callback=None,
+                   timeout=None,
+                   reset_system_locale=True,
+                   ignore_retcode=False,
+                   saltenv='base',
+                   password=None,
+                   success_retcodes=None,
+                   **kwargs):
+    '''
+    Helper for running commands quietly for minion startup. Returns same as
+    the retcode() function.
+    '''
+    return retcode(cmd,
+                   cwd=cwd,
+                   stdin=stdin,
+                   runas=runas,
+                   group=group,
+                   shell=shell,
+                   python_shell=python_shell,
+                   env=env,
+                   clean_env=clean_env,
+                   umask=umask,
+                   output_encoding=output_encoding,
+                   output_loglevel='quiet',
+                   log_callback=log_callback,
+                   timeout=timeout,
+                   reset_system_locale=reset_system_locale,
+                   ignore_retcode=ignore_retcode,
+                   saltenv=saltenv,
+                   password=password,
+                   success_retcodes=success_retcodes,
+                   **kwargs)
+
+def retcode(cmd,
+            cwd=None,
+            stdin=None,
+            runas=None,
+            group=None,
+            shell=DEFAULT_SHELL,
+            python_shell=None,
+            env=None,
+            clean_env=False,
+            umask=None,
+            output_encoding=None,
+            output_loglevel='debug',
+            log_callback=None,
+            timeout=None,
+            reset_system_locale=True,
+            ignore_retcode=False,
+            saltenv='base',
+            password=None,
+            success_retcodes=None,
+            **kwargs):
+    '''
+    Execute a shell command and return the command's return code.
+
+    :param str cmd: The command to run. ex: ``ls -lart /home``
+
+    :param str cwd: The directory from which to execute the command. Defaults
+        to the home directory of the user specified by ``runas`` (or the user
+        under which Salt is running if ``runas`` is not specified).
+
+    :param str stdin: A string of standard input can be specified for the
+        command to be run using the ``stdin`` parameter. This can be useful in
+        cases where sensitive information must be read from standard input.
+
+    :param str runas: Specify an alternate user to run the command. The default
+        behavior is to run as the user under which Salt is running. If running
+        on a Windows minion you must also use the ``password`` argument, and
+        the target user account must be in the Administrators group.
+
+        .. warning::
+
+            For versions 2018.3.3 and above on macosx while using runas,
+            to pass special characters to the command you need to escape
+            the characters on the shell.
+
+            Example:
+
+            .. code-block:: bash
+
+                cmd.retcode 'echo '\\''h=\\"baz\\"'\\\''' runas=macuser
+
+    :param str password: Windows only. Required when specifying ``runas``. This
+        parameter will be ignored on non-Windows platforms.
+
+        .. versionadded:: 2016.3.0
+
+    :param str group: Group to run command as. Not currently supported
+      on Windows.
+
+    :param str shell: Specify an alternate shell. Defaults to the system's
+        default shell.
+
+    :param bool python_shell: If False, let python handle the positional
+        arguments. Set to True to use shell features, such as pipes or
+        redirection.
+
+    :param dict env: Environment variables to be set prior to execution.
+
+        .. note::
+            When passing environment variables on the CLI, they should be
+            passed as the string representation of a dictionary.
+
+            .. code-block:: bash
+
+                salt myminion cmd.retcode 'some command' env='{"FOO": "bar"}'
+
+    :param bool clean_env: Attempt to clean out all other shell environment
+        variables and set only those provided in the 'env' argument to this
+        function.
+
+    :param bool rstrip: Strip all whitespace off the end of output before it is
+        returned.
+
+    :param str umask: The umask (in octal) to use when running the command.
+
+    :param str output_encoding: Control the encoding used to decode the
+        command's output.
+
+        .. note::
+            This should not need to be used in most cases. By default, Salt
+            will try to use the encoding detected from the system locale, and
+            will fall back to UTF-8 if this fails. This should only need to be
+            used in cases where the output of the command is encoded in
+            something other than the system locale or UTF-8.
+
+            To see the encoding Salt has detected from the system locale, check
+            the `locale` line in the output of :py:func:`test.versions_report
+            <salt.modules.test.versions_report>`.
+
+        .. versionadded:: 2018.3.0
+
+    :param str output_loglevel: Control the loglevel at which the output from
+        the command is logged to the minion log.
+
+        .. note::
+            The command being run will still be logged at the ``debug``
+            loglevel regardless, unless ``quiet`` is used for this value.
+
+    :param bool ignore_retcode: If the exit code of the command is nonzero,
+        this is treated as an error condition, and the output from the command
+        will be logged to the minion log. However, there are some cases where
+        programs use the return code for signaling and a nonzero exit code
+        doesn't necessarily mean failure. Pass this argument as ``True`` to
+        skip logging the output if the command has a nonzero exit code.
+
+    :param int timeout: A timeout in seconds for the executed process to return.
+
+    :rtype: int
+    :rtype: None
+    :returns: Return Code as an int or None if there was an exception.
+
+    :param list success_retcodes: This parameter will be allow a list of
+        non-zero return codes that should be considered a success.  If the
+        return code returned from the run matches any in the provided list,
+        the return code will be overridden with zero.
+
+      .. versionadded:: 2019.2.0
+
+    :param bool stdin_raw_newlines: False
+        If ``True``, Salt will not automatically convert the characters ``\\n``
+        present in the ``stdin`` value to newlines.
+
+      .. versionadded:: 2019.2.0
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' cmd.retcode "file /bin/bash"
+
+    A string of standard input can be specified for the command to be run using
+    the ``stdin`` parameter. This can be useful in cases where sensitive
+    information must be read from standard input.
+
+    .. code-block:: bash
+
+        salt '*' cmd.retcode "grep f" stdin='one\\ntwo\\nthree\\nfour\\nfive\\n'
+    '''
+    python_shell = _python_shell_default(python_shell,
+                                         kwargs.get('__pub_jid', ''))
+
+    ret = _run(cmd,
+               runas=runas,
+               group=group,
+               cwd=cwd,
+               stdin=stdin,
+               stderr=subprocess.STDOUT,
+               shell=shell,
+               python_shell=python_shell,
+               env=env,
+               clean_env=clean_env,
+               umask=umask,
+               output_encoding=output_encoding,
+               output_loglevel=output_loglevel,
+               log_callback=log_callback,
+               timeout=timeout,
+               reset_system_locale=reset_system_locale,
+               ignore_retcode=ignore_retcode,
+               saltenv=saltenv,
+               password=password,
+               success_retcodes=success_retcodes,
+               **kwargs)
+    return ret['retcode']
+
+def run(cmd,
+        cwd=None,
+        stdin=None,
+        runas=None,
+        group=None,
+        shell=DEFAULT_SHELL,
+        python_shell=None,
+        env=None,
+        clean_env=False,
+        rstrip=True,
+        umask=None,
+        output_encoding=None,
+        output_loglevel='debug',
+        log_callback=None,
+        hide_output=False,
+        timeout=None,
+        reset_system_locale=True,
+        ignore_retcode=False,
+        saltenv='base',
+        bg=False,
+        password=None,
+        encoded_cmd=False,
+        raise_err=False,
+        prepend_path=None,
+        success_retcodes=None,
+        **kwargs):
+    r'''
+    Execute the passed command and return the output as a string
+
+    :param str cmd: The command to run. ex: ``ls -lart /home``
+
+    :param str cwd: The directory from which to execute the command. Defaults
+        to the home directory of the user specified by ``runas`` (or the user
+        under which Salt is running if ``runas`` is not specified).
+
+    :param str stdin: A string of standard input can be specified for the
+        command to be run using the ``stdin`` parameter. This can be useful in
+        cases where sensitive information must be read from standard input.
+
+    :param str runas: Specify an alternate user to run the command. The default
+        behavior is to run as the user under which Salt is running.
+
+        .. warning::
+
+            For versions 2018.3.3 and above on macosx while using runas,
+            to pass special characters to the command you need to escape
+            the characters on the shell.
+
+            Example:
+
+            .. code-block:: bash
+
+                cmd.run 'echo '\''h=\"baz\"'\''' runas=macuser
+
+    :param str group: Group to run command as. Not currently supported
+        on Windows.
+
+    :param str password: Windows only. Required when specifying ``runas``. This
+        parameter will be ignored on non-Windows platforms.
+
+        .. versionadded:: 2016.3.0
+
+    :param str shell: Specify an alternate shell. Defaults to the system's
+        default shell.
+
+    :param bool python_shell: If ``False``, let python handle the positional
+        arguments. Set to ``True`` to use shell features, such as pipes or
+        redirection.
+
+    :param bool bg: If ``True``, run command in background and do not await or
+        deliver it's results
+
+        .. versionadded:: 2016.3.0
+
+    :param dict env: Environment variables to be set prior to execution.
+
+        .. note::
+            When passing environment variables on the CLI, they should be
+            passed as the string representation of a dictionary.
+
+            .. code-block:: bash
+
+                salt myminion cmd.run 'some command' env='{"FOO": "bar"}'
+
+    :param bool clean_env: Attempt to clean out all other shell environment
+        variables and set only those provided in the 'env' argument to this
+        function.
+
+    :param str prepend_path: $PATH segment to prepend (trailing ':' not
+        necessary) to $PATH
+
+        .. versionadded:: 2018.3.0
+
+    :param bool rstrip: Strip all whitespace off the end of output before it is
+        returned.
+
+    :param str umask: The umask (in octal) to use when running the command.
+
+    :param str output_encoding: Control the encoding used to decode the
+        command's output.
+
+        .. note::
+            This should not need to be used in most cases. By default, Salt
+            will try to use the encoding detected from the system locale, and
+            will fall back to UTF-8 if this fails. This should only need to be
+            used in cases where the output of the command is encoded in
+            something other than the system locale or UTF-8.
+
+            To see the encoding Salt has detected from the system locale, check
+            the `locale` line in the output of :py:func:`test.versions_report
+            <salt.modules.test.versions_report>`.
+
+        .. versionadded:: 2018.3.0
+
+    :param str output_loglevel: Control the loglevel at which the output from
+        the command is logged to the minion log.
+
+        .. note::
+            The command being run will still be logged at the ``debug``
+            loglevel regardless, unless ``quiet`` is used for this value.
+
+    :param bool ignore_retcode: If the exit code of the command is nonzero,
+        this is treated as an error condition, and the output from the command
+        will be logged to the minion log. However, there are some cases where
+        programs use the return code for signaling and a nonzero exit code
+        doesn't necessarily mean failure. Pass this argument as ``True`` to
+        skip logging the output if the command has a nonzero exit code.
+
+    :param bool hide_output: If ``True``, suppress stdout and stderr in the
+        return data.
+
+        .. note::
+            This is separate from ``output_loglevel``, which only handles how
+            Salt logs to the minion log.
+
+        .. versionadded:: 2018.3.0
+
+    :param int timeout: A timeout in seconds for the executed process to return.
+
+    :param bool encoded_cmd: Specify if the supplied command is encoded.
+        Only applies to shell 'powershell'.
+
+    :param bool raise_err: If ``True`` and the command has a nonzero exit code,
+        a CommandExecutionError exception will be raised.
+
+    .. warning::
+        This function does not process commands through a shell
+        unless the python_shell flag is set to True. This means that any
+        shell-specific functionality such as 'echo' or the use of pipes,
+        redirection or &&, should either be migrated to cmd.shell or
+        have the python_shell=True flag set here.
+
+        The use of python_shell=True means that the shell will accept _any_ input
+        including potentially malicious commands such as 'good_command;rm -rf /'.
+        Be absolutely certain that you have sanitized your input prior to using
+        python_shell=True
+
+    :param list success_retcodes: This parameter will be allow a list of
+        non-zero return codes that should be considered a success.  If the
+        return code returned from the run matches any in the provided list,
+        the return code will be overridden with zero.
+
+      .. versionadded:: 2019.2.0
+
+    :param bool stdin_raw_newlines: False
+        If ``True``, Salt will not automatically convert the characters ``\\n``
+        present in the ``stdin`` value to newlines.
+
+      .. versionadded:: 2019.2.0
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' cmd.run "ls -l | awk '/foo/{print \\$2}'"
+
+    Specify an alternate shell with the shell parameter:
+
+    .. code-block:: bash
+
+        salt '*' cmd.run "Get-ChildItem C:\\ " shell='powershell'
+
+    A string of standard input can be specified for the command to be run using
+    the ``stdin`` parameter. This can be useful in cases where sensitive
+    information must be read from standard input.
+
+    .. code-block:: bash
+
+        salt '*' cmd.run "grep f" stdin='one\\ntwo\\nthree\\nfour\\nfive\\n'
+
+    If an equal sign (``=``) appears in an argument to a Salt command it is
+    interpreted as a keyword argument in the format ``key=val``. That
+    processing can be bypassed in order to pass an equal sign through to the
+    remote shell command by manually specifying the kwarg:
+
+    .. code-block:: bash
+
+        salt '*' cmd.run cmd='sed -e s/=/:/g'
+    '''
+    python_shell = _python_shell_default(python_shell,
+                                         kwargs.get('__pub_jid', ''))
+    ret = _run(cmd,
+               runas=runas,
+               group=group,
+               shell=shell,
+               python_shell=python_shell,
+               cwd=cwd,
+               stdin=stdin,
+               stderr=subprocess.STDOUT,
+               env=env,
+               clean_env=clean_env,
+               prepend_path=prepend_path,
+               rstrip=rstrip,
+               umask=umask,
+               output_encoding=output_encoding,
+               output_loglevel=output_loglevel,
+               log_callback=log_callback,
+               timeout=timeout,
+               reset_system_locale=reset_system_locale,
+               ignore_retcode=ignore_retcode,
+               saltenv=saltenv,
+               bg=bg,
+               password=password,
+               encoded_cmd=encoded_cmd,
+               success_retcodes=success_retcodes,
+               **kwargs)
+
+    log_callback = _check_cb(log_callback)
+
+    lvl = _check_loglevel(output_loglevel)
+    if lvl is not None:
+        if not ignore_retcode and ret['retcode'] != 0:
+            if lvl < LOG_LEVELS['error']:
+                lvl = LOG_LEVELS['error']
+            msg = (
+                'Command \'{0}\' failed with return code: {1}'.format(
+                    cmd,
+                    ret['retcode']
+                )
+            )
+            log.error(log_callback(msg))
+            if raise_err:
+                raise CommandExecutionError(
+                    log_callback(ret['stdout'] if not hide_output else '')
+                )
+        log.log(lvl, 'output: %s', log_callback(ret['stdout']))
+    return ret['stdout'] if not hide_output else ''

--- a/hubblestack/utils/args.py
+++ b/hubblestack/utils/args.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+'''
+Functions used for CLI argument handling
+'''
+
+import shlex
+import logging
+
+from hubblestack.utils.exceptions import HubbleInvocationError
+import hubblestack.utils.data
+import hubblestack.utils.stringutils
+
+log = logging.getLogger(__name__)
+
+def clean_kwargs(**kwargs):
+    '''
+    Return a dict without any of the __pub* keys (or any other keys starting
+    with a dunder) from the kwargs dict passed into the execution module
+    functions. These keys are useful for tracking what was used to invoke
+    the function call, but they may not be desirable to have if passing the
+    kwargs forward wholesale.
+
+    Usage example:
+
+    .. code-block:: python
+
+        kwargs = __utils__['args.clean_kwargs'](**kwargs)
+    '''
+    ret = {}
+    for key, val in iter(kwargs.items()):
+        if not key.startswith('__'):
+            ret[key] = val
+    return ret
+
+
+def invalid_kwargs(invalid_kwargs, raise_exc=True):
+    '''
+    Raise a HubbleInvocationError if invalid_kwargs is non-empty
+    '''
+    if invalid_kwargs:
+        if isinstance(invalid_kwargs, dict):
+            new_invalid = [
+                '{0}={1}'.format(x, y)
+                for x, y in iter(invalid_kwargs.items())
+            ]
+            invalid_kwargs = new_invalid
+    msg = (
+        'The following keyword arguments are not valid: {0}'
+        .format(', '.join(invalid_kwargs))
+    )
+    if raise_exc:
+        raise HubbleInvocationError(msg)
+    else:
+        return msg
+
+def shlex_split(s, **kwargs):
+    '''
+    Only split if variable is a string
+    '''
+    if isinstance(s, str):
+        return hubblestack.utils.data.decode(
+            shlex.split(hubblestack.utils.stringutils.to_str(s), **kwargs)
+        )
+    else:
+        return s
+

--- a/hubblestack/utils/data.py
+++ b/hubblestack/utils/data.py
@@ -1,0 +1,396 @@
+# -*- coding: utf-8 -*-
+'''
+Functions for manipulating, inspecting, or otherwise working with data types
+and data structures.
+'''
+
+import logging
+
+try:
+    from collections.abc import Mapping, MutableMapping, Sequence
+except ImportError:
+    from collections import Mapping, MutableMapping, Sequence
+
+import hubblestack.utils.stringutils
+
+import salt.utils.yaml
+
+log = logging.getLogger(__name__)
+
+def decode(data, encoding=None, errors='strict', keep=False,
+           normalize=False, preserve_dict_class=False, preserve_tuples=False,
+           to_str=False):
+    '''
+    Generic function which will decode whichever type is passed, if necessary.
+    Optionally use to_str=True to ensure strings are str types and not unicode
+    on Python 2.
+
+    If `strict` is True, and `keep` is False, and we fail to decode, a
+    UnicodeDecodeError will be raised. Passing `keep` as True allows for the
+    original value to silently be returned in cases where decoding fails. This
+    can be useful for cases where the data passed to this function is likely to
+    contain binary blobs, such as in the case of cp.recv.
+
+    If `normalize` is True, then unicodedata.normalize() will be used to
+    normalize unicode strings down to a single code point per glyph. It is
+    recommended not to normalize unless you know what you're doing. For
+    instance, if `data` contains a dictionary, it is possible that normalizing
+    will lead to data loss because the following two strings will normalize to
+    the same value:
+
+    - u'\\u044f\\u0438\\u0306\\u0446\\u0430.txt'
+    - u'\\u044f\\u0439\\u0446\\u0430.txt'
+
+    One good use case for normalization is in the test suite. For example, on
+    some platforms such as Mac OS, os.listdir() will produce the first of the
+    two strings above, in which "й" is represented as two code points (i.e. one
+    for the base character, and one for the breve mark). Normalizing allows for
+    a more reliable test case.
+    '''
+    _decode_func = hubblestack.utils.stringutils.to_unicode \
+        if not to_str \
+        else hubblestack.utils.stringutils.to_str
+    if isinstance(data, Mapping):
+        return decode_dict(data, encoding, errors, keep, normalize,
+                           preserve_dict_class, preserve_tuples, to_str)
+    elif isinstance(data, list):
+        return decode_list(data, encoding, errors, keep, normalize,
+                           preserve_dict_class, preserve_tuples, to_str)
+    elif isinstance(data, tuple):
+        return decode_tuple(data, encoding, errors, keep, normalize,
+                            preserve_dict_class, to_str) \
+            if preserve_tuples \
+            else decode_list(data, encoding, errors, keep, normalize,
+                             preserve_dict_class, preserve_tuples, to_str)
+    else:
+        try:
+            data = _decode_func(data, encoding, errors, normalize)
+        except TypeError:
+            # to_unicode raises a TypeError when input is not a
+            # string/bytestring/bytearray. This is expected and simply means we
+            # are going to leave the value as-is.
+            pass
+        except UnicodeDecodeError:
+            if not keep:
+                raise
+        return data
+
+def encode(data, encoding=None, errors='strict', keep=False,
+           preserve_dict_class=False, preserve_tuples=False):
+    '''
+    Generic function which will encode whichever type is passed, if necessary
+
+    If `strict` is True, and `keep` is False, and we fail to encode, a
+    UnicodeEncodeError will be raised. Passing `keep` as True allows for the
+    original value to silently be returned in cases where encoding fails. This
+    can be useful for cases where the data passed to this function is likely to
+    contain binary blobs.
+    '''
+    if isinstance(data, Mapping):
+        return encode_dict(data, encoding, errors, keep,
+                           preserve_dict_class, preserve_tuples)
+    elif isinstance(data, list):
+        return encode_list(data, encoding, errors, keep,
+                           preserve_dict_class, preserve_tuples)
+    elif isinstance(data, tuple):
+        return encode_tuple(data, encoding, errors, keep, preserve_dict_class) \
+            if preserve_tuples \
+            else encode_list(data, encoding, errors, keep,
+                             preserve_dict_class, preserve_tuples)
+    else:
+        try:
+            return hubblestack.utils.stringutils.to_bytes(data, encoding, errors)
+        except TypeError:
+            # to_bytes raises a TypeError when input is not a
+            # string/bytestring/bytearray. This is expected and simply
+            # means we are going to leave the value as-is.
+            pass
+        except UnicodeEncodeError:
+            if not keep:
+                raise
+        return data
+
+def encode_dict(data, encoding=None, errors='strict', keep=False,
+                preserve_dict_class=False, preserve_tuples=False):
+    '''
+    Encode all string values to bytes
+    '''
+    rv = data.__class__() if preserve_dict_class else {}
+    for key, value in iter(data.items()):
+        if isinstance(key, tuple):
+            key = encode_tuple(key, encoding, errors, keep, preserve_dict_class) \
+                if preserve_tuples \
+                else encode_list(key, encoding, errors, keep,
+                                 preserve_dict_class, preserve_tuples)
+        else:
+            try:
+                key = hubblestack.utils.stringutils.to_bytes(key, encoding, errors)
+            except TypeError:
+                # to_bytes raises a TypeError when input is not a
+                # string/bytestring/bytearray. This is expected and simply
+                # means we are going to leave the value as-is.
+                pass
+            except UnicodeEncodeError:
+                if not keep:
+                    raise
+
+        if isinstance(value, list):
+            value = encode_list(value, encoding, errors, keep,
+                                preserve_dict_class, preserve_tuples)
+        elif isinstance(value, tuple):
+            value = encode_tuple(value, encoding, errors, keep, preserve_dict_class) \
+                if preserve_tuples \
+                else encode_list(value, encoding, errors, keep,
+                                 preserve_dict_class, preserve_tuples)
+        elif isinstance(value, Mapping):
+            value = encode_dict(value, encoding, errors, keep,
+                                preserve_dict_class, preserve_tuples)
+        else:
+            try:
+                value = hubblestack.utils.stringutils.to_bytes(value, encoding, errors)
+            except TypeError:
+                # to_bytes raises a TypeError when input is not a
+                # string/bytestring/bytearray. This is expected and simply
+                # means we are going to leave the value as-is.
+                pass
+            except UnicodeEncodeError:
+                if not keep:
+                    raise
+
+        rv[key] = value
+    return rv
+
+def encode_list(data, encoding=None, errors='strict', keep=False,
+                preserve_dict_class=False, preserve_tuples=False):
+    '''
+    Encode all string values to bytes
+    '''
+    ret_val = []
+    for item in data:
+        if isinstance(item, list):
+            item = encode_list(item, encoding, errors, keep,
+                               preserve_dict_class, preserve_tuples)
+        elif isinstance(item, tuple):
+            item = encode_tuple(item, encoding, errors, keep, preserve_dict_class) \
+                if preserve_tuples \
+                else encode_list(item, encoding, errors, keep,
+                                 preserve_dict_class, preserve_tuples)
+        elif isinstance(item, Mapping):
+            item = encode_dict(item, encoding, errors, keep,
+                               preserve_dict_class, preserve_tuples)
+        else:
+            try:
+                item = hubblestack.utils.stringutils.to_bytes(item, encoding, errors)
+            except TypeError:
+                # to_bytes raises a TypeError when input is not a
+                # string/bytestring/bytearray. This is expected and simply
+                # means we are going to leave the value as-is.
+                pass
+            except UnicodeEncodeError:
+                if not keep:
+                    raise
+
+        ret_val.append(item)
+    return ret_val
+
+
+def encode_tuple(data, encoding=None, errors='strict', keep=False,
+                 preserve_dict_class=False):
+    '''
+    Encode all string values to Unicode
+    '''
+    return tuple(
+        encode_list(data, encoding, errors, keep, preserve_dict_class, True))
+
+def decode_dict(data, encoding=None, errors='strict', keep=False,
+                normalize=False, preserve_dict_class=False,
+                preserve_tuples=False, to_str=False):
+    '''
+    Decode all string values to Unicode. Optionally use to_str=True to ensure
+    strings are str types and not unicode on Python 2.
+    '''
+    _decode_func = hubblestack.utils.stringutils.to_unicode \
+        if not to_str \
+        else hubblestack.utils.stringutils.to_str
+    # Make sure we preserve OrderedDicts
+    ret_val = data.__class__() if preserve_dict_class else {}
+    for key, value in iter(data.items()):
+        if isinstance(key, tuple):
+            key = decode_tuple(key, encoding, errors, keep, normalize,
+                               preserve_dict_class, to_str) \
+                if preserve_tuples \
+                else decode_list(key, encoding, errors, keep, normalize,
+                                 preserve_dict_class, preserve_tuples, to_str)
+        else:
+            try:
+                key = _decode_func(key, encoding, errors, normalize)
+            except TypeError:
+                # to_unicode raises a TypeError when input is not a
+                # string/bytestring/bytearray. This is expected and simply
+                # means we are going to leave the value as-is.
+                pass
+            except UnicodeDecodeError:
+                if not keep:
+                    raise
+
+        if isinstance(value, list):
+            value = decode_list(value, encoding, errors, keep, normalize,
+                                preserve_dict_class, preserve_tuples, to_str)
+        elif isinstance(value, tuple):
+            value = decode_tuple(value, encoding, errors, keep, normalize,
+                                 preserve_dict_class, to_str) \
+                if preserve_tuples \
+                else decode_list(value, encoding, errors, keep, normalize,
+                                 preserve_dict_class, preserve_tuples, to_str)
+        elif isinstance(value, Mapping):
+            value = decode_dict(value, encoding, errors, keep, normalize,
+                                preserve_dict_class, preserve_tuples, to_str)
+        else:
+            try:
+                value = _decode_func(value, encoding, errors, normalize)
+            except TypeError:
+                # to_unicode raises a TypeError when input is not a
+                # string/bytestring/bytearray. This is expected and simply
+                # means we are going to leave the value as-is.
+                pass
+            except UnicodeDecodeError:
+                if not keep:
+                    raise
+
+        ret_val[key] = value
+    return ret_val
+
+def decode_list(data, encoding=None, errors='strict', keep=False,
+                normalize=False, preserve_dict_class=False,
+                preserve_tuples=False, to_str=False):
+    '''
+    Decode all string values to Unicode. Optionally use to_str=True to ensure
+    strings are str types and not unicode on Python 2.
+    '''
+    _decode_func = hubblestack.utils.stringutils.to_unicode \
+        if not to_str \
+        else hubblestack.utils.stringutils.to_str
+    ret_val = []
+    for item in data:
+        if isinstance(item, list):
+            item = decode_list(item, encoding, errors, keep, normalize,
+                               preserve_dict_class, preserve_tuples, to_str)
+        elif isinstance(item, tuple):
+            item = decode_tuple(item, encoding, errors, keep, normalize,
+                                preserve_dict_class, to_str) \
+                if preserve_tuples \
+                else decode_list(item, encoding, errors, keep, normalize,
+                                 preserve_dict_class, preserve_tuples, to_str)
+        elif isinstance(item, Mapping):
+            item = decode_dict(item, encoding, errors, keep, normalize,
+                               preserve_dict_class, preserve_tuples, to_str)
+        else:
+            try:
+                item = _decode_func(item, encoding, errors, normalize)
+            except TypeError:
+                # to_unicode raises a TypeError when input is not a
+                # string/bytestring/bytearray. This is expected and simply
+                # means we are going to leave the value as-is.
+                pass
+            except UnicodeDecodeError:
+                if not keep:
+                    raise
+
+        ret_val.append(item)
+    return ret_val
+
+
+def decode_tuple(data, encoding=None, errors='strict', keep=False,
+                 normalize=False, preserve_dict_class=False, to_str=False):
+    '''
+    Decode all string values to Unicode. Optionally use to_str=True to ensure
+    strings are str types and not unicode on Python 2.
+    '''
+    return tuple(
+        decode_list(data, encoding, errors, keep, normalize,
+                    preserve_dict_class, True, to_str)
+    )
+
+def repack_dictlist(data,
+                    strict=False,
+                    recurse=False,
+                    key_cb=None,
+                    val_cb=None):
+    '''
+    Takes a list of one-element dicts (as found in many SLS schemas) and
+    repacks into a single dictionary.
+    '''
+    if isinstance(data, str):
+        try:
+            data = salt.utils.yaml.safe_load(data)
+        except salt.utils.yaml.parser.ParserError as err:
+            log.error(err)
+            return {}
+
+    if key_cb is None:
+        key_cb = lambda x: x
+    if val_cb is None:
+        val_cb = lambda x, y: y
+
+    valid_non_dict = (str, int, float)
+    if isinstance(data, list):
+        for element in data:
+            if isinstance(element, valid_non_dict):
+                continue
+            elif isinstance(element, dict):
+                if len(element) != 1:
+                    log.error(
+                        'Invalid input for repack_dictlist: key/value pairs '
+                        'must contain only one element (data passed: %s).',
+                        element
+                    )
+                    return {}
+            else:
+                log.error(
+                    'Invalid input for repack_dictlist: element %s is '
+                    'not a string/dict/numeric value', element
+                )
+                return {}
+    else:
+        log.error(
+            'Invalid input for repack_dictlist, data passed is not a list '
+            '(%s)', data
+        )
+        return {}
+
+    ret = {}
+    for element in data:
+        if isinstance(element, valid_non_dict):
+            ret[key_cb(element)] = None
+        else:
+            key = next(iter(element))
+            val = element[key]
+            if is_dictlist(val):
+                if recurse:
+                    ret[key_cb(key)] = repack_dictlist(val, recurse=recurse)
+                elif strict:
+                    log.error(
+                        'Invalid input for repack_dictlist: nested dictlist '
+                        'found, but recurse is set to False'
+                    )
+                    return {}
+                else:
+                    ret[key_cb(key)] = val_cb(key, val)
+            else:
+                ret[key_cb(key)] = val_cb(key, val)
+    return ret
+
+def is_dictlist(data):
+    '''
+    Returns True if data is a list of one-element dicts (as found in many SLS
+    schemas), otherwise returns False
+    '''
+    if isinstance(data, list):
+        for element in data:
+            if isinstance(element, dict):
+                if len(element) != 1:
+                    return False
+            else:
+                return False
+        return True
+    return False

--- a/hubblestack/utils/exceptions.py
+++ b/hubblestack/utils/exceptions.py
@@ -2,8 +2,6 @@
 '''
 This module is a central location for all hubble exceptions
 '''
-from __future__ import absolute_import, print_function, unicode_literals
-
 # Import python libs
 import copy
 import logging
@@ -61,6 +59,17 @@ class CommandExecutionError(HubbleException):
         # message.
         super(CommandExecutionError, self).__init__(exc_str)
 
+class TimedProcTimeoutError(HubbleException):
+    '''
+    Thrown when a timed subprocess does not terminate within the timeout,
+    or if the specified timeout is not an int or a float
+    '''
+
+class HubbleInvocationError(HubbleException, TypeError):
+    '''
+    Used when the wrong number of arguments are sent to modules or invalid
+    arguments are specified on the command line
+    '''
 
 class LoaderError(HubbleException):
     '''

--- a/hubblestack/utils/files.py
+++ b/hubblestack/utils/files.py
@@ -1,0 +1,168 @@
+# -*- coding: utf-8 -*-
+'''
+Functions for working with files
+'''
+
+# Import Python libs
+import contextlib
+import errno
+import logging
+import os
+
+import hubblestack.utils.stringutils
+import hubblestack.utils.exceptions
+
+try:
+    import fcntl
+    HAS_FCNTL = True
+except ImportError:
+    # fcntl is not available on windows
+    HAS_FCNTL = False
+
+log = logging.getLogger(__name__)
+
+def fopen(*args, **kwargs):
+    '''
+    Wrapper around open() built-in to set CLOEXEC on the fd.
+
+    This flag specifies that the file descriptor should be closed when an exec
+    function is invoked;
+
+    When a file descriptor is allocated (as with open or dup), this bit is
+    initially cleared on the new file descriptor, meaning that descriptor will
+    survive into the new program after exec.
+
+    NB! We still have small race condition between open and fcntl.
+    '''
+    try:
+        # Don't permit stdin/stdout/stderr to be opened. The boolean False
+        # and True are treated by Python 3's open() as file descriptors 0
+        # and 1, respectively.
+        if args[0] in (0, 1, 2):
+            raise TypeError(
+                '{0} is not a permitted file descriptor'.format(args[0])
+            )
+    except IndexError:
+        pass
+    binary = None
+    if 'encoding' not in kwargs:
+        # if text mode is used and the encoding
+        # is not specified, set the encoding to 'utf-8'.
+        binary = False
+        if len(args) > 1:
+            args = list(args)
+            if 'b' in args[1]:
+                binary = True
+        if kwargs.get('mode', None):
+            if 'b' in kwargs['mode']:
+                binary = True
+        if not binary:
+            kwargs['encoding'] = __salt_system_encoding__
+    elif (kwargs.pop('binary', False)):
+        if len(args) > 1:
+            args = list(args)
+            if 'b' not in args[1]:
+                args[1] = args[1].replace('t', 'b')
+                if 'b' not in args[1]:
+                    args[1] += 'b'
+        elif kwargs.get('mode'):
+            if 'b' not in kwargs['mode']:
+                kwargs['mode'] = kwargs['mode'].replace('t', 'b')
+                if 'b' not in kwargs['mode']:
+                    kwargs['mode'] += 'b'
+        else:
+            # the default is to read
+            kwargs['mode'] = 'rb'
+
+    if not binary and not kwargs.get('newline', None):
+        kwargs['newline'] = ''
+
+    f_handle = open(*args, **kwargs)  # pylint: disable=resource-leakage
+
+    if is_fcntl_available():
+        # modify the file descriptor on systems with fcntl
+        # unix and unix-like systems only
+        try:
+            FD_CLOEXEC = fcntl.FD_CLOEXEC   # pylint: disable=C0103
+        except AttributeError:
+            FD_CLOEXEC = 1                  # pylint: disable=C0103
+        old_flags = fcntl.fcntl(f_handle.fileno(), fcntl.F_GETFD)
+        fcntl.fcntl(f_handle.fileno(), fcntl.F_SETFD, old_flags | FD_CLOEXEC)
+
+    return f_handle
+
+def is_fcntl_available():
+    '''
+    Simple function to check if the ``fcntl`` module is available or not.
+    '''
+    return HAS_FCNTL
+
+@contextlib.contextmanager
+def flopen(*args, **kwargs):
+    '''
+    Shortcut for fopen with lock and context manager.
+    '''
+    filename, args = args[0], args[1:]
+    writing = 'wa'
+    with fopen(filename, *args, **kwargs) as f_handle:
+        try:
+            if is_fcntl_available(check_sunos=True):
+                lock_type = fcntl.LOCK_SH
+                if args and any([write in args[0] for write in writing]):
+                    lock_type = fcntl.LOCK_EX
+                fcntl.flock(f_handle.fileno(), lock_type)
+            yield f_handle
+        finally:
+            if is_fcntl_available(check_sunos=True):
+                fcntl.flock(f_handle.fileno(), fcntl.LOCK_UN)
+
+def is_binary(path):
+    '''
+    Detects if the file is a binary, returns bool. Returns True if the file is
+    a bin, False if the file is not and None if the file is not available.
+    '''
+    if not os.path.isfile(path):
+        return False
+    try:
+        with fopen(path, 'rb') as fp_:
+            try:
+                data = fp_.read(2048)
+                data = data.decode(__salt_system_encoding__)
+                return hubblestack.utils.stringutils.is_binary(data)
+            except UnicodeDecodeError:
+                return True
+    except os.error:
+        return False
+
+def remove(path):
+    '''
+    Runs os.remove(path) and suppresses the OSError if the file doesn't exist
+    '''
+    try:
+        os.remove(path)
+    except OSError as exc:
+        if exc.errno != errno.ENOENT:
+            raise
+
+def rename(src, dst):
+    '''
+    On Windows, os.rename() will fail with a WindowsError exception if a file
+    exists at the destination path. This function checks for this error and if
+    found, it deletes the destination path first.
+    '''
+    try:
+        os.rename(src, dst)
+    except OSError as exc:
+        if exc.errno != errno.EEXIST:
+            raise
+        try:
+            os.remove(dst)
+        except OSError as exc:
+            if exc.errno != errno.ENOENT:
+                raise hubblestack.utils.exceptions.HubbleError(
+                    'Error: Unable to remove {0}: {1}'.format(
+                        dst,
+                        exc.strerror
+                    )
+                )
+        os.rename(src, dst)

--- a/hubblestack/utils/path.py
+++ b/hubblestack/utils/path.py
@@ -1,0 +1,161 @@
+# -*- coding: utf-8 -*-
+'''
+Platform independent versions of some os/os.path functions. Gets around PY2's
+lack of support for reading NTFS links.
+'''
+
+# Import python libs
+import logging
+import collections
+import os
+import posixpath
+import re
+
+import hubblestack.utils.stringutils
+import hubblestack.utils.args
+import hubblestack.utils.data
+from hubblestack.utils.decorators.memoize import memoize
+
+log = logging.getLogger(__name__)
+
+def which(exe=None):
+    '''
+    Python clone of /usr/bin/which
+    '''
+    def _is_executable_file_or_link(exe):
+        # check for os.X_OK doesn't suffice because directory may executable
+        return (os.access(exe, os.X_OK) and
+                (os.path.isfile(exe) or os.path.islink(exe)))
+
+    if exe:
+        if _is_executable_file_or_link(exe):
+            # executable in cwd or fullpath
+            return exe
+
+        ext_list = hubblestack.utils.stringutils.to_str(
+            os.environ.get('PATHEXT', str('.EXE'))
+        ).split(str(';'))
+
+        @memoize
+        def _exe_has_ext():
+            '''
+            Do a case insensitive test if exe has a file extension match in
+            PATHEXT
+            '''
+            for ext in ext_list:
+                try:
+                    pattern = r'.*\.{0}$'.format(
+                        hubblestack.utils.stringutils.to_unicode(ext).lstrip('.')
+                    )
+                    re.match(
+                        pattern,
+                        hubblestack.utils.stringutils.to_unicode(exe),
+                        re.I).groups()
+                    return True
+                except AttributeError:
+                    continue
+            return False
+
+        # Enhance POSIX path for the reliability at some environments, when $PATH is changing
+        # This also keeps order, where 'first came, first win' for cases to find optional alternatives
+        system_path = hubblestack.utils.stringutils.to_unicode(os.environ.get('PATH', ''))
+        search_path = system_path.split(os.pathsep)
+        if not hubblestack.utils.platform.is_windows():
+            search_path.extend([
+                x for x in ('/bin', '/sbin', '/usr/bin',
+                            '/usr/sbin', '/usr/local/bin')
+                if x not in search_path
+            ])
+
+        for path in search_path:
+            full_path = join(path, exe)
+            if _is_executable_file_or_link(full_path):
+                return full_path
+            elif hubblestack.utils.platform.is_windows() and not _exe_has_ext():
+                # On Windows, check for any extensions in PATHEXT.
+                # Allows both 'cmd' and 'cmd.exe' to be matched.
+                for ext in ext_list:
+                    # Windows filesystem is case insensitive so we
+                    # safely rely on that behavior
+                    if _is_executable_file_or_link(full_path + ext):
+                        return full_path + ext
+        log.trace(
+            '\'%s\' could not be found in the following search path: \'%s\'',
+            exe, search_path
+        )
+    else:
+        log.error('No executable was passed to be searched by hubblestack.utils.path.which()')
+
+    return None
+
+def which_bin(exes):
+    '''
+    Scan over some possible executables and return the first one that is found
+    '''
+    if not isinstance(exes, collections.Iterable):
+        return None
+    for exe in exes:
+        path = which(exe)
+        if not path:
+            continue
+        return path
+    return None
+
+def join(*parts, **kwargs):
+    '''
+    This functions tries to solve some issues when joining multiple absolute
+    paths on both *nix and windows platforms.
+
+    The "use_posixpath" kwarg can be be used to force joining using poxixpath,
+    which is useful for fileserver paths on Windows
+    '''
+    new_parts = []
+    for part in parts:
+        new_parts.append(hubblestack.utils.stringutils.to_str(part))
+    parts = new_parts
+
+    kwargs = hubblestack.utils.args.clean_kwargs(**kwargs)
+    use_posixpath = kwargs.pop('use_posixpath', False)
+    if kwargs:
+        hubblestack.utils.args.invalid_kwargs(kwargs)
+
+    pathlib = posixpath if use_posixpath else os.path
+
+    # Normalize path converting any os.sep as needed
+    parts = [pathlib.normpath(p) for p in parts]
+
+    try:
+        root = parts.pop(0)
+    except IndexError:
+        # No args passed to func
+        return ''
+
+    root = hubblestack.utils.stringutils.to_unicode(root)
+    if not parts:
+        ret = root
+    else:
+        stripped = [p.lstrip(os.sep) for p in parts]
+        ret = pathlib.join(root, *hubblestack.utils.data.decode(stripped))
+    return pathlib.normpath(ret)
+
+def islink(path):
+    '''
+    call to os.path.islink()
+    '''
+    return os.path.islink(path)
+
+def readlink(path):
+    '''
+    call to os.readlink()
+    '''
+    return os.readlink(path)
+
+def os_walk(top, *args, **kwargs):
+    '''
+    This is a helper than ensures that all paths returned from os.walk are
+    unicode.
+    '''
+    top_query = hubblestack.utils.stringutils.to_str(top)
+    for item in os.walk(top_query, *args, **kwargs):
+        yield hubblestack.utils.data.decode(item, preserve_tuples=True)
+

--- a/hubblestack/utils/stringutils.py
+++ b/hubblestack/utils/stringutils.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+'''
+Functions for manipulating or otherwise processing strings
+'''
+
+# Import Python libs
+import logging
+import unicodedata
+
+log = logging.getLogger(__name__)
+
+def to_unicode(string_to_convert, encoding=None, errors='strict', normalize=False):
+    '''
+    Given str or unicode, return unicode (str for python 3)
+    '''
+    if encoding is None:
+        # Try utf-8 first, and fall back to detected encoding
+        encoding = ('utf-8', __salt_system_encoding__)
+    if not isinstance(encoding, (tuple, list)):
+        encoding = (encoding,)
+
+    if not encoding:
+        raise ValueError('encoding cannot be empty')
+
+    if isinstance(string_to_convert, str):
+        return _normalize(string_to_convert, normalize)
+    elif isinstance(string_to_convert, (bytes, bytearray)):
+        return _normalize(to_str(string_to_convert, encoding, errors), normalize)
+    raise TypeError('expected str, bytes, or bytearray')
+
+def to_bytes(string_to_convert, encoding=None, errors='strict'):
+    '''
+    Given bytes, bytearray, str, or unicode, return bytes
+    '''
+    if encoding is None:
+        # Try utf-8 first, and fall back to detected encoding
+        encoding = ('utf-8', __salt_system_encoding__)
+    if not isinstance(encoding, (tuple, list)):
+        encoding = (encoding,)
+
+    if not encoding:
+        raise ValueError('encoding cannot be empty')
+
+    exc = None
+    if isinstance(string_to_convert, bytes):
+        return string_to_convert
+    if isinstance(string_to_convert, bytearray):
+        return bytes(string_to_convert)
+    if isinstance(string_to_convert, str):
+        for enc in encoding:
+            try:
+                return string_to_convert.encode(enc, errors)
+            except UnicodeEncodeError as err:
+                exc = err
+                continue
+        # The only way we get this far is if a UnicodeEncodeError was
+        # raised, otherwise we would have already returned (or raised some
+        # other exception).
+        raise exc  # pylint: disable=raising-bad-type
+    raise TypeError('expected bytes, bytearray, or str')
+
+def to_str(string_to_convert, encoding=None, errors='strict', normalize=False):
+    '''
+    Given str, bytes, bytearray, or unicode (py2), return str
+    '''
+    if encoding is None:
+        # Try utf-8 first, and fall back to detected encoding
+        encoding = ('utf-8', __salt_system_encoding__)
+    if not isinstance(encoding, (tuple, list)):
+        encoding = (encoding,)
+
+    if not encoding:
+        raise ValueError('encoding cannot be empty')
+
+    # This shouldn't be six.string_types because if we're on PY2 and we already
+    # have a string, we should just return it.
+    if isinstance(string_to_convert, str):
+        return _normalize(string_to_convert, normalize)
+
+    exc = None
+    if isinstance(string_to_convert, (bytes, bytearray)):
+        for enc in encoding:
+            try:
+                return _normalize(string_to_convert.decode(enc, errors), normalize)
+            except UnicodeDecodeError as err:
+                exc = err
+                continue
+        # The only way we get this far is if a UnicodeDecodeError was
+        # raised, otherwise we would have already returned (or raised some
+        # other exception).
+        raise exc  # pylint: disable=raising-bad-type
+    raise TypeError('expected str, bytes, or bytearray not {}'.format(type(string_to_convert)))
+
+def _normalize(string_to_convert, normalize=False):
+    '''
+    a utility method for normalizing string
+    '''
+    try:
+        return unicodedata.normalize('NFC', string_to_convert) if normalize else string_to_convert
+    except TypeError:
+        return string_to_convert
+
+def is_binary(data):
+    '''
+    Detects if the passed string of data is binary or text
+    '''
+    if not data or not isinstance(data, (str, bytes)):
+        return False
+
+    if isinstance(data, bytes):
+        if b'\0' in data:
+            return True
+    elif str('\0') in data:
+        return True
+
+    text_characters = ''.join([chr(x) for x in range(32, 127)] + list('\n\r\t\b'))
+    # Get the non-text characters (map each character to itself then use the
+    # 'remove' option to get rid of the text characters.)
+    if isinstance(data, bytes):
+        import hubblestack.utils.data
+        nontext = data.translate(None, hubblestack.utils.data.encode(text_characters))
+    else:
+        trans = ''.maketrans('', '', text_characters)
+        nontext = data.translate(trans)
+
+    # If more than 30% non-text characters, then
+    # this is considered binary data
+    if float(len(nontext)) / len(data) > 0.30:
+        return True
+    return False

--- a/hubblestack/utils/timed_subprocess.py
+++ b/hubblestack/utils/timed_subprocess.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+'''
+For running command line executables with a timeout
+'''
+
+import shlex
+import subprocess
+import threading
+import hubblestack.utils.exceptions
+import hubblestack.utils.data
+import hubblestack.utils.stringutils
+
+class TimedProc(object):
+    '''
+    Create a TimedProc object, calls subprocess.Popen with passed args and **kwargs
+    '''
+    def __init__(self, args, **kwargs):
+
+        self.wait = not kwargs.pop('bg', False)
+        self.stdin = kwargs.pop('stdin', None)
+        self.with_communicate = kwargs.pop('with_communicate', self.wait)
+        self.timeout = kwargs.pop('timeout', None)
+        self.stdin_raw_newlines = kwargs.pop('stdin_raw_newlines', False)
+
+        # If you're not willing to wait for the process
+        # you can't define any stdin, stdout or stderr
+        if not self.wait:
+            self.stdin = kwargs['stdin'] = None
+            self.with_communicate = False
+        elif self.stdin is not None:
+            if not self.stdin_raw_newlines:
+                # Translate a newline submitted as '\n' on the CLI to an actual
+                # newline character.
+                self.stdin = hubblestack.utils.stringutils.to_bytes(self.stdin.replace('\\n', '\n'))
+            kwargs['stdin'] = subprocess.PIPE
+
+        if not self.with_communicate:
+            self.stdout = kwargs['stdout'] = None
+            self.stderr = kwargs['stderr'] = None
+
+        if self.timeout and not isinstance(self.timeout, (int, float)):
+            raise hubblestack.utils.exceptions.TimedProcTimeoutError('Error: timeout {0} must be a number'.format(self.timeout))
+        if kwargs.get('shell', False):
+            args = hubblestack.utils.data.decode(args, to_str=True)
+
+        try:
+            self.process = subprocess.Popen(args, **kwargs)
+        except (AttributeError, TypeError):
+            if not kwargs.get('shell', False):
+                if not isinstance(args, (list, tuple)):
+                    try:
+                        args = shlex.split(args)
+                    except AttributeError:
+                        args = shlex.split(str(args))
+                str_args = []
+                for arg in args:
+                    if not isinstance(arg, str):
+                        str_args.append(str(arg))
+                    else:
+                        str_args.append(arg)
+                args = str_args
+            else:
+                if not isinstance(args, (list, tuple, str)):
+                    # Handle corner case where someone does a 'cmd.run 3'
+                    args = str(args)
+            # Ensure that environment variables are strings
+            for key, val in iter(kwargs.get('env', {}).items()):
+                if not isinstance(val, str):
+                    kwargs['env'][key] = str(val)
+                if not isinstance(key, str):
+                    kwargs['env'][str(key)] = kwargs['env'].pop(key)
+            args = hubblestack.utils.data.decode(args)
+            self.process = subprocess.Popen(args, **kwargs)
+        self.command = args
+
+    def run(self):
+        '''
+        wait for subprocess to terminate and return subprocess' return code.
+        If timeout is reached, throw TimedProcTimeoutError
+        '''
+        def receive():
+            if self.with_communicate:
+                self.stdout, self.stderr = self.process.communicate(input=self.stdin)
+            elif self.wait:
+                self.process.wait()
+
+        if not self.timeout:
+            receive()
+        else:
+            rt = threading.Thread(target=receive)
+            rt.start()
+            rt.join(self.timeout)
+            if rt.isAlive():
+                # Subprocess cleanup (best effort)
+                self.process.kill()
+
+                def terminate():
+                    if rt.isAlive():
+                        self.process.terminate()
+                threading.Timer(10, terminate).start()
+                raise hubblestack.utils.exceptions.TimedProcTimeoutError(
+                    '{0} : Timed out after {1} seconds'.format(
+                        self.command,
+                        str(self.timeout),
+                    )
+                )
+        return self.process.returncode


### PR DESCRIPTION
- moved salt.utils.stringutils to hubblestack.utils.stringutils
  - Removed JinjaFilters as this is for some templating that we dont need
- moved salt.utils.path to hubblestack.utils.path
- moved salt.utils.args to hubblestack.utils.args
- moved salt.utils.data to hubblestack.utils.data
- moved salt.utils.files to hubblestack.utils.files
- Misc
  - Added a new exception: HubbleInvocationError
  - Added new encoding method in utils.__init__.py
- moved salt.modules.cmdmod.py to hubblestack.modules.cmdmod.py
  - removed jinja templating code
  - remove vt-terminal code
- moved salt.utils.timed_subprocess to hubblestack.utils.timed_subprocess
