### PR TITLE
Salt-less work - Bringing all dependencies for grains

### DIFF
--- a/hubblestack/grains/default_gw.py
+++ b/hubblestack/grains/default_gw.py
@@ -19,7 +19,6 @@ List of grains:
 
 import logging
 
-import salt.utils
 import hubblestack.utils.path
 
 import hubblestack.modules.cmdmod

--- a/hubblestack/grains/extra.py
+++ b/hubblestack/grains/extra.py
@@ -8,11 +8,10 @@ import os
 # Import third party libs
 import logging
 
-# Import salt libs
 import hubblestack.utils.data
 import hubblestack.utils.files
 import hubblestack.utils.platform
-import salt.utils.yaml
+import hubblestack.utils.yaml
 
 __proxyenabled__ = ['*']
 log = logging.getLogger(__name__)
@@ -70,7 +69,7 @@ def config():
         log.debug('Loading static grains from %s', gfn)
         with hubblestack.utils.files.fopen(gfn, 'rb') as fp_:
             try:
-                return hubblestack.utils.data.decode(salt.utils.yaml.safe_load(fp_))
+                return hubblestack.utils.data.decode(hubblestack.utils.yaml.safe_load(fp_))
             except Exception:
                 log.warning("Bad syntax in grains file! Skipping.")
                 return {}

