### PR TITLE
Docker file changes for fast build system

### DIFF
--- a/pkg/amazonlinux2016.09/Dockerfile
+++ b/pkg/amazonlinux2016.09/Dockerfile
@@ -20,7 +20,9 @@ RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osque
 RUN yum -y install git \
     libffi-devel openssl-devel libffi libssh2-devel autoconf automake libtool \
     libxml2-devel libxslt-devel libjpeg-devel zlib-devel \
-    make cmake gcc python-devel python-setuptools wget openssl
+    make cmake gcc python-devel python-setuptools wget openssl \
+    && yum clean all \
+    && rm -rf /var/cache/yum
 
 #libcurl install start
 #install libcurl to avoid depending on host version
@@ -37,7 +39,8 @@ RUN mkdir -p "$LIBCURL_TEMP" \
  && ./buildconf \
  && ./configure --prefix=/opt/hubble --disable-ldap --without-nss --disable-manual --disable-gopher --disable-smtp --disable-smb --disable-imap --disable-pop3 --disable-tftp --disable-telnet --disable-dict --disable-ldaps --disable-ldap --disable-rtsp --with-libssh2 \
  && make \
- && make install
+ && make install \
+ && rm -rf "$LIBCURL_TEMP"
 
 #git install start
 #install git so that git package won't be a package dependency
@@ -56,7 +59,8 @@ RUN mkdir -p "$GITTEMP" \
  && echo "NO_PERL=YesPlease" >> config.mak.autogen \
  && sed -i '0,/^NO_GETTEXT/s/^NO_GETTEXT.*/NO_GETTEXT=YesPlease/' config.mak.autogen \
  && make \
- && make install
+ && make install \
+ && rm -rf "$GITTEMP"
 
 #clean up of /opt/hubble
 RUN rm /opt/hubble/bin/curl* \
@@ -77,15 +81,20 @@ RUN mkdir -p "$LIBGIT2TEMP" \
  && cd libgit2-"$LIBGIT2_SRC_VERSION"/ \
  && cmake . -DCMAKE_INSTALL_PREFIX=/usr/local/ \
  && make \
- && make install
+ && make install \
+ && rm -rf "$LIBGIT2TEMP"
 
 #fpm package making requirements start
 RUN yum install -y ruby ruby-devel rpmbuild rpm-build rubygems gcc make \
  && gem install --no-ri --no-rdoc ffi --version 1.12.2 \
- && gem install --no-ri --no-rdoc fpm
+ && gem install --no-ri --no-rdoc fpm \
+ && yum clean all \
+ && rm -rf /var/cache/yum
 
 # things we may need to build a python
-RUN yum install -y bzip2-devel
+RUN yum install -y bzip2-devel \
+ && yum clean all \
+ && rm -rf /var/cache/yum
 
 # use pyenv
 ARG PYENV_VERSION=3.6.10
@@ -125,22 +134,12 @@ ENV _BINARY_LOG_LEVEL="INFO"
 ENV _INCLUDE_PATH=""
 ENV LD_LIBRARY_PATH=/opt/hubble/lib:/lib:/lib64:/usr/lib:/usr/lib64:/usr/local/lib:/usr/local/lib64
 
-RUN set -x; git clone "$HUBBLE_GIT_URL" "$HUBBLE_SRC_PATH" \
- && cd "$HUBBLE_SRC_PATH" && git checkout "$HUBBLE_CHECKOUT"
-
-RUN cp -rf "$HUBBLE_SRC_PATH" /hubble_build \
- && rm -rf /hubble_build/.git
-
-RUN cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.orig \
- && sed -i -e "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT}/g" \
-           -e "s/COMMIT_NOT_SET/$(cd $HUBBLE_SRC_PATH; git describe --long --always --tags)/g" \
-           /hubble_build/hubblestack/__init__.py \
- && cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixed
-
 RUN mkdir /data
 VOLUME /data
 
 WORKDIR /hubble_build
 
 COPY entrypoint.sh /entrypoint.sh
+ENV HUBBLE_CHECKOUT_ENV=$HUBBLE_CHECKOUT
+ENV HUBBLE_GIT_URL_ENV=$HUBBLE_GIT_URL
 ENTRYPOINT [ "/bin/bash", "/entrypoint.sh" ]

--- a/pkg/amazonlinux2016.09/entrypoint.sh
+++ b/pkg/amazonlinux2016.09/entrypoint.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+#Moving hubble source code logic in the shell script
+set -x -e
+git clone "${HUBBLE_GIT_URL_ENV}" "${HUBBLE_SRC_PATH}"
+cd "${HUBBLE_SRC_PATH}"
+git checkout "${HUBBLE_CHECKOUT_ENV}"
+
+cp -rf "${HUBBLE_SRC_PATH}"/* /hubble_build
+rm -rf /hubble_build/.git
+
+cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.orig
+
+sed -i -e "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT_ENV}/g" -e "s/COMMIT_NOT_SET/$(cd ${HUBBLE_SRC_PATH}; git describe --long --always --tags)/g" /hubble_build/hubblestack/__init__.py
+cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixed
 
 eval "$(pyenv init -)"
 
@@ -17,7 +30,6 @@ fi
 
 # from now on, exit on error (rather than && every little thing)
 PS4=$'-------------=: '
-set -x -e
 
 # possibly replace the version file
 if [ -f /data/hubble_buildinfo ]; then

--- a/pkg/centos6/Dockerfile
+++ b/pkg/centos6/Dockerfile
@@ -20,7 +20,9 @@ RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osque
 RUN yum -y install git \
     libffi-devel openssl-devel libxml2-devel libxslt-devel libffi \
     libssh2-devel autoconf automake libtool libjpeg-devel zlib-devel \
-    make cmake gcc wget openssl
+    make cmake gcc wget openssl \
+    && yum clean all \
+    && rm -rf /var/cache/yum
     
 #libcurl install start
 #install libcurl to avoid depending on host version
@@ -37,7 +39,8 @@ RUN mkdir -p "$LIBCURL_TEMP" \
  && ./buildconf \
  && ./configure --prefix=/opt/hubble --disable-ldap --without-nss --disable-manual --disable-gopher --disable-smtp --disable-smb --disable-imap --disable-pop3 --disable-tftp --disable-telnet --disable-dict --disable-ldaps --disable-ldap --disable-rtsp --with-libssh2 \
  && make \
- && make install
+ && make install \
+ && rm -rf "$LIBCURL_TEMP"
 
 #git install start
 #install git so that git package won't be a package dependency
@@ -56,7 +59,8 @@ RUN mkdir -p "$GITTEMP" \
  && echo "NO_PERL=YesPlease" >> config.mak.autogen \
  && sed -i '0,/^NO_GETTEXT/s/^NO_GETTEXT.*/NO_GETTEXT=YesPlease/' config.mak.autogen \
  && make \
- && make install
+ && make install \
+ && rm -rf "$GITTEMP"
 
 #clean up of /opt/hubble
 RUN rm /opt/hubble/bin/curl* \
@@ -77,15 +81,22 @@ RUN mkdir -p "$LIBGIT2TEMP" \
  && cd libgit2-"$LIBGIT2_SRC_VERSION"/ \
  && cmake . -DCMAKE_INSTALL_PREFIX=/usr/local/ \
  && make \
- && make install
+ && make install \
+ && rm -rf "$LIBGIT2TEMP"
 
 #fpm package making requirements start
-RUN yum install -y centos-release-scl scl-utils
-RUN yum install -y rpmbuild rpm-build gcc make rh-ruby23 rh-ruby23-ruby-devel
+RUN yum install -y centos-release-scl scl-utils \
+ && yum clean all \
+ && rm -rf /var/cache/yum
+RUN yum install -y rpmbuild rpm-build gcc make rh-ruby23 rh-ruby23-ruby-devel \
+ && yum clean all \
+ && rm -rf /var/cache/yum
 RUN scl enable rh-ruby23 "gem install --no-ri --no-rdoc fpm"
 
 # things we may need to build a python
-RUN yum install -y bzip2-devel sqlite-devel
+RUN yum install -y bzip2-devel sqlite-devel \
+ && yum clean all \
+ && rm -rf /var/cache/yum
 
 # use pyenv
 ARG PYENV_VERSION=3.6.10
@@ -125,22 +136,12 @@ ENV _BINARY_LOG_LEVEL="INFO"
 ENV _INCLUDE_PATH=""
 ENV LD_LIBRARY_PATH=/opt/hubble/lib:/lib:/lib64:/usr/lib:/usr/lib64:/usr/local/lib:/usr/local/lib64
 
-RUN set -x; git clone "$HUBBLE_GIT_URL" "$HUBBLE_SRC_PATH" \
- && cd "$HUBBLE_SRC_PATH" && git checkout "$HUBBLE_CHECKOUT"
-
-RUN cp -rf "$HUBBLE_SRC_PATH" /hubble_build \
- && rm -rf /hubble_build/.git
-
-RUN cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.orig \
- && sed -i -e "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT}/g" \
-           -e "s/COMMIT_NOT_SET/$(cd $HUBBLE_SRC_PATH; git describe --long --always --tags)/g" \
-           /hubble_build/hubblestack/__init__.py \
- && cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixed
-
 RUN mkdir /data
 VOLUME /data
 
 WORKDIR /hubble_build
 
 COPY entrypoint.sh /entrypoint.sh
+ENV HUBBLE_CHECKOUT_ENV=$HUBBLE_CHECKOUT
+ENV HUBBLE_GIT_URL_ENV=$HUBBLE_GIT_URL
 ENTRYPOINT [ "/bin/bash", "/entrypoint.sh" ]

--- a/pkg/centos6/entrypoint.sh
+++ b/pkg/centos6/entrypoint.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+#Moving hubble source code logic in the shell script
+set -x -e
+git clone "${HUBBLE_GIT_URL_ENV}" "${HUBBLE_SRC_PATH}"
+cd "${HUBBLE_SRC_PATH}"
+git checkout "${HUBBLE_CHECKOUT_ENV}"
+
+cp -rf "${HUBBLE_SRC_PATH}"/* /hubble_build
+rm -rf /hubble_build/.git
+
+cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.orig
+
+sed -i -e "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT_ENV}/g" -e "s/COMMIT_NOT_SET/$(cd ${HUBBLE_SRC_PATH}; git describe --long --always --tags)/g" /hubble_build/hubblestack/__init__.py
+cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixed
 
 eval "$(pyenv init -)"
 
@@ -17,7 +30,6 @@ fi
 
 # from now on, exit on error (rather than && every little thing)
 PS4=$'-------------=: '
-set -x -e
 
 # possibly replace the version file
 if [ -f /data/hubble_buildinfo ]; then

--- a/pkg/centos7/Dockerfile
+++ b/pkg/centos7/Dockerfile
@@ -20,7 +20,9 @@ RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osque
 RUN yum -y install git \
     libffi-devel openssl-devel libffi libssh2-devel autoconf automake libtool \
     libxml2-devel libxslt-devel libjpeg-devel zlib-devel \
-    make cmake gcc python-devel python-setuptools wget openssl
+    make cmake gcc python-devel python-setuptools wget openssl \
+    && yum clean all \
+    && rm -rf /var/cache/yum
 
 #libcurl install start
 #install libcurl to avoid depending on host version
@@ -37,7 +39,8 @@ RUN mkdir -p "$LIBCURL_TEMP" \
  && ./buildconf \
  && ./configure --prefix=/opt/hubble --disable-ldap --without-nss --disable-manual --disable-gopher --disable-smtp --disable-smb --disable-imap --disable-pop3 --disable-tftp --disable-telnet --disable-dict --disable-ldaps --disable-ldap --disable-rtsp --with-libssh2 \
  && make \
- && make install
+ && make install \
+ && rm -rf "$LIBCURL_TEMP"
 
 #git install start
 #install git so that git package won't be a package dependency
@@ -56,7 +59,8 @@ RUN mkdir -p "$GITTEMP" \
  && echo "NO_PERL=YesPlease" >> config.mak.autogen \
  && sed -i '0,/^NO_GETTEXT/s/^NO_GETTEXT.*/NO_GETTEXT=YesPlease/' config.mak.autogen \
  && make \
- && make install
+ && make install \
+ && rm -rf "$GITTEMP"
 
 #clean up of /opt/hubble
 RUN rm /opt/hubble/bin/curl* \
@@ -77,15 +81,20 @@ RUN mkdir -p "$LIBGIT2TEMP" \
  && cd libgit2-"$LIBGIT2_SRC_VERSION"/ \
  && cmake . -DCMAKE_INSTALL_PREFIX=/usr/local/ \
  && make \
- && make install
+ && make install \
+ && rm -rf "$LIBGIT2TEMP"
 
 #fpm package making requirements start
 RUN yum install -y ruby ruby-devel rpmbuild rpm-build rubygems gcc make \
  && gem install --no-ri --no-rdoc ffi --version 1.12.2 \
- && gem install --no-ri --no-rdoc fpm
+ && gem install --no-ri --no-rdoc fpm \
+ && yum clean all \
+ && rm -rf /var/cache/yum
 
 # things we may need to build a python
-RUN yum install -y bzip2-devel sqlite-devel
+RUN yum install -y bzip2-devel sqlite-devel \
+ && yum clean all \
+ && rm -rf /var/cache/yum
 
 # use pyenv
 ARG PYENV_VERSION=3.6.10
@@ -125,22 +134,12 @@ ENV _BINARY_LOG_LEVEL="INFO"
 ENV _INCLUDE_PATH=""
 ENV LD_LIBRARY_PATH=/opt/hubble/lib:/lib:/lib64:/usr/lib:/usr/lib64:/usr/local/lib:/usr/local/lib64
 
-RUN set -x; git clone "$HUBBLE_GIT_URL" "$HUBBLE_SRC_PATH" \
- && cd "$HUBBLE_SRC_PATH" && git checkout "$HUBBLE_CHECKOUT"
-
-RUN cp -rf "$HUBBLE_SRC_PATH" /hubble_build \
- && rm -rf /hubble_build/.git
-
-RUN cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.orig \
- && sed -i -e "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT}/g" \
-           -e "s/COMMIT_NOT_SET/$(cd $HUBBLE_SRC_PATH; git describe --long --always --tags)/g" \
-           /hubble_build/hubblestack/__init__.py \
- && cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixed
-
 RUN mkdir /data
 VOLUME /data
 
 WORKDIR /hubble_build
 
 COPY entrypoint.sh /entrypoint.sh
+ENV HUBBLE_CHECKOUT_ENV=$HUBBLE_CHECKOUT
+ENV HUBBLE_GIT_URL_ENV=$HUBBLE_GIT_URL
 ENTRYPOINT [ "/bin/bash", "/entrypoint.sh" ]

--- a/pkg/centos7/entrypoint.sh
+++ b/pkg/centos7/entrypoint.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+#Moving hubble source code logic in the shell script
+set -x -e
+git clone "${HUBBLE_GIT_URL_ENV}" "${HUBBLE_SRC_PATH}"
+cd "${HUBBLE_SRC_PATH}"
+git checkout "${HUBBLE_CHECKOUT_ENV}"
+
+cp -rf "${HUBBLE_SRC_PATH}"/* /hubble_build
+rm -rf /hubble_build/.git
+
+cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.orig
+
+sed -i -e "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT_ENV}/g" -e "s/COMMIT_NOT_SET/$(cd ${HUBBLE_SRC_PATH}; git describe --long --always --tags)/g" /hubble_build/hubblestack/__init__.py
+cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixed
 
 eval "$(pyenv init -)"
 
@@ -17,7 +30,6 @@ fi
 
 # from now on, exit on error (rather than && every little thing)
 PS4=$'-------------=: '
-set -x -e
 
 # possibly replace the version file
 if [ -f /data/hubble_buildinfo ]; then

--- a/pkg/centos8/Dockerfile
+++ b/pkg/centos8/Dockerfile
@@ -20,7 +20,9 @@ RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osque
 RUN dnf -y install git \
     libffi-devel openssl-devel libffi libssh-devel autoconf automake libtool \
     libxml2-devel libxslt-devel libjpeg-devel zlib-devel \
-    make cmake gcc python3-devel wget openssl
+    make cmake gcc python3-devel wget openssl \
+    && dnf clean all \
+    && rm -rf /var/cache/dnf
 
 #libcurl install start
 #install libcurl to avoid depending on host version
@@ -43,7 +45,8 @@ RUN mkdir -p "$LIBCURL_TEMP" \
         --disable-rtsp \
         --with-libssh \
  && make \
- && make install
+ && make install \
+ && rm -rf "$LIBCURL_TEMP"
 
 #git install start
 #install git so that git package won't be a package dependency
@@ -62,7 +65,8 @@ RUN mkdir -p "$GITTEMP" \
  && echo "NO_PERL=YesPlease" >> config.mak.autogen \
  && sed -i '0,/^NO_GETTEXT/s/^NO_GETTEXT.*/NO_GETTEXT=YesPlease/' config.mak.autogen \
  && make \
- && make install
+ && make install \
+ && rm -rf "$GITTEMP"
 
 #clean up of /opt/hubble
 RUN rm /opt/hubble/bin/curl* \
@@ -83,10 +87,13 @@ RUN mkdir -p "$LIBGIT2TEMP" \
  && cd libgit2-"$LIBGIT2_SRC_VERSION"/ \
  && cmake . -DCMAKE_INSTALL_PREFIX=/usr/local/ \
  && make \
- && make install
+ && make install \
+ && rm -rf "$LIBGIT2TEMP"
 
 # things we may need to build python and get fpm working
-RUN dnf -y update && dnf install -y ruby ruby-devel rpm-build rubygems gcc make bzip2-devel sqlite-devel
+RUN dnf -y update && dnf install -y ruby ruby-devel rpm-build rubygems gcc make bzip2-devel sqlite-devel \
+    && dnf clean all \
+    && rm -rf /var/cache/dnf
 
 # install fpm
 RUN gem install --no-ri --no-rdoc ffi --version 1.12.2 \
@@ -130,22 +137,12 @@ ENV _BINARY_LOG_LEVEL="INFO"
 ENV _INCLUDE_PATH=""
 ENV LD_LIBRARY_PATH=/opt/hubble/lib:/lib:/lib64:/usr/lib:/usr/lib64:/usr/local/lib:/usr/local/lib64
 
-RUN set -x; git clone "$HUBBLE_GIT_URL" "$HUBBLE_SRC_PATH" \
- && cd "$HUBBLE_SRC_PATH" && git checkout "$HUBBLE_CHECKOUT"
-
-RUN cp -rf "$HUBBLE_SRC_PATH" /hubble_build \
- && rm -rf /hubble_build/.git
-
-RUN cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.orig \
- && sed -i -e "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT}/g" \
-           -e "s/COMMIT_NOT_SET/$(cd $HUBBLE_SRC_PATH; git describe --long --always --tags)/g" \
-           /hubble_build/hubblestack/__init__.py \
- && cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixed
-
 RUN mkdir /data
 VOLUME /data
 
 WORKDIR /hubble_build
 
 COPY entrypoint.sh /entrypoint.sh
+ENV HUBBLE_CHECKOUT_ENV=$HUBBLE_CHECKOUT
+ENV HUBBLE_GIT_URL_ENV=$HUBBLE_GIT_URL
 ENTRYPOINT [ "/bin/bash", "/entrypoint.sh" ]