--- a/hubblestack/grains/fqdn.py
+++ b/hubblestack/grains/fqdn.py
@@ -4,7 +4,6 @@ Custom grains around fqdn
 """
 import hubblestack.grains.hubble_core
 import hubblestack.modules.cmdmod
-import salt.utils
 import hubblestack.utils.platform
 
 __salt__ = {'cmd.run': hubblestack.modules.cmdmod._run_quiet,

--- a/hubblestack/grains/osqueryinfo.py
+++ b/hubblestack/grains/osqueryinfo.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """ Handle metadata about osquery: return version and path as grains """
 
-import salt.utils
 import hubblestack.utils.path
 import hubblestack.modules.cmdmod
 

--- a/hubblestack/grains/zfs.py
+++ b/hubblestack/grains/zfs.py
@@ -4,7 +4,6 @@ ZFS grain provider
 
 :maintainer:    Jorge Schrauwen <sjorge@blackdot.be>
 :maturity:      new
-:depends:       salt.utils, salt.module.cmdmod
 :platform:      illumos,freebsd,linux
 
 .. versionadded:: 2018.3.0
@@ -16,24 +15,24 @@ from __future__ import absolute_import, print_function, unicode_literals
 import logging
 
 # Import salt libs
-import salt.utils.dictupdate
+import hubblestack.utils.dictupdate
 import hubblestack.utils.path
 import hubblestack.utils.platform
 
 # Solve the Chicken and egg problem where grains need to run before any
 # of the modules are loaded and are generally available for any usage.
 import hubblestack.modules.cmdmod
-import salt.utils.zfs
+import hubblestack.utils.zfs
 
 __virtualname__ = 'zfs'
 __salt__ = {
     'cmd.run': hubblestack.modules.cmdmod.run,
 }
 __utils__ = {
-    'zfs.is_supported': salt.utils.zfs.is_supported,
-    'zfs.has_feature_flags': salt.utils.zfs.has_feature_flags,
-    'zfs.zpool_command': salt.utils.zfs.zpool_command,
-    'zfs.to_size': salt.utils.zfs.to_size,
+    'zfs.is_supported': hubblestack.utils.zfs.is_supported,
+    'zfs.has_feature_flags': hubblestack.utils.zfs.has_feature_flags,
+    'zfs.zpool_command': hubblestack.utils.zfs.zpool_command,
+    'zfs.to_size': hubblestack.utils.zfs.to_size,
 }
 
 log = logging.getLogger(__name__)
@@ -81,7 +80,7 @@ def zfs():
     grains['zfs_support'] = __utils__['zfs.is_supported']()
     grains['zfs_feature_flags'] = __utils__['zfs.has_feature_flags']()
     if grains['zfs_support']:
-        grains = salt.utils.dictupdate.update(grains, _zfs_pool_data(), merge_lists=True)
+        grains = hubblestack.utils.dictupdate.update(grains, _zfs_pool_data(), merge_lists=True)
 
     return grains
 

--- a/hubblestack/utils/dictupdate.py
+++ b/hubblestack/utils/dictupdate.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+'''
+Alex Martelli's soulution for recursive dict update from
+http://stackoverflow.com/a/3233356
+'''
+
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
+
+# Import 3rd-party libs
+import copy
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def update(dest, upd, recursive_update=True, merge_lists=False):
+    '''
+    Recursive version of the default dict.update
+
+    Merges upd recursively into dest
+
+    If recursive_update=False, will use the classic dict.update, or fall back
+    on a manual merge (helpful for non-dict types like FunctionWrapper)
+
+    If merge_lists=True, will aggregate list object types instead of replace.
+    The list in ``upd`` is added to the list in ``dest``, so the resulting list
+    is ``dest[key] + upd[key]``. This behavior is only activated when
+    recursive_update=True. By default merge_lists=False.
+
+    .. versionchanged: 2016.11.6
+        When merging lists, duplicate values are removed. Values already
+        present in the ``dest`` list are not added from the ``upd`` list.
+    '''
+    if (not isinstance(dest, Mapping)) \
+            or (not isinstance(upd, Mapping)):
+        raise TypeError('Cannot update using non-dict types in dictupdate.update()')
+    updkeys = list(upd.keys())
+    if not set(list(dest.keys())) & set(updkeys):
+        recursive_update = False
+    if recursive_update:
+        for key in updkeys:
+            val = upd[key]
+            try:
+                dest_subkey = dest.get(key, None)
+            except AttributeError:
+                dest_subkey = None
+            if isinstance(dest_subkey, Mapping) \
+                    and isinstance(val, Mapping):
+                ret = update(dest_subkey, val, merge_lists=merge_lists)
+                dest[key] = ret
+            elif isinstance(dest_subkey, list) \
+                     and isinstance(val, list):
+                if merge_lists:
+                    merged = copy.deepcopy(dest_subkey)
+                    merged.extend([x for x in val if x not in merged])
+                    dest[key] = merged
+                else:
+                    dest[key] = upd[key]
+            else:
+                dest[key] = upd[key]
+        return dest
+    else:
+        try:
+            for k in upd:
+                dest[k] = upd[k]
+        except AttributeError:
+            # this mapping is not a dict
+            for k in upd:
+                dest[k] = upd[k]
+        return dest
+

--- a/hubblestack/utils/odict.py
+++ b/hubblestack/utils/odict.py
@@ -1,0 +1,344 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: Pedro Algarvio (pedro@algarvio.me)
+
+
+    salt.utils.odict
+    ~~~~~~~~~~~~~~~~
+
+    This is a compatibility/"importability" layer for an ordered dictionary.
+    Tries to import from the standard library if python >= 2.7, then from the
+    ``ordereddict`` package available from PyPi, and, as a last resort,
+    provides an ``OrderedDict`` implementation based on::
+
+        http://code.activestate.com/recipes/576669/
+
+    It also implements a DefaultOrderedDict Class that serves  as a
+    combination of ``OrderedDict`` and ``defaultdict``
+    It's source was submitted here::
+
+        http://stackoverflow.com/questions/6190331/
+'''
+
+try:
+    from collections.abc import Callable
+except ImportError:
+    from collections import Callable
+
+try:
+    import collections
+
+    class OrderedDict(collections.OrderedDict):
+        __hash__ = None
+except (ImportError, AttributeError):
+    try:
+        import ordereddict
+
+        class OrderedDict(ordereddict.OrderedDict):  # pylint: disable=W0232
+            __hash_ = None
+    except ImportError:
+        # {{{ http://code.activestate.com/recipes/576693/ (r9)
+        # Backport of OrderedDict() class that runs on Python 2.4, 2.5, 2.6, 2.7 and pypy.
+        # Passes Python2.7's test suite and incorporates all the latest updates.
+
+        try:
+            from _thread import get_ident as _get_ident
+        except ImportError:
+            from _dummy_thread import get_ident as _get_ident
+
+        class OrderedDict(dict):
+            'Dictionary that remembers insertion order'
+            # An inherited dict maps keys to values.
+            # The inherited dict provides __getitem__, __len__, __contains__, and get.
+            # The remaining methods are order-aware.
+            # Big-O running times for all methods are the same as for regular dictionaries.
+
+            # The internal self.__map dictionary maps keys to links in a doubly linked list.
+            # The circular doubly linked list starts and ends with a sentinel element.
+            # The sentinel element never gets deleted (this simplifies the algorithm).
+            # Each link is stored as a list of length three:  [PREV, NEXT, KEY].
+            __hash_ = None
+
+            def __init__(self, *args, **kwds):  # pylint: disable=E1003
+                '''Initialize an ordered dictionary.  Signature is the same as for
+                regular dictionaries, but keyword arguments are not recommended
+                because their insertion order is arbitrary.
+
+                '''
+                super(OrderedDict, self).__init__()  # pylint: disable=E1003
+                if len(args) > 1:
+                    raise TypeError(
+                        'expected at most 1 arguments, got {0}'.format(len(args))
+                    )
+                try:
+                    self.__root
+                except AttributeError:
+                    self.__root = root = []                     # sentinel node
+                    root[:] = [root, root, None]
+                    self.__map = {}
+                self.__update(*args, **kwds)
+
+            def __setitem__(self, key, value, dict_setitem=dict.__setitem__):
+                'od.__setitem__(i, y) <==> od[i]=y'
+                # Setting a new item creates a new link which goes at the end of the linked
+                # list, and the inherited dictionary is updated with the new key/value pair.
+                if key not in self:
+                    root = self.__root
+                    last = root[0]
+                    last[1] = root[0] = self.__map[key] = [last, root, key]
+                dict_setitem(self, key, value)
+
+            def __delitem__(self, key, dict_delitem=dict.__delitem__):
+                'od.__delitem__(y) <==> del od[y]'
+                # Deleting an existing item uses self.__map to find the link which is
+                # then removed by updating the links in the predecessor and successor nodes.
+                dict_delitem(self, key)
+                link_prev, link_next, key = self.__map.pop(key)
+                link_prev[1] = link_next
+                link_next[0] = link_prev
+
+            def __iter__(self):
+                'od.__iter__() <==> iter(od)'
+                root = self.__root
+                curr = root[1]
+                while curr is not root:
+                    yield curr[2]
+                    curr = curr[1]
+
+            def __reversed__(self):
+                'od.__reversed__() <==> reversed(od)'
+                root = self.__root
+                curr = root[0]
+                while curr is not root:
+                    yield curr[2]
+                    curr = curr[0]
+
+            def clear(self):
+                'od.clear() -> None.  Remove all items from od.'
+                try:
+                    for node in six.itervalues(self.__map):
+                        del node[:]
+                    root = self.__root
+                    root[:] = [root, root, None]
+                    self.__map.clear()
+                except AttributeError:
+                    pass
+                dict.clear(self)
+
+            def popitem(self, last=True):
+                '''od.popitem() -> (k, v), return and remove a (key, value) pair.
+                Pairs are returned in LIFO order if last is true or FIFO order if false.
+
+                '''
+                if not self:
+                    raise KeyError('dictionary is empty')
+                root = self.__root
+                if last:
+                    link = root[0]
+                    link_prev = link[0]
+                    link_prev[1] = root
+                    root[0] = link_prev
+                else:
+                    link = root[1]
+                    link_next = link[1]
+                    root[1] = link_next
+                    link_next[0] = root
+                key = link[2]
+                del self.__map[key]
+                value = dict.pop(self, key)
+                return key, value
+
+            # -- the following methods do not depend on the internal structure --
+
+            def keys(self):
+                'od.keys() -> list of keys in od'
+                return list(self)
+
+            def values(self):
+                'od.values() -> list of values in od'
+                return [self[key] for key in self]
+
+            def items(self):
+                'od.items() -> list of (key, value) pairs in od'
+                return [(key, self[key]) for key in self]
+
+            def iterkeys(self):
+                'od.iterkeys() -> an iterator over the keys in od'
+                return iter(self)
+
+            def itervalues(self):
+                'od.itervalues -> an iterator over the values in od'
+                for k in self:
+                    yield self[k]
+
+            def iteritems(self):
+                'od.iteritems -> an iterator over the (key, value) items in od'
+                for k in self:
+                    yield (k, self[k])
+
+            def update(*args, **kwds):  # pylint: disable=E0211
+                '''od.update(E, **F) -> None.  Update od from dict/iterable E and F.
+
+                If E is a dict instance, does:           for k in E: od[k] = E[k]
+                If E has a .keys() method, does:         for k in E.keys(): od[k] = E[k]
+                Or if E is an iterable of items, does:   for k, v in E: od[k] = v
+                In either case, this is followed by:     for k, v in F.items(): od[k] = v
+
+                '''
+                if len(args) > 2:
+                    raise TypeError(
+                        'update() takes at most 2 positional '
+                        'arguments ({0} given)'.format(len(args))
+                    )
+                elif not args:
+                    raise TypeError('update() takes at least 1 argument (0 given)')
+                self = args[0]
+                # Make progressively weaker assumptions about "other"
+                other = ()
+                if len(args) == 2:
+                    other = args[1]
+                if isinstance(other, dict):
+                    for key in other:
+                        self[key] = other[key]
+                elif hasattr(other, 'keys'):
+                    for key in other:
+                        self[key] = other[key]
+                else:
+                    for key, value in other:
+                        self[key] = value
+                for key, value in six.iteritems(kwds):
+                    self[key] = value
+
+            __update = update  # let subclasses override update without breaking __init__
+
+            __marker = object()
+
+            def pop(self, key, default=__marker):
+                '''od.pop(k[,d]) -> v, remove specified key and return the corresponding value.
+                If key is not found, d is returned if given, otherwise KeyError is raised.
+
+                '''
+                if key in self:
+                    result = self[key]
+                    del self[key]
+                    return result
+                if default is self.__marker:
+                    raise KeyError(key)
+                return default
+
+            def setdefault(self, key, default=None):
+                'od.setdefault(k[,d]) -> od.get(k,d), also set od[k]=d if k not in od'
+                if key in self:
+                    return self[key]
+                self[key] = default
+                return default
+
+            def __repr__(self, _repr_running={}):  # pylint: disable=W0102
+                'od.__repr__() <==> repr(od)'
+                call_key = id(self), _get_ident()
+                if call_key in _repr_running:
+                    return '...'
+                _repr_running[call_key] = 1
+                try:
+                    if not self:
+                        return '{0}()'.format(self.__class__.__name__)
+                    return '{0}(\'{1}\')'.format(self.__class__.__name__, list(self.items()))
+                finally:
+                    del _repr_running[call_key]
+
+            def __reduce__(self):
+                'Return state information for pickling'
+                items = [[k, self[k]] for k in self]
+                inst_dict = vars(self).copy()
+                for k in vars(OrderedDict()):
+                    inst_dict.pop(k, None)
+                if inst_dict:
+                    return (self.__class__, (items,), inst_dict)
+                return self.__class__, (items,)
+
+            def copy(self):
+                'od.copy() -> a shallow copy of od'
+                return self.__class__(self)
+
+            @classmethod
+            def fromkeys(cls, iterable, value=None):
+                '''OD.fromkeys(S[, v]) -> New ordered dictionary with keys from S
+                and values equal to v (which defaults to None).
+
+                '''
+                d = cls()
+                for key in iterable:
+                    d[key] = value
+                return d
+
+            def __eq__(self, other):
+                '''od.__eq__(y) <==> od==y.  Comparison to another OD is order-sensitive
+                while comparison to a regular mapping is order-insensitive.
+
+                '''
+                if isinstance(other, OrderedDict):
+                    return len(self) == len(other) and self.items() == other.items()
+                return dict.__eq__(self, other)
+
+            def __ne__(self, other):
+                return not self == other
+
+#            # -- the following methods are only used in Python 2.7 --
+#
+#            def viewkeys(self):
+#                "od.viewkeys() -> a set-like object providing a view on od's keys"
+#                return KeysView(self)
+#
+#            def viewvalues(self):
+#                "od.viewvalues() -> an object providing a view on od's values"
+#                return ValuesView(self)
+#
+#            def viewitems(self):
+#                "od.viewitems() -> a set-like object providing a view on od's items"
+#                return ItemsView(self)
+#        ## end of http://code.activestate.com/recipes/576693/ }}}
+
+
+class DefaultOrderedDict(OrderedDict):
+    'Dictionary that remembers insertion order and '
+    def __init__(self, default_factory=None, *a, **kw):
+        if (default_factory is not None and
+            not isinstance(default_factory, Callable)):
+            raise TypeError('first argument must be callable')
+        super(DefaultOrderedDict, self).__init__(*a, **kw)
+        self.default_factory = default_factory
+
+    def __getitem__(self, key):
+        try:
+            return OrderedDict.__getitem__(self, key)
+        except KeyError:
+            return self.__missing__(key)
+
+    def __missing__(self, key):
+        if self.default_factory is None:
+            raise KeyError(key)
+        self[key] = value = self.default_factory()
+        return value
+
+    def __reduce__(self):
+        if self.default_factory is None:
+            args = tuple()
+        else:
+            args = self.default_factory,
+        return type(self), args, None, None, self.items()
+
+    def copy(self):
+        return self.__copy__()
+
+    def __copy__(self):
+        return type(self)(self.default_factory, self)
+
+    def __deepcopy__(self):
+        import copy
+        return type(self)(self.default_factory,
+                          copy.deepcopy(self.items()))
+
+    def __repr__(self, _repr_running={}):  # pylint: disable=W0102
+        return 'DefaultOrderedDict({0}, {1})'.format(self.default_factory,
+                                                     super(DefaultOrderedDict,
+                                                           self).__repr__())

--- a/hubblestack/utils/stringutils.py
+++ b/hubblestack/utils/stringutils.py
@@ -128,3 +128,18 @@ def is_binary(data):
     if float(len(nontext)) / len(data) > 0.30:
         return True
     return False
+
+def to_num(text):
+    '''
+    Convert a string to a number.
+    Returns an integer if the string represents an integer, a floating
+    point number if the string is a real number, or the string unchanged
+    otherwise.
+    '''
+    try:
+        return int(text)
+    except ValueError:
+        try:
+            return float(text)
+        except ValueError:
+            return text

--- a/hubblestack/utils/yaml.py
+++ b/hubblestack/utils/yaml.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+'''
+Convenience module that provides our custom loader and dumper in a single module
+'''
+
+from yaml import YAMLError, parser, scanner
+from hubblestack.utils.yamlloader import *

--- a/hubblestack/utils/yamlloader.py
+++ b/hubblestack/utils/yamlloader.py
@@ -1,0 +1,176 @@
+# -*- coding: utf-8 -*-
+'''
+Custom YAML loading in Salt
+'''
+
+import warnings
+import yaml
+from yaml.nodes import MappingNode, SequenceNode
+from yaml.constructor import ConstructorError
+try:
+    yaml.Loader = yaml.CLoader
+    yaml.Dumper = yaml.CDumper
+    yaml.SafeLoader = yaml.CSafeLoader
+    yaml.SafeDumper = yaml.CSafeDumper
+except Exception:
+    pass
+
+import hubblestack.utils.stringutils
+
+__all__ = ['SaltYamlSafeLoader', 'load', 'safe_load']
+
+
+class DuplicateKeyWarning(RuntimeWarning):
+    '''
+    Warned when duplicate keys exist
+    '''
+
+
+warnings.simplefilter('always', category=DuplicateKeyWarning)
+
+
+# with code integrated from https://gist.github.com/844388
+class SaltYamlSafeLoader(yaml.SafeLoader):
+    '''
+    Create a custom YAML loader that uses the custom constructor. This allows
+    for the YAML loading defaults to be manipulated based on needs within salt
+    to make things like sls file more intuitive.
+    '''
+    def __init__(self, stream, dictclass=dict):
+        super(SaltYamlSafeLoader, self).__init__(stream)
+        if dictclass is not dict:
+            # then assume ordered dict and use it for both !map and !omap
+            self.add_constructor(
+                'tag:yaml.org,2002:map',
+                type(self).construct_yaml_map)
+            self.add_constructor(
+                'tag:yaml.org,2002:omap',
+                type(self).construct_yaml_map)
+        self.add_constructor(
+            'tag:yaml.org,2002:str',
+            type(self).construct_yaml_str)
+        self.add_constructor(
+            'tag:yaml.org,2002:python/unicode',
+            type(self).construct_unicode)
+        self.add_constructor(
+            'tag:yaml.org,2002:timestamp',
+            type(self).construct_scalar)
+        self.dictclass = dictclass
+
+    def construct_yaml_map(self, node):
+        data = self.dictclass()
+        yield data
+        value = self.construct_mapping(node)
+        data.update(value)
+
+    def construct_unicode(self, node):
+        return node.value
+
+    def construct_mapping(self, node, deep=False):
+        '''
+        Build the mapping for YAML
+        '''
+        if not isinstance(node, MappingNode):
+            raise ConstructorError(
+                None,
+                None,
+                'expected a mapping node, but found {0}'.format(node.id),
+                node.start_mark)
+
+        self.flatten_mapping(node)
+
+        context = 'while constructing a mapping'
+        mapping = self.dictclass()
+        for key_node, value_node in node.value:
+            key = self.construct_object(key_node, deep=deep)
+            try:
+                hash(key)
+            except TypeError:
+                raise ConstructorError(
+                    context,
+                    node.start_mark,
+                    "found unacceptable key {0}".format(key_node.value),
+                    key_node.start_mark)
+            value = self.construct_object(value_node, deep=deep)
+            if key in mapping:
+                raise ConstructorError(
+                    context,
+                    node.start_mark,
+                    "found conflicting ID '{0}'".format(key),
+                    key_node.start_mark)
+            mapping[key] = value
+        return mapping
+
+    def construct_scalar(self, node):
+        '''
+        Verify integers and pass them in correctly is they are declared
+        as octal
+        '''
+        if node.tag == 'tag:yaml.org,2002:int':
+            if node.value == '0':
+                pass
+            elif node.value.startswith('0') and not node.value.startswith(('0b', '0x')):
+                node.value = node.value.lstrip('0')
+                # If value was all zeros, node.value would have been reduced to
+                # an empty string. Change it to '0'.
+                if node.value == '':
+                    node.value = '0'
+        return super(SaltYamlSafeLoader, self).construct_scalar(node)
+
+    def construct_yaml_str(self, node):
+        value = self.construct_scalar(node)
+        return hubblestack.utils.stringutils.to_unicode(value)
+
+    def flatten_mapping(self, node):
+        merge = []
+        index = 0
+        while index < len(node.value):
+            key_node, value_node = node.value[index]
+
+            if key_node.tag == 'tag:yaml.org,2002:merge':
+                del node.value[index]
+                if isinstance(value_node, MappingNode):
+                    self.flatten_mapping(value_node)
+                    merge.extend(value_node.value)
+                elif isinstance(value_node, SequenceNode):
+                    submerge = []
+                    for subnode in value_node.value:
+                        if not isinstance(subnode, MappingNode):
+                            raise ConstructorError("while constructing a mapping",
+                                                   node.start_mark,
+                                                   "expected a mapping for merging, but found {0}".format(subnode.id),
+                                                   subnode.start_mark)
+                        self.flatten_mapping(subnode)
+                        submerge.append(subnode.value)
+                    submerge.reverse()
+                    for value in submerge:
+                        merge.extend(value)
+                else:
+                    raise ConstructorError("while constructing a mapping",
+                                           node.start_mark,
+                                           "expected a mapping or list of mappings for merging, but found {0}".format(value_node.id),
+                                           value_node.start_mark)
+            elif key_node.tag == 'tag:yaml.org,2002:value':
+                key_node.tag = 'tag:yaml.org,2002:str'
+                index += 1
+            else:
+                index += 1
+        if merge:
+            # Here we need to discard any duplicate entries based on key_node
+            existing_nodes = [name_node.value for name_node, value_node in node.value]
+            mergeable_items = [x for x in merge if x[0].value not in existing_nodes]
+
+            node.value = mergeable_items + node.value
+
+
+def load(stream, Loader=SaltYamlSafeLoader):
+    return yaml.load(stream, Loader=Loader)
+
+
+def safe_load(stream, Loader=SaltYamlSafeLoader):
+    '''
+    .. versionadded:: 2018.3.0
+
+    Helper function which automagically uses our custom loader.
+    '''
+    return yaml.load(stream, Loader=Loader)

--- a/hubblestack/utils/zfs.py
+++ b/hubblestack/utils/zfs.py
@@ -1,0 +1,706 @@
+# -*- coding: utf-8 -*-
+'''
+Utility functions for zfs
+
+These functions are for dealing with type conversion and basic execution
+
+:maintainer:    Jorge Schrauwen <sjorge@blackdot.be>
+:maturity:      new
+:platform:      illumos,freebsd,linux
+
+.. versionadded:: 2018.3.1
+
+'''
+
+import os
+import re
+import math
+import logging
+from numbers import Number
+
+from hubblestack.utils.decorators import memoize as real_memoize
+from hubblestack.utils.odict import OrderedDict
+from hubblestack.utils.stringutils import to_num as str_to_num
+import hubblestack.modules.cmdmod
+import hubblestack.utils.platform
+import hubblestack.utils.path
+
+# Size conversion data
+re_zfs_size = re.compile(r'^(\d+|\d+(?=\d*)\.\d+)([KkMmGgTtPpEe][Bb]?)$')
+zfs_size = ['K', 'M', 'G', 'T', 'P', 'E']
+
+log = logging.getLogger(__name__)
+
+
+def _check_retcode(cmd):
+    '''
+    Simple internal wrapper for cmdmod.retcode
+    '''
+    return hubblestack.modules.cmdmod.retcode(cmd, output_loglevel='quiet', ignore_retcode=True) == 0
+
+
+def _exec(**kwargs):
+    '''
+    Simple internal wrapper for cmdmod.run
+    '''
+    if 'ignore_retcode' not in kwargs:
+        kwargs['ignore_retcode'] = True
+    if 'output_loglevel' not in kwargs:
+        kwargs['output_loglevel'] = 'quiet'
+    return hubblestack.modules.cmdmod.run_all(**kwargs)
+
+
+def _merge_last(values, merge_after, merge_with=' '):
+    '''
+    Merge values all values after X into the last value
+    '''
+    if len(values) > merge_after:
+        values = values[0:(merge_after-1)] + [merge_with.join(values[(merge_after-1):])]
+
+    return values
+
+
+def _property_normalize_name(name):
+    '''
+    Normalizes property names
+    '''
+    if '@' in name:
+        name = name[:name.index('@')+1]
+    return name
+
+
+def _property_detect_type(name, values):
+    '''
+    Detect the datatype of a property
+    '''
+    value_type = 'str'
+    if values.startswith('on | off'):
+        value_type = 'bool'
+    elif values.startswith('yes | no'):
+        value_type = 'bool_alt'
+    elif values in ['<size>', '<size> | none']:
+        value_type = 'size'
+    elif values in ['<count>', '<count> | none', '<guid>']:
+        value_type = 'numeric'
+    elif name in ['sharenfs', 'sharesmb', 'canmount']:
+        value_type = 'bool'
+    elif name in ['version', 'copies']:
+        value_type = 'numeric'
+    return value_type
+
+
+def _property_create_dict(header, data):
+    '''
+    Create a property dict
+    '''
+    prop = dict(zip(header, _merge_last(data, len(header))))
+    prop['name'] = _property_normalize_name(prop['property'])
+    prop['type'] = _property_detect_type(prop['name'], prop['values'])
+    prop['edit'] = from_bool(prop['edit'])
+    if 'inherit' in prop:
+        prop['inherit'] = from_bool(prop['inherit'])
+    del prop['property']
+    return prop
+
+
+def _property_parse_cmd(cmd, alias=None):
+    '''
+    Parse output of zpool/zfs get command
+    '''
+    if not alias:
+        alias = {}
+    properties = {}
+
+    # NOTE: append get to command
+    if cmd[-3:] != 'get':
+        cmd += ' get'
+
+    # NOTE: parse output
+    prop_hdr = []
+    for prop_data in _exec(cmd=cmd)['stderr'].split('\n'):
+        # NOTE: make the line data more managable
+        prop_data = prop_data.lower().split()
+
+        # NOTE: skip empty lines
+        if not prop_data:
+            continue
+        # NOTE: parse header
+        elif prop_data[0] == 'property':
+            prop_hdr = prop_data
+            continue
+        # NOTE: skip lines after data
+        elif not prop_hdr or prop_data[1] not in ['no', 'yes']:
+            continue
+
+        # NOTE: create property dict
+        prop = _property_create_dict(prop_hdr, prop_data)
+
+        # NOTE: add property to dict
+        properties[prop['name']] = prop
+        if prop['name'] in alias:
+            properties[alias[prop['name']]] = prop
+
+        # NOTE: cleanup some duplicate data
+        del prop['name']
+    return properties
+
+
+def _auto(direction, name, value, source='auto', convert_to_human=True):
+    '''
+    Internal magic for from_auto and to_auto
+    '''
+    # NOTE: check direction
+    if direction not in ['to', 'from']:
+        return value
+
+    # NOTE: collect property data
+    props = property_data_zpool()
+    if source == 'zfs':
+        props = property_data_zfs()
+    elif source == 'auto':
+        props.update(property_data_zfs())
+
+    # NOTE: figure out the conversion type
+    value_type = props[name]['type'] if name in props else 'str'
+
+    # NOTE: convert
+    if value_type == 'size' and direction == 'to':
+        return globals()['{}_{}'.format(direction, value_type)](value, convert_to_human)
+
+    return globals()['{}_{}'.format(direction, value_type)](value)
+
+
+@real_memoize
+def _zfs_cmd():
+    '''
+    Return the path of the zfs binary if present
+    '''
+    # Get the path to the zfs binary.
+    return hubblestack.utils.path.which('zfs')
+
+
+@real_memoize
+def _zpool_cmd():
+    '''
+    Return the path of the zpool binary if present
+    '''
+    # Get the path to the zfs binary.
+    return hubblestack.utils.path.which('zpool')
+
+
+def _command(source, command, flags=None, opts=None,
+             property_name=None, property_value=None,
+             filesystem_properties=None, pool_properties=None,
+             target=None):
+    '''
+    Build and properly escape a zfs command
+
+    .. note::
+
+        Input is not considered safe and will be passed through
+        to_auto(from_auto('input_here')), you do not need to do so
+        your self first.
+
+    '''
+    # NOTE: start with the zfs binary and command
+    cmd = [_zpool_cmd() if source == 'zpool' else _zfs_cmd(), command]
+
+    # NOTE: append flags if we have any
+    if flags is None:
+        flags = []
+    for flag in flags:
+        cmd.append(flag)
+
+    # NOTE: append options
+    #       we pass through 'sorted' to garentee the same order
+    if opts is None:
+        opts = {}
+    for opt in sorted(opts):
+        if not isinstance(opts[opt], list):
+            opts[opt] = [opts[opt]]
+        for val in opts[opt]:
+            cmd.append(opt)
+            cmd.append(to_str(val))
+
+    # NOTE: append filesystem properties (really just options with a key/value)
+    #       we pass through 'sorted' to garentee the same order
+    if filesystem_properties is None:
+        filesystem_properties = {}
+    for fsopt in sorted(filesystem_properties):
+        cmd.append('-O' if source == 'zpool' else '-o')
+        cmd.append('{key}={val}'.format(
+            key=fsopt,
+            val=to_auto(fsopt, filesystem_properties[fsopt], source='zfs', convert_to_human=False),
+        ))
+
+    # NOTE: append pool properties (really just options with a key/value)
+    #       we pass through 'sorted' to garentee the same order
+    if pool_properties is None:
+        pool_properties = {}
+    for fsopt in sorted(pool_properties):
+        cmd.append('-o')
+        cmd.append('{key}={val}'.format(
+            key=fsopt,
+            val=to_auto(fsopt, pool_properties[fsopt], source='zpool', convert_to_human=False),
+        ))
+
+    # NOTE: append property and value
+    #       the set command takes a key=value pair, we need to support this
+    if property_name is not None:
+        if property_value is not None:
+            if not isinstance(property_name, list):
+                property_name = [property_name]
+            if not isinstance(property_value, list):
+                property_value = [property_value]
+            for key, val in zip(property_name, property_value):
+                cmd.append('{key}={val}'.format(
+                    key=key,
+                    val=to_auto(key, val, source=source, convert_to_human=False),
+                ))
+        else:
+            cmd.append(property_name)
+
+    # NOTE: append the target(s)
+    if target is not None:
+        if not isinstance(target, list):
+            target = [target]
+        for tgt in target:
+            # NOTE: skip None list items
+            #       we do not want to skip False and 0!
+            if tgt is None:
+                continue
+            cmd.append(to_str(tgt))
+
+    return ' '.join(cmd)
+
+
+def is_supported():
+    '''
+    Check the system for ZFS support
+    '''
+    # Check for supported platforms
+    # NOTE: ZFS on Windows is in development
+    # NOTE: ZFS on NetBSD is in development
+    on_supported_platform = False
+    if hubblestack.utils.platform.is_sunos():
+        on_supported_platform = True
+    elif hubblestack.utils.platform.is_freebsd() and _check_retcode('kldstat -q -m zfs'):
+        on_supported_platform = True
+    elif hubblestack.utils.platform.is_linux() and os.path.exists('/sys/module/zfs'):
+        on_supported_platform = True
+    elif hubblestack.utils.platform.is_linux() and hubblestack.utils.path.which('zfs-fuse'):
+        on_supported_platform = True
+    elif hubblestack.utils.platform.is_darwin() and \
+         os.path.exists('/Library/Extensions/zfs.kext') and \
+         os.path.exists('/dev/zfs'):
+        on_supported_platform = True
+
+    # Additional check for the zpool command
+    return (hubblestack.utils.path.which('zpool') and on_supported_platform) is True
+
+
+@real_memoize
+def has_feature_flags():
+    '''
+    Check if zpool-features is available
+    '''
+    # get man location
+    man = hubblestack.utils.path.which('man')
+    return _check_retcode('{man} zpool-features'.format(
+        man=man
+    )) if man else False
+
+
+@real_memoize
+def property_data_zpool():
+    '''
+    Return a dict of zpool properties
+
+    .. note::
+
+        Each property will have an entry with the following info:
+            - edit : boolean - is this property editable after pool creation
+            - type : str - either bool, bool_alt, size, numeric, or string
+            - values : str - list of possible values
+
+    .. warning::
+
+        This data is probed from the output of 'zpool get' with some suplimental
+        data that is hardcoded. There is no better way to get this informatio aside
+        from reading the code.
+
+    '''
+    # NOTE: man page also mentions a few short forms
+    property_data = _property_parse_cmd(_zpool_cmd(), {
+        'allocated': 'alloc',
+        'autoexpand': 'expand',
+        'autoreplace': 'replace',
+        'listsnapshots': 'listsnaps',
+        'fragmentation': 'frag',
+    })
+
+    # NOTE: zpool status/iostat has a few extra fields
+    zpool_size_extra = [
+        'capacity-alloc', 'capacity-free',
+        'operations-read', 'operations-write',
+        'bandwith-read', 'bandwith-write',
+        'read', 'write',
+    ]
+    zpool_numeric_extra = [
+        'cksum', 'cap',
+    ]
+
+    for prop in zpool_size_extra:
+        property_data[prop] = {
+            'edit': False,
+            'type': 'size',
+            'values': '<size>',
+        }
+
+    for prop in zpool_numeric_extra:
+        property_data[prop] = {
+            'edit': False,
+            'type': 'numeric',
+            'values': '<count>',
+        }
+
+    return property_data
+
+
+@real_memoize
+def property_data_zfs():
+    '''
+    Return a dict of zfs properties
+
+    .. note::
+
+        Each property will have an entry with the following info:
+            - edit : boolean - is this property editable after pool creation
+            - inherit : boolean - is this property inheritable
+            - type : str - either bool, bool_alt, size, numeric, or string
+            - values : str - list of possible values
+
+    .. warning::
+
+        This data is probed from the output of 'zfs get' with some suplimental
+        data that is hardcoded. There is no better way to get this informatio aside
+        from reading the code.
+
+    '''
+    return _property_parse_cmd(_zfs_cmd(), {
+        'available': 'avail',
+        'logicalreferenced': 'lrefer.',
+        'logicalused': 'lused.',
+        'referenced': 'refer',
+        'volblocksize': 'volblock',
+        'compression': 'compress',
+        'readonly': 'rdonly',
+        'recordsize': 'recsize',
+        'refreservation': 'refreserv',
+        'reservation': 'reserv',
+    })
+
+
+def from_numeric(value):
+    '''
+    Convert zfs numeric to python int
+    '''
+    if value == 'none':
+        value = None
+    elif value:
+        value = str_to_num(value)
+    return value
+
+
+def to_numeric(value):
+    '''
+    Convert python int to zfs numeric
+    '''
+    value = from_numeric(value)
+    if value is None:
+        value = 'none'
+    return value
+
+
+def from_bool(value):
+    '''
+    Convert zfs bool to python bool
+    '''
+    if value in ['on', 'yes']:
+        value = True
+    elif value in ['off', 'no']:
+        value = False
+    elif value == 'none':
+        value = None
+
+    return value
+
+
+def from_bool_alt(value):
+    '''
+    Convert zfs bool_alt to python bool
+    '''
+    return from_bool(value)
+
+
+def to_bool(value):
+    '''
+    Convert python bool to zfs on/off bool
+    '''
+    value = from_bool(value)
+    if isinstance(value, bool):
+        value = 'on' if value else 'off'
+    elif value is None:
+        value = 'none'
+
+    return value
+
+
+def to_bool_alt(value):
+    '''
+    Convert python to zfs yes/no value
+    '''
+    value = from_bool_alt(value)
+    if isinstance(value, bool):
+        value = 'yes' if value else 'no'
+    elif value is None:
+        value = 'none'
+
+    return value
+
+
+def from_size(value):
+    '''
+    Convert zfs size (human readble) to python int (bytes)
+    '''
+    match_size = re_zfs_size.match(str(value))
+    if match_size:
+        v_unit = match_size.group(2).upper()[0]
+        v_size = float(match_size.group(1))
+        v_multiplier = math.pow(1024, zfs_size.index(v_unit) + 1)
+        value = v_size * v_multiplier
+        if int(value) == value:
+            value = int(value)
+    elif value is not None:
+        value = str(value)
+
+    return from_numeric(value)
+
+
+def to_size(value, convert_to_human=True):
+    '''
+    Convert python int (bytes) to zfs size
+
+    NOTE: http://src.illumos.org/source/xref/illumos-gate/usr/src/lib/pyzfs/common/util.py#114
+    '''
+    value = from_size(value)
+    if value is None:
+        value = 'none'
+
+    if isinstance(value, Number) and value > 1024 and convert_to_human:
+        v_power = int(math.floor(math.log(value, 1024)))
+        v_multiplier = math.pow(1024, v_power)
+
+        # NOTE: zfs is a bit odd on how it does the rounding,
+        #       see libzfs implementation linked above
+        v_size_float = float(value) / v_multiplier
+        if v_size_float == int(v_size_float):
+            value = "{:.0f}{}".format(
+                v_size_float,
+                zfs_size[v_power-1],
+            )
+        else:
+            for v_precision in ["{:.2f}{}", "{:.1f}{}", "{:.0f}{}"]:
+                v_size = v_precision.format(
+                    v_size_float,
+                    zfs_size[v_power-1],
+                )
+                if len(v_size) <= 5:
+                    value = v_size
+                    break
+
+    return value
+
+
+def from_str(value):
+    '''
+    Decode zfs safe string (used for name, path, ...)
+    '''
+    if value == 'none':
+        value = None
+    if value:
+        value = str(value)
+        if value.startswith('"') and value.endswith('"'):
+            value = value[1:-1]
+        value = value.replace('\\"', '"')
+
+    return value
+
+
+def to_str(value):
+    '''
+    Encode zfs safe string (used for name, path, ...)
+    '''
+    value = from_str(value)
+
+    if value:
+        value = value.replace('"', '\\"')
+        if ' ' in value:
+            value = '"' + value + '"'
+    elif value is None:
+        value = 'none'
+
+    return value
+
+
+def from_auto(name, value, source='auto'):
+    '''
+    Convert zfs value to python value
+    '''
+    return _auto('from', name, value, source)
+
+
+def to_auto(name, value, source='auto', convert_to_human=True):
+    '''
+    Convert python value to zfs value
+    '''
+    return _auto('to', name, value, source, convert_to_human)
+
+
+def from_auto_dict(values, source='auto'):
+    '''
+    Pass an entire dictionary to from_auto
+
+    .. note::
+        The key will be passed as the name
+
+    '''
+    for name, value in values.items():
+        values[name] = from_auto(name, value, source)
+
+    return values
+
+
+def to_auto_dict(values, source='auto', convert_to_human=True):
+    '''
+    Pass an entire dictionary to to_auto
+
+    .. note::
+        The key will be passed as the name
+    '''
+    for name, value in values.items():
+        values[name] = to_auto(name, value, source, convert_to_human)
+
+    return values
+
+
+def is_snapshot(name):
+    '''
+    Check if name is a valid snapshot name
+    '''
+    return from_str(name).count('@') == 1
+
+
+def is_bookmark(name):
+    '''
+    Check if name is a valid bookmark name
+    '''
+    return from_str(name).count('#') == 1
+
+
+def is_dataset(name):
+    '''
+    Check if name is a valid filesystem or volume name
+    '''
+    return not is_snapshot(name) and not is_bookmark(name)
+
+
+def zfs_command(command, flags=None, opts=None, property_name=None, property_value=None,
+                filesystem_properties=None, target=None):
+    '''
+    Build and properly escape a zfs command
+
+    .. note::
+
+        Input is not considered safe and will be passed through
+        to_auto(from_auto('input_here')), you do not need to do so
+        your self first.
+
+    '''
+    return _command(
+        'zfs',
+        command=command,
+        flags=flags,
+        opts=opts,
+        property_name=property_name,
+        property_value=property_value,
+        filesystem_properties=filesystem_properties,
+        pool_properties=None,
+        target=target,
+    )
+
+
+def zpool_command(command, flags=None, opts=None, property_name=None, property_value=None,
+                  filesystem_properties=None, pool_properties=None, target=None):
+    '''
+    Build and properly escape a zpool command
+
+    .. note::
+
+        Input is not considered safe and will be passed through
+        to_auto(from_auto('input_here')), you do not need to do so
+        your self first.
+
+    '''
+    return _command(
+        'zpool',
+        command=command,
+        flags=flags,
+        opts=opts,
+        property_name=property_name,
+        property_value=property_value,
+        filesystem_properties=filesystem_properties,
+        pool_properties=pool_properties,
+        target=target,
+    )
+
+
+def parse_command_result(res, label=None):
+    '''
+    Parse the result of a zpool/zfs command
+
+    .. note::
+
+        Output on failure is rather predicatable.
+        - retcode > 0
+        - each 'error' is a line on stderr
+        - optional 'Usage:' block under those with hits
+
+        We simple check those and return a OrderedDict were
+        we set label = True|False and error = error_messages
+
+    '''
+    ret = OrderedDict()
+
+    if label:
+        ret[label] = res['retcode'] == 0
+
+    if res['retcode'] != 0:
+        ret['error'] = []
+        for error in res['stderr'].splitlines():
+            if error.lower().startswith('usage:'):
+                break
+            if error.lower().startswith("use '-f'"):
+                error = error.replace('-f', 'force=True')
+            if error.lower().startswith("use '-r'"):
+                error = error.replace('-r', 'recursive=True')
+            ret['error'].append(error)
+
+        if ret['error']:
+            ret['error'] = "\n".join(ret['error'])
+        else:
+            del ret['error']
+
+    return ret
+
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4


### PR DESCRIPTION
This set completes all dependencies for grains.

- moved salt.utils.dictupdate to hubblestack.utils.dictupdate
- moved salt.utils.zfs to hubblestack.utils.zfs
- moved salt.utils.odict to hubblestack.utils.odict
- moved salt.utils.yaml to hubblestack.utils.yaml
- moved salt.utils.yamlloader to hubblestack.utils.yamlloader