--- a/pkg/centos8/entrypoint.sh
+++ b/pkg/centos8/entrypoint.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+#Moving hubble source code logic in the shell script
+set -x -e
+git clone "${HUBBLE_GIT_URL_ENV}" "${HUBBLE_SRC_PATH}"
+cd "${HUBBLE_SRC_PATH}"
+git checkout "${HUBBLE_CHECKOUT_ENV}"
+
+cp -rf "${HUBBLE_SRC_PATH}"/* /hubble_build
+rm -rf /hubble_build/.git
+
+cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.orig
+
+sed -i -e "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT_ENV}/g" -e "s/COMMIT_NOT_SET/$(cd ${HUBBLE_SRC_PATH}; git describe --long --always --tags)/g" /hubble_build/hubblestack/__init__.py
+cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixed
 
 eval "$(pyenv init -)"
 
@@ -17,7 +30,6 @@ fi
 
 # from now on, exit on error (rather than && every little thing)
 PS4=$'-------------=: '
-set -x -e
 
 # possibly replace the version file
 if [ -f /data/hubble_buildinfo ]; then

--- a/pkg/coreos/Dockerfile
+++ b/pkg/coreos/Dockerfile
@@ -22,7 +22,8 @@ RUN apt-get -y install git curl \
     python-dev libffi-dev libssl-dev libyaml-dev libssh2-1 libssh2-1-dev autoconf automake libtool \
     libxml2-dev libxslt1-dev python-cffi zlib1g-dev python-setuptools \
     cmake gcc wget python-pip openssl \
- && apt-get clean
+ && apt-get clean \
+ && rm -rf /var/cache/apt
 
 #libcurl install start
 #install libcurl to avoid depending on host version
@@ -39,7 +40,8 @@ RUN mkdir -p "$LIBCURL_TEMP" \
  && ./buildconf \
  && ./configure --prefix=/opt/hubble --disable-ldap --without-nss --disable-manual --disable-gopher --disable-smtp --disable-smb --disable-imap --disable-pop3 --disable-tftp --disable-telnet --disable-dict --disable-ldaps --disable-ldap --disable-rtsp --with-libssh2 \
  && make \
- && make install
+ && make install \
+ && rm -rf "$LIBCURL_TEMP"
 
 #git install start
 #install git so that git package won't be a package dependency
@@ -58,7 +60,8 @@ RUN mkdir -p "$GITTEMP" \
  && echo "NO_PERL=YesPlease" >> config.mak.autogen \
  && sed -i '0,/^NO_GETTEXT/s/^NO_GETTEXT.*/NO_GETTEXT=YesPlease/' config.mak.autogen \
  && make \
- && make install
+ && make install \
+ && rm -rf "$GITTEMP"
 
 #clean up of /opt/hubble
 RUN rm /opt/hubble/bin/curl* \
@@ -80,9 +83,12 @@ RUN mkdir -p "$LIBGIT2TEMP" \
  && export LIBGIT2=/usr/local/ \
  && cmake . -DCMAKE_INSTALL_PREFIX=$LIBGIT2 \
  && make \
- && make install
+ && make install \
+ && rm -rf "$LIBGIT2TEMP"
 
-RUN apt-get install -y libbz2-dev libsqlite3-dev
+RUN apt-get install -y libbz2-dev libsqlite3-dev \
+ && apt-get clean \
+ && rm -rf /var/cache/apt
 
 # use pyenv
 ARG PYENV_VERSION=3.6.10
@@ -120,22 +126,12 @@ ENV _BINARY_LOG_LEVEL="INFO"
 ENV _INCLUDE_PATH=""
 ENV LD_LIBRARY_PATH=/opt/hubble/lib:/lib:/lib64:/usr/lib:/usr/lib64:/usr/local/lib:/usr/local/lib64
 
-RUN set -x; git clone "$HUBBLE_GIT_URL" "$HUBBLE_SRC_PATH" \
- && cd "$HUBBLE_SRC_PATH" && git checkout "$HUBBLE_CHECKOUT"
-
-RUN cp -rf "$HUBBLE_SRC_PATH" /hubble_build \
- && rm -rf /hubble_build/.git
-
-RUN cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.orig \
- && sed -i -e "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT}/g" \
-           -e "s/COMMIT_NOT_SET/$(cd $HUBBLE_SRC_PATH; git describe --long --always --tags)/g" \
-           /hubble_build/hubblestack/__init__.py \
- && cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixed
-
 RUN mkdir /data
 VOLUME /data
 
 WORKDIR /hubble_build
 
 COPY entrypoint.sh /entrypoint.sh
+ENV HUBBLE_CHECKOUT_ENV=$HUBBLE_CHECKOUT
+ENV HUBBLE_GIT_URL_ENV=$HUBBLE_GIT_URL
 ENTRYPOINT [ "/bin/bash", "/entrypoint.sh" ]

--- a/pkg/coreos/entrypoint.sh
+++ b/pkg/coreos/entrypoint.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+#Moving hubble source code logic in the shell script
+set -x -e
+git clone "${HUBBLE_GIT_URL_ENV}" "${HUBBLE_SRC_PATH}"
+cd "${HUBBLE_SRC_PATH}"
+git checkout "${HUBBLE_CHECKOUT_ENV}"
+
+cp -rf "${HUBBLE_SRC_PATH}"/* /hubble_build
+rm -rf /hubble_build/.git
+
+cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.orig
+
+sed -i -e "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT_ENV}/g" -e "s/COMMIT_NOT_SET/$(cd ${HUBBLE_SRC_PATH}; git describe --long --always --tags)/g" /hubble_build/hubblestack/__init__.py
+cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixed
 
 eval "$(pyenv init -)"
 
@@ -17,7 +30,6 @@ fi
 
 # from now on, exit on error (rather than && every little thing)
 PS4=$'-------------=: '
-set -x -e
 
 # possibly replace the version file
 if [ -f /data/hubble_buildinfo ]; then

--- a/pkg/debian10/Dockerfile
+++ b/pkg/debian10/Dockerfile
@@ -23,7 +23,8 @@ RUN apt-get -y install git curl \
     libxml2-dev libxslt1-dev python-cffi \
     zlib1g-dev cmake python-setuptools  \
     gcc wget python-pip openssl \
- && apt-get clean
+ && apt-get clean \
+ && rm -rf /var/cache/apt
 
 #libcurl install start
 #install libcurl to avoid depending on host version
@@ -40,7 +41,8 @@ RUN mkdir -p "$LIBCURL_TEMP" \
  && ./buildconf \
  && ./configure --prefix=/opt/hubble --disable-ldap --without-nss --disable-manual --disable-gopher --disable-smtp --disable-smb --disable-imap --disable-pop3 --disable-tftp --disable-telnet --disable-dict --disable-ldaps --disable-ldap --disable-rtsp --with-libssh2 \
  && make \
- && make install
+ && make install \
+ && rm -rf "$LIBCURL_TEMP"
 
 #git install start
 #install git so that git package won't be a package dependency
@@ -59,7 +61,8 @@ RUN mkdir -p "$GITTEMP" \
  && echo "NO_PERL=YesPlease" >> config.mak.autogen \
  && sed -i '0,/^NO_GETTEXT/s/^NO_GETTEXT.*/NO_GETTEXT=YesPlease/' config.mak.autogen \
  && make \
- && make install
+ && make install \
+ && rm -rf "$GITTEMP"
 
 #clean up of /opt/hubble
 RUN rm /opt/hubble/bin/curl* \
@@ -81,14 +84,19 @@ RUN mkdir -p "$LIBGIT2TEMP" \
  && export LIBGIT2=/usr/local/ \
  && cmake . -DCMAKE_INSTALL_PREFIX=$LIBGIT2 \
  && make \
- && make install
+ && make install \
+ && rm -rf "$LIBGIT2TEMP"
 
 #fpm package making requirements start
 RUN apt-get install -y ruby ruby-dev rubygems gcc make \
  && gem install --no-ri --no-rdoc ffi --version 1.12.2 \
- && gem install --no-ri --no-rdoc fpm
+ && gem install --no-ri --no-rdoc fpm \
+ && apt-get clean \
+ && rm -rf /var/cache/apt
 
-RUN apt-get install -y libbz2-dev libsqlite3-dev
+RUN apt-get install -y libbz2-dev libsqlite3-dev \
+ && apt-get clean \
+ && rm -rf /var/cache/apt
 
 # use pyenv
 ARG PYENV_VERSION=3.6.10
@@ -126,22 +134,12 @@ ENV _BINARY_LOG_LEVEL="INFO"
 ENV _INCLUDE_PATH=""
 ENV LD_LIBRARY_PATH=/opt/hubble/lib:/lib:/lib64:/usr/lib:/usr/lib64:/usr/local/lib:/usr/local/lib64
 
-RUN set -x; git clone "$HUBBLE_GIT_URL" "$HUBBLE_SRC_PATH" \
- && cd "$HUBBLE_SRC_PATH" && git checkout "$HUBBLE_CHECKOUT"
-
-RUN cp -rf "$HUBBLE_SRC_PATH" /hubble_build \
- && rm -rf /hubble_build/.git
-
-RUN cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.orig \
- && sed -i -e "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT}/g" \
-           -e "s/COMMIT_NOT_SET/$(cd $HUBBLE_SRC_PATH; git describe --long --always --tags)/g" \
-           /hubble_build/hubblestack/__init__.py \
- && cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixed
-
 RUN mkdir /data
 VOLUME /data
 
 WORKDIR /hubble_build
 
 COPY entrypoint.sh /entrypoint.sh
+ENV HUBBLE_CHECKOUT_ENV=$HUBBLE_CHECKOUT
+ENV HUBBLE_GIT_URL_ENV=$HUBBLE_GIT_URL
 ENTRYPOINT [ "/bin/bash", "/entrypoint.sh" ]

--- a/pkg/debian10/entrypoint.sh
+++ b/pkg/debian10/entrypoint.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+#Moving hubble source code logic in the shell script
+set -x -e
+git clone "${HUBBLE_GIT_URL_ENV}" "${HUBBLE_SRC_PATH}"
+cd "${HUBBLE_SRC_PATH}"
+git checkout "${HUBBLE_CHECKOUT_ENV}"
+
+cp -rf "${HUBBLE_SRC_PATH}"/* /hubble_build
+rm -rf /hubble_build/.git
+
+cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.orig
+
+sed -i -e "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT_ENV}/g" -e "s/COMMIT_NOT_SET/$(cd ${HUBBLE_SRC_PATH}; git describe --long --always --tags)/g" /hubble_build/hubblestack/__init__.py
+cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixed
 
 eval "$(pyenv init -)"
 
@@ -17,7 +30,6 @@ fi
 
 # from now on, exit on error (rather than && every little thing)
 PS4=$'-------------=: '
-set -x -e
 
 # possibly replace the version file
 if [ -f /data/hubble_buildinfo ]; then

--- a/pkg/debian8/Dockerfile
+++ b/pkg/debian8/Dockerfile
@@ -22,7 +22,8 @@ RUN apt-get -y install git curl \
     python-dev libffi-dev libssl-dev libyaml-dev libssh2-1 libssh2-1-dev autoconf automake libtool \
     libxml2-dev libxslt1-dev zlib1g-dev cmake python-setuptools \
     gcc wget openssl \
- && apt-get clean
+ && apt-get clean \
+ && rm -rf /var/cache/apt
 
 #libcurl install start
 #install libcurl to avoid depending on host version
@@ -39,7 +40,8 @@ RUN mkdir -p "$LIBCURL_TEMP" \
  && ./buildconf \
  && ./configure --prefix=/opt/hubble --disable-ldap --without-nss --disable-manual --disable-gopher --disable-smtp --disable-smb --disable-imap --disable-pop3 --disable-tftp --disable-telnet --disable-dict --disable-ldaps --disable-ldap --disable-rtsp --with-libssh2 \
  && make \
- && make install
+ && make install \
+ && rm -rf "$LIBCURL_TEMP"
 
 #git install start
 #install git so that git package won't be a package dependency
@@ -58,7 +60,8 @@ RUN mkdir -p "$GITTEMP" \
  && echo "NO_PERL=YesPlease" >> config.mak.autogen \
  && sed -i '0,/^NO_GETTEXT/s/^NO_GETTEXT.*/NO_GETTEXT=YesPlease/' config.mak.autogen \
  && make \
- && make install
+ && make install \
+ && rm -rf "$GITTEMP"
 
 #clean up of /opt/hubble
 RUN rm /opt/hubble/bin/curl* \
@@ -80,14 +83,19 @@ RUN mkdir -p "$LIBGIT2TEMP" \
  && export LIBGIT2=/usr/local/ \
  && cmake . -DCMAKE_INSTALL_PREFIX=$LIBGIT2 \
  && make \
- && make install
+ && make install \
+ && rm -rf "$LIBGIT2TEMP"
 
 #fpm package making requirements start
 RUN apt-get install -y ruby ruby-dev rubygems gcc make \
  && gem install --no-ri --no-rdoc ffi --version 1.12.2 \
- && gem install --no-ri --no-rdoc fpm
+ && gem install --no-ri --no-rdoc fpm \
+ && apt-get clean \
+ && rm -rf /var/cache/apt
 
-RUN apt-get install -y libbz2-dev libsqlite3-dev
+RUN apt-get install -y libbz2-dev libsqlite3-dev \
+ && apt-get clean \
+ && rm -rf /var/cache/apt
 
 # use pyenv
 ARG PYENV_VERSION=3.6.10
@@ -125,22 +133,12 @@ ENV _BINARY_LOG_LEVEL="INFO"
 ENV _INCLUDE_PATH=""
 ENV LD_LIBRARY_PATH=/opt/hubble/lib:/lib:/lib64:/usr/lib:/usr/lib64:/usr/local/lib:/usr/local/lib64
 
-RUN set -x; git clone "$HUBBLE_GIT_URL" "$HUBBLE_SRC_PATH" \
- && cd "$HUBBLE_SRC_PATH" && git checkout "$HUBBLE_CHECKOUT"
-
-RUN cp -rf "$HUBBLE_SRC_PATH" /hubble_build \
- && rm -rf /hubble_build/.git
-
-RUN cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.orig \
- && sed -i -e "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT}/g" \
-           -e "s/COMMIT_NOT_SET/$(cd $HUBBLE_SRC_PATH; git describe --long --always --tags)/g" \
-           /hubble_build/hubblestack/__init__.py \
- && cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixed
-
 RUN mkdir /data
 VOLUME /data
 
 WORKDIR /hubble_build
 
 COPY entrypoint.sh /entrypoint.sh
+ENV HUBBLE_CHECKOUT_ENV=$HUBBLE_CHECKOUT
+ENV HUBBLE_GIT_URL_ENV=$HUBBLE_GIT_URL
 ENTRYPOINT [ "/bin/bash", "/entrypoint.sh" ]

--- a/pkg/debian8/entrypoint.sh
+++ b/pkg/debian8/entrypoint.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+#Moving hubble source code logic in the shell script
+set -x -e
+git clone "${HUBBLE_GIT_URL_ENV}" "${HUBBLE_SRC_PATH}"
+cd "${HUBBLE_SRC_PATH}"
+git checkout "${HUBBLE_CHECKOUT_ENV}"
+
+cp -rf "${HUBBLE_SRC_PATH}"/* /hubble_build
+rm -rf /hubble_build/.git
+
+cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.orig
+
+sed -i -e "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT_ENV}/g" -e "s/COMMIT_NOT_SET/$(cd ${HUBBLE_SRC_PATH}; git describe --long --always --tags)/g" /hubble_build/hubblestack/__init__.py
+cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixed
 
 eval "$(pyenv init -)"
 
@@ -17,7 +30,6 @@ fi
 
 # from now on, exit on error (rather than && every little thing)
 PS4=$'-------------=: '
-set -x -e
 
 # possibly replace the version file
 if [ -f /data/hubble_buildinfo ]; then

--- a/pkg/debian9/Dockerfile
+++ b/pkg/debian9/Dockerfile
@@ -23,7 +23,8 @@ RUN apt-get -y install git curl \
     libxml2-dev libxslt1-dev python-cffi \
     zlib1g-dev cmake python-setuptools  \
     gcc wget python-pip openssl \
- && apt-get clean
+    && apt-get clean \
+    && rm -rf /var/cache/apt
 
 #libcurl install start
 #install libcurl to avoid depending on host version
@@ -40,7 +41,8 @@ RUN mkdir -p "$LIBCURL_TEMP" \
  && ./buildconf \
  && ./configure --prefix=/opt/hubble --disable-ldap --without-nss --disable-manual --disable-gopher --disable-smtp --disable-smb --disable-imap --disable-pop3 --disable-tftp --disable-telnet --disable-dict --disable-ldaps --disable-ldap --disable-rtsp --with-libssh2 \
  && make \
- && make install
+ && make install \
+ && rm -rf "$LIBCURL_TEMP"
 
 #git install start
 #install git so that git package won't be a package dependency
@@ -59,7 +61,8 @@ RUN mkdir -p "$GITTEMP" \
  && echo "NO_PERL=YesPlease" >> config.mak.autogen \
  && sed -i '0,/^NO_GETTEXT/s/^NO_GETTEXT.*/NO_GETTEXT=YesPlease/' config.mak.autogen \
  && make \
- && make install
+ && make install \
+ && rm -rf "$GITTEMP"
 
 #clean up of /opt/hubble
 RUN rm /opt/hubble/bin/curl* \
@@ -81,14 +84,19 @@ RUN mkdir -p "$LIBGIT2TEMP" \
  && export LIBGIT2=/usr/local/ \
  && cmake . -DCMAKE_INSTALL_PREFIX=$LIBGIT2 \
  && make \
- && make install
+ && make install \
+ && rm -rf "$LIBGIT2TEMP"
 
 #fpm package making requirements start
 RUN apt-get install -y ruby ruby-dev rubygems gcc make \
  && gem install --no-ri --no-rdoc ffi --version 1.12.2 \
- && gem install --no-ri --no-rdoc fpm
+ && gem install --no-ri --no-rdoc fpm \
+ && apt-get clean \
+ && rm -rf /var/cache/apt
 
-RUN apt-get install -y libbz2-dev libsqlite3-dev
+RUN apt-get install -y libbz2-dev libsqlite3-dev \
+ && apt-get clean \
+ && rm -rf /var/cache/apt
 
 # use pyenv
 ARG PYENV_VERSION=3.6.10
@@ -126,22 +134,12 @@ ENV _BINARY_LOG_LEVEL="INFO"
 ENV _INCLUDE_PATH=""
 ENV LD_LIBRARY_PATH=/opt/hubble/lib:/lib:/lib64:/usr/lib:/usr/lib64:/usr/local/lib:/usr/local/lib64
 
-RUN set -x; git clone "$HUBBLE_GIT_URL" "$HUBBLE_SRC_PATH" \
- && cd "$HUBBLE_SRC_PATH" && git checkout "$HUBBLE_CHECKOUT"
-
-RUN cp -rf "$HUBBLE_SRC_PATH" /hubble_build \
- && rm -rf /hubble_build/.git
-
-RUN cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.orig \
- && sed -i -e "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT}/g" \
-           -e "s/COMMIT_NOT_SET/$(cd $HUBBLE_SRC_PATH; git describe --long --always --tags)/g" \
-           /hubble_build/hubblestack/__init__.py \
- && cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixed
-
 RUN mkdir /data
 VOLUME /data
 
 WORKDIR /hubble_build
 
 COPY entrypoint.sh /entrypoint.sh
+ENV HUBBLE_CHECKOUT_ENV=$HUBBLE_CHECKOUT
+ENV HUBBLE_GIT_URL_ENV=$HUBBLE_GIT_URL
 ENTRYPOINT [ "/bin/bash", "/entrypoint.sh" ]

--- a/pkg/debian9/entrypoint.sh
+++ b/pkg/debian9/entrypoint.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+#Moving hubble source code logic in the shell script
+set -x -e
+git clone "${HUBBLE_GIT_URL_ENV}" "${HUBBLE_SRC_PATH}"
+cd "${HUBBLE_SRC_PATH}"
+git checkout "${HUBBLE_CHECKOUT_ENV}"
+
+cp -rf "${HUBBLE_SRC_PATH}"/* /hubble_build
+rm -rf /hubble_build/.git
+
+cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.orig
+
+sed -i -e "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT_ENV}/g" -e "s/COMMIT_NOT_SET/$(cd ${HUBBLE_SRC_PATH}; git describe --long --always --tags)/g" /hubble_build/hubblestack/__init__.py
+cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixed
 
 eval "$(pyenv init -)"
 
@@ -17,7 +30,6 @@ fi
 
 # from now on, exit on error (rather than && every little thing)
 PS4=$'-------------=: '
-set -x -e
 
 # possibly replace the version file
 if [ -f /data/hubble_buildinfo ]; then

--- a/pkg/dev/amazonlinux2016.09/Dockerfile
+++ b/pkg/dev/amazonlinux2016.09/Dockerfile
@@ -20,7 +20,9 @@ RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osque
 RUN yum -y install git \
     libffi-devel openssl-devel libffi libssh2-devel autoconf automake libtool \
     libxml2-devel libxslt-devel libjpeg-devel zlib-devel \
-    make cmake gcc python-devel python-setuptools wget openssl
+    make cmake gcc python-devel python-setuptools wget openssl \
+    && yum clean all \
+    && rm -rf /var/cache/yum
 
 #libcurl install start
 #install libcurl to avoid depending on host version
@@ -37,7 +39,8 @@ RUN mkdir -p "$LIBCURL_TEMP" \
  && ./buildconf \
  && ./configure --prefix=/opt/hubble --disable-ldap --without-nss --disable-manual --disable-gopher --disable-smtp --disable-smb --disable-imap --disable-pop3 --disable-tftp --disable-telnet --disable-dict --disable-ldaps --disable-ldap --disable-rtsp --with-libssh2 \
  && make \
- && make install
+ && make install \
+ && rm -rf "$LIBCURL_TEMP"
 
 #git install start
 #install git so that git package won't be a package dependency
@@ -56,7 +59,8 @@ RUN mkdir -p "$GITTEMP" \
  && echo "NO_PERL=YesPlease" >> config.mak.autogen \
  && sed -i '0,/^NO_GETTEXT/s/^NO_GETTEXT.*/NO_GETTEXT=YesPlease/' config.mak.autogen \
  && make \
- && make install
+ && make install \
+ && rm -rf "$GITTEMP"
 
 #clean up of /opt/hubble
 RUN rm /opt/hubble/bin/curl* \
@@ -77,15 +81,20 @@ RUN mkdir -p "$LIBGIT2TEMP" \
  && cd libgit2-"$LIBGIT2_SRC_VERSION"/ \
  && cmake . -DCMAKE_INSTALL_PREFIX=/usr/local/ \
  && make \
- && make install
+ && make install \
+ && rm -rf "$LIBGIT2TEMP"
 
 #fpm package making requirements start
 RUN yum install -y ruby ruby-devel rpmbuild rpm-build rubygems gcc make \
  && gem install --no-ri --no-rdoc ffi --version 1.12.2 \
- && gem install --no-ri --no-rdoc fpm
+ && gem install --no-ri --no-rdoc fpm \
+ && yum clean all \
+ && rm -rf /var/cache/yum
 
 # things we may need to build a python
-RUN yum install -y bzip2-devel
+RUN yum install -y bzip2-devel \
+ && yum clean all \
+ && rm -rf /var/cache/yum
 
 # use pyenv
 ARG PYENV_VERSION=3.6.10
@@ -125,22 +134,12 @@ ENV _BINARY_LOG_LEVEL="INFO"
 ENV _INCLUDE_PATH=""
 ENV LD_LIBRARY_PATH=/opt/hubble/lib:/lib:/lib64:/usr/lib:/usr/lib64:/usr/local/lib:/usr/local/lib64
 
-RUN set -x; git clone "$HUBBLE_GIT_URL" "$HUBBLE_SRC_PATH" \
- && cd "$HUBBLE_SRC_PATH" && git checkout "$HUBBLE_CHECKOUT"
-
-RUN cp -rf "$HUBBLE_SRC_PATH" /hubble_build \
- && rm -rf /hubble_build/.git
-
-RUN cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.orig \
- && sed -i -e "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT}/g" \
-           -e "s/COMMIT_NOT_SET/$(cd $HUBBLE_SRC_PATH; git describe --long --always --tags)/g" \
-           /hubble_build/hubblestack/__init__.py \
- && cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixed
-
 RUN mkdir /data
 VOLUME /data
 
 WORKDIR /hubble_build
 
 COPY entrypoint.sh /entrypoint.sh
+ENV HUBBLE_CHECKOUT_ENV=$HUBBLE_CHECKOUT
+ENV HUBBLE_GIT_URL_ENV=$HUBBLE_GIT_URL
 ENTRYPOINT [ "/bin/bash", "/entrypoint.sh" ]

--- a/pkg/dev/amazonlinux2016.09/entrypoint.sh
+++ b/pkg/dev/amazonlinux2016.09/entrypoint.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+#Moving hubble source code logic in the shell script
+set -x -e
+git clone "${HUBBLE_GIT_URL_ENV}" "${HUBBLE_SRC_PATH}"
+cd "${HUBBLE_SRC_PATH}"
+git checkout "${HUBBLE_CHECKOUT_ENV}"
+
+cp -rf "${HUBBLE_SRC_PATH}"/* /hubble_build
+rm -rf /hubble_build/.git
+
+cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.orig
+
+sed -i -e "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT_ENV}/g" -e "s/COMMIT_NOT_SET/$(cd ${HUBBLE_SRC_PATH}; git describe --long --always --tags)/g" /hubble_build/hubblestack/__init__.py
+cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixed
 
 eval "$(pyenv init -)"
 
@@ -17,7 +30,6 @@ fi
 
 # from now on, exit on error (rather than && every little thing)
 PS4=$'-------------=: '
-set -x -e
 
 # possibly replace the version file
 if [ -f /data/hubble_buildinfo ]; then

--- a/pkg/dev/centos6/Dockerfile
+++ b/pkg/dev/centos6/Dockerfile
@@ -20,7 +20,9 @@ RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osque
 RUN yum -y install git \
     libffi-devel openssl-devel libxml2-devel libxslt-devel libffi \
     libssh2-devel autoconf automake libtool libjpeg-devel zlib-devel \
-    make cmake gcc wget openssl
+    make cmake gcc wget openssl \
+    && yum clean all \
+    && rm -rf /var/cache/yum
     
 #libcurl install start
 #install libcurl to avoid depending on host version
@@ -37,7 +39,8 @@ RUN mkdir -p "$LIBCURL_TEMP" \
  && ./buildconf \
  && ./configure --prefix=/opt/hubble --disable-ldap --without-nss --disable-manual --disable-gopher --disable-smtp --disable-smb --disable-imap --disable-pop3 --disable-tftp --disable-telnet --disable-dict --disable-ldaps --disable-ldap --disable-rtsp --with-libssh2 \
  && make \
- && make install
+ && make install \
+ && rm -rf "$LIBCURL_TEMP"
 
 #git install start
 #install git so that git package won't be a package dependency
@@ -56,7 +59,8 @@ RUN mkdir -p "$GITTEMP" \
  && echo "NO_PERL=YesPlease" >> config.mak.autogen \
  && sed -i '0,/^NO_GETTEXT/s/^NO_GETTEXT.*/NO_GETTEXT=YesPlease/' config.mak.autogen \
  && make \
- && make install
+ && make install \
+ && rm -rf "$GITTEMP"
 
 #clean up of /opt/hubble
 RUN rm /opt/hubble/bin/curl* \
@@ -77,15 +81,22 @@ RUN mkdir -p "$LIBGIT2TEMP" \
  && cd libgit2-"$LIBGIT2_SRC_VERSION"/ \
  && cmake . -DCMAKE_INSTALL_PREFIX=/usr/local/ \
  && make \
- && make install
+ && make install \
+ && rm -rf "$LIBGIT2TEMP"
 
 #fpm package making requirements start
-RUN yum install -y centos-release-scl scl-utils
-RUN yum install -y rpmbuild rpm-build gcc make rh-ruby23 rh-ruby23-ruby-devel
+RUN yum install -y centos-release-scl scl-utils \
+ && yum clean all \
+ && rm -rf /var/cache/yum
+RUN yum install -y rpmbuild rpm-build gcc make rh-ruby23 rh-ruby23-ruby-devel \
+ && yum clean all \
+ && rm -rf /var/cache/yum
 RUN scl enable rh-ruby23 "gem install --no-ri --no-rdoc fpm"
 
 # things we may need to build a python
-RUN yum install -y bzip2-devel sqlite-devel
+RUN yum install -y bzip2-devel sqlite-devel \
+ && yum clean all \
+ && rm -rf /var/cache/yum
 
 # use pyenv
 ARG PYENV_VERSION=3.6.10
@@ -125,22 +136,12 @@ ENV _BINARY_LOG_LEVEL="INFO"
 ENV _INCLUDE_PATH=""
 ENV LD_LIBRARY_PATH=/opt/hubble/lib:/lib:/lib64:/usr/lib:/usr/lib64:/usr/local/lib:/usr/local/lib64
 
-RUN set -x; git clone "$HUBBLE_GIT_URL" "$HUBBLE_SRC_PATH" \
- && cd "$HUBBLE_SRC_PATH" && git checkout "$HUBBLE_CHECKOUT"
-
-RUN cp -rf "$HUBBLE_SRC_PATH" /hubble_build \
- && rm -rf /hubble_build/.git
-
-RUN cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.orig \
- && sed -i -e "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT}/g" \
-           -e "s/COMMIT_NOT_SET/$(cd $HUBBLE_SRC_PATH; git describe --long --always --tags)/g" \
-           /hubble_build/hubblestack/__init__.py \
- && cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixed
-
 RUN mkdir /data
 VOLUME /data
 
 WORKDIR /hubble_build
 
 COPY entrypoint.sh /entrypoint.sh
+ENV HUBBLE_CHECKOUT_ENV=$HUBBLE_CHECKOUT
+ENV HUBBLE_GIT_URL_ENV=$HUBBLE_GIT_URL
 ENTRYPOINT [ "/bin/bash", "/entrypoint.sh" ]

--- a/pkg/dev/centos6/entrypoint.sh
+++ b/pkg/dev/centos6/entrypoint.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+#Moving hubble source code logic in the shell script
+set -x -e
+git clone "${HUBBLE_GIT_URL_ENV}" "${HUBBLE_SRC_PATH}"
+cd "${HUBBLE_SRC_PATH}"
+git checkout "${HUBBLE_CHECKOUT_ENV}"
+
+cp -rf "${HUBBLE_SRC_PATH}"/* /hubble_build
+rm -rf /hubble_build/.git
+
+cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.orig
+
+sed -i -e "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT_ENV}/g" -e "s/COMMIT_NOT_SET/$(cd ${HUBBLE_SRC_PATH}; git describe --long --always --tags)/g" /hubble_build/hubblestack/__init__.py
+cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixed
 
 eval "$(pyenv init -)"
 
@@ -17,7 +30,6 @@ fi
 
 # from now on, exit on error (rather than && every little thing)
 PS4=$'-------------=: '
-set -x -e
 
 # possibly replace the version file
 if [ -f /data/hubble_buildinfo ]; then

--- a/pkg/dev/centos7/Dockerfile
+++ b/pkg/dev/centos7/Dockerfile
@@ -20,7 +20,9 @@ RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osque
 RUN yum -y install git \
     libffi-devel openssl-devel libffi libssh2-devel autoconf automake libtool \
     libxml2-devel libxslt-devel libjpeg-devel zlib-devel \
-    make cmake gcc python-devel python-setuptools wget openssl
+    make cmake gcc python-devel python-setuptools wget openssl \
+    && yum clean all \
+    && rm -rf /var/cache/yum
 
 #libcurl install start
 #install libcurl to avoid depending on host version
@@ -37,7 +39,8 @@ RUN mkdir -p "$LIBCURL_TEMP" \
  && ./buildconf \
  && ./configure --prefix=/opt/hubble --disable-ldap --without-nss --disable-manual --disable-gopher --disable-smtp --disable-smb --disable-imap --disable-pop3 --disable-tftp --disable-telnet --disable-dict --disable-ldaps --disable-ldap --disable-rtsp --with-libssh2 \
  && make \
- && make install
+ && make install \
+ && rm -rf "$LIBCURL_TEMP"
 
 #git install start
 #install git so that git package won't be a package dependency
@@ -56,7 +59,8 @@ RUN mkdir -p "$GITTEMP" \
  && echo "NO_PERL=YesPlease" >> config.mak.autogen \
  && sed -i '0,/^NO_GETTEXT/s/^NO_GETTEXT.*/NO_GETTEXT=YesPlease/' config.mak.autogen \
  && make \
- && make install
+ && make install \
+ && rm -rf "$GITTEMP"
 
 #clean up of /opt/hubble
 RUN rm /opt/hubble/bin/curl* \
@@ -77,15 +81,20 @@ RUN mkdir -p "$LIBGIT2TEMP" \
  && cd libgit2-"$LIBGIT2_SRC_VERSION"/ \
  && cmake . -DCMAKE_INSTALL_PREFIX=/usr/local/ \
  && make \
- && make install
+ && make install \
+ && rm -rf "$LIBGIT2TEMP"
 
 #fpm package making requirements start
 RUN yum install -y ruby ruby-devel rpmbuild rpm-build rubygems gcc make \
  && gem install --no-ri --no-rdoc ffi --version 1.12.2 \
- && gem install --no-ri --no-rdoc fpm
+ && gem install --no-ri --no-rdoc fpm \
+ && yum clean all \
+ && rm -rf /var/cache/yum
 
 # things we may need to build a python
-RUN yum install -y bzip2-devel sqlite-devel
+RUN yum install -y bzip2-devel sqlite-devel \
+ && yum clean all \
+ && rm -rf /var/cache/yum
 
 # use pyenv
 ARG PYENV_VERSION=3.6.10
@@ -125,22 +134,12 @@ ENV _BINARY_LOG_LEVEL="INFO"
 ENV _INCLUDE_PATH=""
 ENV LD_LIBRARY_PATH=/opt/hubble/lib:/lib:/lib64:/usr/lib:/usr/lib64:/usr/local/lib:/usr/local/lib64
 
-RUN set -x; git clone "$HUBBLE_GIT_URL" "$HUBBLE_SRC_PATH" \
- && cd "$HUBBLE_SRC_PATH" && git checkout "$HUBBLE_CHECKOUT"
-
-RUN cp -rf "$HUBBLE_SRC_PATH" /hubble_build \
- && rm -rf /hubble_build/.git
-
-RUN cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.orig \
- && sed -i -e "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT}/g" \
-           -e "s/COMMIT_NOT_SET/$(cd $HUBBLE_SRC_PATH; git describe --long --always --tags)/g" \
-           /hubble_build/hubblestack/__init__.py \
- && cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixed
-
 RUN mkdir /data
 VOLUME /data
 
 WORKDIR /hubble_build
 
 COPY entrypoint.sh /entrypoint.sh
+ENV HUBBLE_CHECKOUT_ENV=$HUBBLE_CHECKOUT
+ENV HUBBLE_GIT_URL_ENV=$HUBBLE_GIT_URL
 ENTRYPOINT [ "/bin/bash", "/entrypoint.sh" ]

--- a/pkg/dev/centos7/entrypoint.sh
+++ b/pkg/dev/centos7/entrypoint.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+#Moving hubble source code logic in the shell script
+set -x -e
+git clone "${HUBBLE_GIT_URL_ENV}" "${HUBBLE_SRC_PATH}"
+cd "${HUBBLE_SRC_PATH}"
+git checkout "${HUBBLE_CHECKOUT_ENV}"
+
+cp -rf "${HUBBLE_SRC_PATH}"/* /hubble_build
+rm -rf /hubble_build/.git
+
+cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.orig
+
+sed -i -e "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT_ENV}/g" -e "s/COMMIT_NOT_SET/$(cd ${HUBBLE_SRC_PATH}; git describe --long --always --tags)/g" /hubble_build/hubblestack/__init__.py
+cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixed
 
 eval "$(pyenv init -)"
 
@@ -17,7 +30,6 @@ fi
 
 # from now on, exit on error (rather than && every little thing)
 PS4=$'-------------=: '
-set -x -e
 
 # possibly replace the version file
 if [ -f /data/hubble_buildinfo ]; then

--- a/pkg/dev/centos8/Dockerfile
+++ b/pkg/dev/centos8/Dockerfile
@@ -20,7 +20,9 @@ RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osque
 RUN dnf -y install git \
     libffi-devel openssl-devel libffi libssh-devel autoconf automake libtool \
     libxml2-devel libxslt-devel libjpeg-devel zlib-devel \
-    make cmake gcc python3-devel wget openssl
+    make cmake gcc python3-devel wget openssl \
+    && dnf clean all \
+    && rm -rf /var/cache/dnf
 
 #libcurl install start
 #install libcurl to avoid depending on host version
@@ -43,7 +45,8 @@ RUN mkdir -p "$LIBCURL_TEMP" \
         --disable-rtsp \
         --with-libssh \
  && make \
- && make install
+ && make install \
+ && rm -rf "$LIBCURL_TEMP"
 
 #git install start
 #install git so that git package won't be a package dependency
@@ -62,7 +65,8 @@ RUN mkdir -p "$GITTEMP" \
  && echo "NO_PERL=YesPlease" >> config.mak.autogen \
  && sed -i '0,/^NO_GETTEXT/s/^NO_GETTEXT.*/NO_GETTEXT=YesPlease/' config.mak.autogen \
  && make \
- && make install
+ && make install \
+ && rm -rf "$GITTEMP"
 
 #clean up of /opt/hubble
 RUN rm /opt/hubble/bin/curl* \
@@ -83,10 +87,13 @@ RUN mkdir -p "$LIBGIT2TEMP" \
  && cd libgit2-"$LIBGIT2_SRC_VERSION"/ \
  && cmake . -DCMAKE_INSTALL_PREFIX=/usr/local/ \
  && make \
- && make install
+ && make install \
+ && rm -rf "$LIBGIT2TEMP"
 
 # things we may need to build python and get fpm working
-RUN dnf -y update && dnf install -y ruby ruby-devel rpm-build rubygems gcc make bzip2-devel sqlite-devel
+RUN dnf -y update && dnf install -y ruby ruby-devel rpm-build rubygems gcc make bzip2-devel sqlite-devel \
+    && dnf clean all \
+    && rm -rf /var/cache/dnf
 
 # install fpm
 RUN gem install --no-ri --no-rdoc ffi --version 1.12.2 \
@@ -130,22 +137,12 @@ ENV _BINARY_LOG_LEVEL="INFO"
 ENV _INCLUDE_PATH=""
 ENV LD_LIBRARY_PATH=/opt/hubble/lib:/lib:/lib64:/usr/lib:/usr/lib64:/usr/local/lib:/usr/local/lib64
 
-RUN set -x; git clone "$HUBBLE_GIT_URL" "$HUBBLE_SRC_PATH" \
- && cd "$HUBBLE_SRC_PATH" && git checkout "$HUBBLE_CHECKOUT"
-
-RUN cp -rf "$HUBBLE_SRC_PATH" /hubble_build \
- && rm -rf /hubble_build/.git
-
-RUN cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.orig \
- && sed -i -e "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT}/g" \
-           -e "s/COMMIT_NOT_SET/$(cd $HUBBLE_SRC_PATH; git describe --long --always --tags)/g" \
-           /hubble_build/hubblestack/__init__.py \
- && cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixed
-
 RUN mkdir /data
 VOLUME /data
 
 WORKDIR /hubble_build
 
 COPY entrypoint.sh /entrypoint.sh
+ENV HUBBLE_CHECKOUT_ENV=$HUBBLE_CHECKOUT
+ENV HUBBLE_GIT_URL_ENV=$HUBBLE_GIT_URL
 ENTRYPOINT [ "/bin/bash", "/entrypoint.sh" ]

--- a/pkg/dev/centos8/entrypoint.sh
+++ b/pkg/dev/centos8/entrypoint.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+#Moving hubble source code logic in the shell script
+set -x -e
+git clone "${HUBBLE_GIT_URL_ENV}" "${HUBBLE_SRC_PATH}"
+cd "${HUBBLE_SRC_PATH}"
+git checkout "${HUBBLE_CHECKOUT_ENV}"
+
+cp -rf "${HUBBLE_SRC_PATH}"/* /hubble_build
+rm -rf /hubble_build/.git
+
+cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.orig
+
+sed -i -e "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT_ENV}/g" -e "s/COMMIT_NOT_SET/$(cd ${HUBBLE_SRC_PATH}; git describe --long --always --tags)/g" /hubble_build/hubblestack/__init__.py
+cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixed
 
 eval "$(pyenv init -)"
 
@@ -17,7 +30,6 @@ fi
 
 # from now on, exit on error (rather than && every little thing)
 PS4=$'-------------=: '
-set -x -e
 
 # possibly replace the version file
 if [ -f /data/hubble_buildinfo ]; then

--- a/pkg/dev/coreos/Dockerfile
+++ b/pkg/dev/coreos/Dockerfile
@@ -22,7 +22,8 @@ RUN apt-get -y install git curl \
     python-dev libffi-dev libssl-dev libyaml-dev libssh2-1 libssh2-1-dev autoconf automake libtool \
     libxml2-dev libxslt1-dev python-cffi zlib1g-dev python-setuptools \
     cmake gcc wget python-pip openssl \
- && apt-get clean
+ && apt-get clean \
+ && rm -rf /var/cache/apt
 
 #libcurl install start
 #install libcurl to avoid depending on host version
@@ -39,7 +40,8 @@ RUN mkdir -p "$LIBCURL_TEMP" \
  && ./buildconf \
  && ./configure --prefix=/opt/hubble --disable-ldap --without-nss --disable-manual --disable-gopher --disable-smtp --disable-smb --disable-imap --disable-pop3 --disable-tftp --disable-telnet --disable-dict --disable-ldaps --disable-ldap --disable-rtsp --with-libssh2 \
  && make \
- && make install
+ && make install \
+ && rm -rf "$LIBCURL_TEMP"
 
 #git install start
 #install git so that git package won't be a package dependency
@@ -58,7 +60,8 @@ RUN mkdir -p "$GITTEMP" \
  && echo "NO_PERL=YesPlease" >> config.mak.autogen \
  && sed -i '0,/^NO_GETTEXT/s/^NO_GETTEXT.*/NO_GETTEXT=YesPlease/' config.mak.autogen \
  && make \
- && make install
+ && make install \
+ && rm -rf "$GITTEMP"
 
 #clean up of /opt/hubble
 RUN rm /opt/hubble/bin/curl* \
@@ -80,9 +83,12 @@ RUN mkdir -p "$LIBGIT2TEMP" \
  && export LIBGIT2=/usr/local/ \
  && cmake . -DCMAKE_INSTALL_PREFIX=$LIBGIT2 \
  && make \
- && make install
+ && make install \
+ && rm -rf "$LIBGIT2TEMP"
 
-RUN apt-get install -y libbz2-dev libsqlite3-dev
+RUN apt-get install -y libbz2-dev libsqlite3-dev \
+ && apt-get clean \
+ && rm -rf /var/cache/apt
 
 # use pyenv
 ARG PYENV_VERSION=3.6.10
@@ -120,22 +126,12 @@ ENV _BINARY_LOG_LEVEL="INFO"
 ENV _INCLUDE_PATH=""
 ENV LD_LIBRARY_PATH=/opt/hubble/lib:/lib:/lib64:/usr/lib:/usr/lib64:/usr/local/lib:/usr/local/lib64
 
-RUN set -x; git clone "$HUBBLE_GIT_URL" "$HUBBLE_SRC_PATH" \
- && cd "$HUBBLE_SRC_PATH" && git checkout "$HUBBLE_CHECKOUT"
-
-RUN cp -rf "$HUBBLE_SRC_PATH" /hubble_build \
- && rm -rf /hubble_build/.git
-
-RUN cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.orig \
- && sed -i -e "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT}/g" \
-           -e "s/COMMIT_NOT_SET/$(cd $HUBBLE_SRC_PATH; git describe --long --always --tags)/g" \
-           /hubble_build/hubblestack/__init__.py \
- && cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixed
-
 RUN mkdir /data
 VOLUME /data
 
 WORKDIR /hubble_build
 
 COPY entrypoint.sh /entrypoint.sh
+ENV HUBBLE_CHECKOUT_ENV=$HUBBLE_CHECKOUT
+ENV HUBBLE_GIT_URL_ENV=$HUBBLE_GIT_URL
 ENTRYPOINT [ "/bin/bash", "/entrypoint.sh" ]

--- a/pkg/dev/coreos/entrypoint.sh
+++ b/pkg/dev/coreos/entrypoint.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+#Moving hubble source code logic in the shell script
+set -x -e
+git clone "${HUBBLE_GIT_URL_ENV}" "${HUBBLE_SRC_PATH}"
+cd "${HUBBLE_SRC_PATH}"
+git checkout "${HUBBLE_CHECKOUT_ENV}"
+
+cp -rf "${HUBBLE_SRC_PATH}"/* /hubble_build
+rm -rf /hubble_build/.git
+
+cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.orig
+
+sed -i -e "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT_ENV}/g" -e "s/COMMIT_NOT_SET/$(cd ${HUBBLE_SRC_PATH}; git describe --long --always --tags)/g" /hubble_build/hubblestack/__init__.py
+cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixed
 
 eval "$(pyenv init -)"
 
@@ -17,7 +30,6 @@ fi
 
 # from now on, exit on error (rather than && every little thing)
 PS4=$'-------------=: '
-set -x -e
 
 # possibly replace the version file
 if [ -f /data/hubble_buildinfo ]; then

--- a/pkg/dev/debian10/Dockerfile
+++ b/pkg/dev/debian10/Dockerfile
@@ -23,7 +23,8 @@ RUN apt-get -y install git curl \
     libxml2-dev libxslt1-dev python-cffi \
     zlib1g-dev cmake python-setuptools  \
     gcc wget python-pip openssl \
- && apt-get clean
+ && apt-get clean \
+ && rm -rf /var/cache/apt
 
 #libcurl install start
 #install libcurl to avoid depending on host version
@@ -40,7 +41,8 @@ RUN mkdir -p "$LIBCURL_TEMP" \
  && ./buildconf \
  && ./configure --prefix=/opt/hubble --disable-ldap --without-nss --disable-manual --disable-gopher --disable-smtp --disable-smb --disable-imap --disable-pop3 --disable-tftp --disable-telnet --disable-dict --disable-ldaps --disable-ldap --disable-rtsp --with-libssh2 \
  && make \
- && make install
+ && make install \
+ && rm -rf "$LIBCURL_TEMP"
 
 #git install start
 #install git so that git package won't be a package dependency
@@ -59,7 +61,8 @@ RUN mkdir -p "$GITTEMP" \
  && echo "NO_PERL=YesPlease" >> config.mak.autogen \
  && sed -i '0,/^NO_GETTEXT/s/^NO_GETTEXT.*/NO_GETTEXT=YesPlease/' config.mak.autogen \
  && make \
- && make install
+ && make install \
+ && rm -rf "$GITTEMP"
 
 #clean up of /opt/hubble
 RUN rm /opt/hubble/bin/curl* \
@@ -81,14 +84,19 @@ RUN mkdir -p "$LIBGIT2TEMP" \
  && export LIBGIT2=/usr/local/ \
  && cmake . -DCMAKE_INSTALL_PREFIX=$LIBGIT2 \
  && make \
- && make install
+ && make install \
+ && rm -rf "$LIBGIT2TEMP"
 
 #fpm package making requirements start
 RUN apt-get install -y ruby ruby-dev rubygems gcc make \
  && gem install --no-ri --no-rdoc ffi --version 1.12.2 \
- && gem install --no-ri --no-rdoc fpm
+ && gem install --no-ri --no-rdoc fpm \
+ && apt-get clean \
+ && rm -rf /var/cache/apt
 
-RUN apt-get install -y libbz2-dev libsqlite3-dev
+RUN apt-get install -y libbz2-dev libsqlite3-dev \
+ && apt-get clean \
+ && rm -rf /var/cache/apt
 
 # use pyenv
 ARG PYENV_VERSION=3.6.10
@@ -126,22 +134,12 @@ ENV _BINARY_LOG_LEVEL="INFO"
 ENV _INCLUDE_PATH=""
 ENV LD_LIBRARY_PATH=/opt/hubble/lib:/lib:/lib64:/usr/lib:/usr/lib64:/usr/local/lib:/usr/local/lib64
 
-RUN set -x; git clone "$HUBBLE_GIT_URL" "$HUBBLE_SRC_PATH" \
- && cd "$HUBBLE_SRC_PATH" && git checkout "$HUBBLE_CHECKOUT"
-
-RUN cp -rf "$HUBBLE_SRC_PATH" /hubble_build \
- && rm -rf /hubble_build/.git
-
-RUN cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.orig \
- && sed -i -e "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT}/g" \
-           -e "s/COMMIT_NOT_SET/$(cd $HUBBLE_SRC_PATH; git describe --long --always --tags)/g" \
-           /hubble_build/hubblestack/__init__.py \
- && cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixed
-
 RUN mkdir /data
 VOLUME /data
 
 WORKDIR /hubble_build
 
 COPY entrypoint.sh /entrypoint.sh
+ENV HUBBLE_CHECKOUT_ENV=$HUBBLE_CHECKOUT
+ENV HUBBLE_GIT_URL_ENV=$HUBBLE_GIT_URL
 ENTRYPOINT [ "/bin/bash", "/entrypoint.sh" ]

--- a/pkg/dev/debian10/entrypoint.sh
+++ b/pkg/dev/debian10/entrypoint.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+#Moving hubble source code logic in the shell script
+set -x -e
+git clone "${HUBBLE_GIT_URL_ENV}" "${HUBBLE_SRC_PATH}"
+cd "${HUBBLE_SRC_PATH}"
+git checkout "${HUBBLE_CHECKOUT_ENV}"
+
+cp -rf "${HUBBLE_SRC_PATH}"/* /hubble_build
+rm -rf /hubble_build/.git
+
+cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.orig
+
+sed -i -e "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT_ENV}/g" -e "s/COMMIT_NOT_SET/$(cd ${HUBBLE_SRC_PATH}; git describe --long --always --tags)/g" /hubble_build/hubblestack/__init__.py
+cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixed
 
 eval "$(pyenv init -)"
 
@@ -17,7 +30,6 @@ fi
 
 # from now on, exit on error (rather than && every little thing)
 PS4=$'-------------=: '
-set -x -e
 
 # possibly replace the version file
 if [ -f /data/hubble_buildinfo ]; then

--- a/pkg/dev/debian8/Dockerfile
+++ b/pkg/dev/debian8/Dockerfile
@@ -22,7 +22,8 @@ RUN apt-get -y install git curl \
     python-dev libffi-dev libssl-dev libyaml-dev libssh2-1 libssh2-1-dev autoconf automake libtool \
     libxml2-dev libxslt1-dev zlib1g-dev cmake python-setuptools \
     gcc wget openssl \
- && apt-get clean
+ && apt-get clean \
+ && rm -rf /var/cache/apt
 
 #libcurl install start
 #install libcurl to avoid depending on host version
@@ -39,7 +40,8 @@ RUN mkdir -p "$LIBCURL_TEMP" \
  && ./buildconf \
  && ./configure --prefix=/opt/hubble --disable-ldap --without-nss --disable-manual --disable-gopher --disable-smtp --disable-smb --disable-imap --disable-pop3 --disable-tftp --disable-telnet --disable-dict --disable-ldaps --disable-ldap --disable-rtsp --with-libssh2 \
  && make \
- && make install
+ && make install \
+ && rm -rf "$LIBCURL_TEMP"
 
 #git install start
 #install git so that git package won't be a package dependency
@@ -58,7 +60,8 @@ RUN mkdir -p "$GITTEMP" \
  && echo "NO_PERL=YesPlease" >> config.mak.autogen \
  && sed -i '0,/^NO_GETTEXT/s/^NO_GETTEXT.*/NO_GETTEXT=YesPlease/' config.mak.autogen \
  && make \
- && make install
+ && make install \
+ && rm -rf "$GITTEMP"
 
 #clean up of /opt/hubble
 RUN rm /opt/hubble/bin/curl* \
@@ -80,14 +83,19 @@ RUN mkdir -p "$LIBGIT2TEMP" \
  && export LIBGIT2=/usr/local/ \
  && cmake . -DCMAKE_INSTALL_PREFIX=$LIBGIT2 \
  && make \
- && make install
+ && make install \
+ && rm -rf "$LIBGIT2TEMP"
 
 #fpm package making requirements start
 RUN apt-get install -y ruby ruby-dev rubygems gcc make \
  && gem install --no-ri --no-rdoc ffi --version 1.12.2 \
- && gem install --no-ri --no-rdoc fpm
+ && gem install --no-ri --no-rdoc fpm \
+ && apt-get clean \
+ && rm -rf /var/cache/apt
 
-RUN apt-get install -y libbz2-dev libsqlite3-dev
+RUN apt-get install -y libbz2-dev libsqlite3-dev \
+ && apt-get clean \
+ && rm -rf /var/cache/apt
 
 # use pyenv
 ARG PYENV_VERSION=3.6.10
@@ -125,22 +133,12 @@ ENV _BINARY_LOG_LEVEL="INFO"
 ENV _INCLUDE_PATH=""
 ENV LD_LIBRARY_PATH=/opt/hubble/lib:/lib:/lib64:/usr/lib:/usr/lib64:/usr/local/lib:/usr/local/lib64
 
-RUN set -x; git clone "$HUBBLE_GIT_URL" "$HUBBLE_SRC_PATH" \
- && cd "$HUBBLE_SRC_PATH" && git checkout "$HUBBLE_CHECKOUT"
-
-RUN cp -rf "$HUBBLE_SRC_PATH" /hubble_build \
- && rm -rf /hubble_build/.git
-
-RUN cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.orig \
- && sed -i -e "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT}/g" \
-           -e "s/COMMIT_NOT_SET/$(cd $HUBBLE_SRC_PATH; git describe --long --always --tags)/g" \
-           /hubble_build/hubblestack/__init__.py \
- && cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixed
-
 RUN mkdir /data
 VOLUME /data
 
 WORKDIR /hubble_build
 
 COPY entrypoint.sh /entrypoint.sh
+ENV HUBBLE_CHECKOUT_ENV=$HUBBLE_CHECKOUT
+ENV HUBBLE_GIT_URL_ENV=$HUBBLE_GIT_URL
 ENTRYPOINT [ "/bin/bash", "/entrypoint.sh" ]

--- a/pkg/dev/debian8/entrypoint.sh
+++ b/pkg/dev/debian8/entrypoint.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+#Moving hubble source code logic in the shell script
+set -x -e
+git clone "${HUBBLE_GIT_URL_ENV}" "${HUBBLE_SRC_PATH}"
+cd "${HUBBLE_SRC_PATH}"
+git checkout "${HUBBLE_CHECKOUT_ENV}"
+
+cp -rf "${HUBBLE_SRC_PATH}"/* /hubble_build
+rm -rf /hubble_build/.git
+
+cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.orig
+
+sed -i -e "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT_ENV}/g" -e "s/COMMIT_NOT_SET/$(cd ${HUBBLE_SRC_PATH}; git describe --long --always --tags)/g" /hubble_build/hubblestack/__init__.py
+cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixed
 
 eval "$(pyenv init -)"
 
@@ -17,7 +30,6 @@ fi
 
 # from now on, exit on error (rather than && every little thing)
 PS4=$'-------------=: '
-set -x -e
 
 # possibly replace the version file
 if [ -f /data/hubble_buildinfo ]; then

--- a/pkg/dev/debian9/Dockerfile
+++ b/pkg/dev/debian9/Dockerfile
@@ -23,7 +23,8 @@ RUN apt-get -y install git curl \
     libxml2-dev libxslt1-dev python-cffi \
     zlib1g-dev cmake python-setuptools  \
     gcc wget python-pip openssl \
- && apt-get clean
+    && apt-get clean \
+    && rm -rf /var/cache/apt
 
 #libcurl install start
 #install libcurl to avoid depending on host version
@@ -40,7 +41,8 @@ RUN mkdir -p "$LIBCURL_TEMP" \
  && ./buildconf \
  && ./configure --prefix=/opt/hubble --disable-ldap --without-nss --disable-manual --disable-gopher --disable-smtp --disable-smb --disable-imap --disable-pop3 --disable-tftp --disable-telnet --disable-dict --disable-ldaps --disable-ldap --disable-rtsp --with-libssh2 \
  && make \
- && make install
+ && make install \
+ && rm -rf "$LIBCURL_TEMP"
 
 #git install start
 #install git so that git package won't be a package dependency
@@ -59,7 +61,8 @@ RUN mkdir -p "$GITTEMP" \
  && echo "NO_PERL=YesPlease" >> config.mak.autogen \
  && sed -i '0,/^NO_GETTEXT/s/^NO_GETTEXT.*/NO_GETTEXT=YesPlease/' config.mak.autogen \
  && make \
- && make install
+ && make install \
+ && rm -rf "$GITTEMP"
 
 #clean up of /opt/hubble
 RUN rm /opt/hubble/bin/curl* \
@@ -81,14 +84,19 @@ RUN mkdir -p "$LIBGIT2TEMP" \
  && export LIBGIT2=/usr/local/ \
  && cmake . -DCMAKE_INSTALL_PREFIX=$LIBGIT2 \
  && make \
- && make install
+ && make install \
+ && rm -rf "$LIBGIT2TEMP"
 
 #fpm package making requirements start
 RUN apt-get install -y ruby ruby-dev rubygems gcc make \
  && gem install --no-ri --no-rdoc ffi --version 1.12.2 \
- && gem install --no-ri --no-rdoc fpm
+ && gem install --no-ri --no-rdoc fpm \
+ && apt-get clean \
+ && rm -rf /var/cache/apt
 
-RUN apt-get install -y libbz2-dev libsqlite3-dev
+RUN apt-get install -y libbz2-dev libsqlite3-dev \
+ && apt-get clean \
+ && rm -rf /var/cache/apt
 
 # use pyenv
 ARG PYENV_VERSION=3.6.10
@@ -126,22 +134,12 @@ ENV _BINARY_LOG_LEVEL="INFO"
 ENV _INCLUDE_PATH=""
 ENV LD_LIBRARY_PATH=/opt/hubble/lib:/lib:/lib64:/usr/lib:/usr/lib64:/usr/local/lib:/usr/local/lib64
 
-RUN set -x; git clone "$HUBBLE_GIT_URL" "$HUBBLE_SRC_PATH" \
- && cd "$HUBBLE_SRC_PATH" && git checkout "$HUBBLE_CHECKOUT"
-
-RUN cp -rf "$HUBBLE_SRC_PATH" /hubble_build \
- && rm -rf /hubble_build/.git
-
-RUN cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.orig \
- && sed -i -e "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT}/g" \
-           -e "s/COMMIT_NOT_SET/$(cd $HUBBLE_SRC_PATH; git describe --long --always --tags)/g" \
-           /hubble_build/hubblestack/__init__.py \
- && cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixed
-
 RUN mkdir /data
 VOLUME /data
 
 WORKDIR /hubble_build
 
 COPY entrypoint.sh /entrypoint.sh
+ENV HUBBLE_CHECKOUT_ENV=$HUBBLE_CHECKOUT
+ENV HUBBLE_GIT_URL_ENV=$HUBBLE_GIT_URL
 ENTRYPOINT [ "/bin/bash", "/entrypoint.sh" ]

--- a/pkg/dev/debian9/entrypoint.sh
+++ b/pkg/dev/debian9/entrypoint.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+#Moving hubble source code logic in the shell script
+set -x -e
+git clone "${HUBBLE_GIT_URL_ENV}" "${HUBBLE_SRC_PATH}"
+cd "${HUBBLE_SRC_PATH}"
+git checkout "${HUBBLE_CHECKOUT_ENV}"
+
+cp -rf "${HUBBLE_SRC_PATH}"/* /hubble_build
+rm -rf /hubble_build/.git
+
+cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.orig
+
+sed -i -e "s/BRANCH_NOT_SET/${HUBBLE_CHECKOUT_ENV}/g" -e "s/COMMIT_NOT_SET/$(cd ${HUBBLE_SRC_PATH}; git describe --long --always --tags)/g" /hubble_build/hubblestack/__init__.py
+cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixed
 
 eval "$(pyenv init -)"
 
@@ -17,7 +30,6 @@ fi
 
 # from now on, exit on error (rather than && every little thing)
 PS4=$'-------------=: '
-set -x -e
 
 # possibly replace the version file
 if [ -f /data/hubble_buildinfo ]; then


### PR DESCRIPTION
- Moved git cloning logic to entrypoint so that it is not cached by docker and runs everytime.
- Cleaned up various redundant files to make docker images smaller which will be helpful in caching.