### PR TITLE
Adding FDG Command line parser module

### DIFF
--- a/hubblestack/extmods/fdg/command_line_parser.py
+++ b/hubblestack/extmods/fdg/command_line_parser.py
@@ -1,0 +1,195 @@
+"""
+This module is used to find the value of a command line parameter.
+Inputs : key_aliases (List) : List of keys whose value is to be fetched
+         delimiter (String): the assignment operator between the key and the value
+         chained (String): The command line in which to search for keys.
+                    This needs to be passed from another FDG module via chaining.
+         chained_status (boolean): Status returned by the chained method.
+Output (tuple):  tuple with two values. First item is the status of the module's execution.
+                Second item is list of values corresponding to the given key_aliases, fetched from the chained string.
+
+BASIC EXAMPLES:
+Inputs:
+    key_aliases = ["config-file"]
+    delimiter = "="
+    chained = "dockerd --config-file=/etc/docker/daemon.json --log-level=debug"
+Output: (True, ["/etc/docker/daemon.json"])
+
+UNIT TESTS:
+Check the unit test case file 'test_command_line_parser.py' to understand more examples on how this module works.
+
+NOTES:
+
+Understanding the regex(s):
+You can copy paste the regex(s) on this webpage - https://regex101.com/ to understand more about the regex.
+However, here is a small explanation
+
+regex_pattern :
+    "(?<=(\s|{))-{0,2}\"{0,1}\'{0,1}" + key_alias + "\"{0,1}\'{0,1}\s?" + delimiter + "\s?openingbracket.*closingbracket(?=(\s|$))"
+    This regex primarily focuses on whether the value is embedded inside brackets.
+
+1. '?<=' : denotes a positive lookbehind
+2. '\s' : matches the <space> character
+3. '{' : matches opening braces
+4. (\s|{) : () brackets signify a group. This is the first group in this regex
+4. -{0,2} : matches (zero to two) hyphens.
+5. \"{0,1}\'{0,1} : matches if any quotes are present.
+5. key_alias : matches the given key_alias.
+6. /s? : matches 0 or 1 <space> character
+7. delimiter : matches the input delimiter
+8. openingbracket : is later replaced by one of the three opening bracket types
+9. .*? : matches any character lazily.
+10. closingbracket : is later replaced by one of the three closing bracket types
+11. (?=(\s|$|})) : matches that the end of the pattern must contain either <space> or EOL
+
+regex1 :
+    "(?<=(\s|{))-{0,2}\"{0,1}\'{0,1}" + key_alias + "\"{0,1}\'{0,1}\s?" + delimiter + "\s?([\",\']).*?\\2"
+    This regex primarily focuses on whether the value is embedded inside double or single quotes
+
+The starting regex is similar to the regex_pattern.
+1. ([\", \']) : () brackets signify a group. This is the second group in this regex.
+                    [\",\'] inside the () matches either a double-quote or a single-quote.
+2. .*? : matches any character lazily.
+3. \\2 : matches the second group of the regex.
+
+regex2 :
+    "(?<=(\s|{))-{0,2}\"{0,1}\'{0,1}" + key_alias + "\"{0,1}\'{0,1}\s?" + delimiter + "\s?.+?(?=(\s|$|}))"
+The starting regex is similar to the regex_pattern.
+
+1. (?=(\s|$)) : matches that the end of the pattern must contain either <space> or EOL
+"""
+
+import logging
+import re
+
+log = logging.getLogger(__name__)
+default_delimiters = [":", "=", " "]
+logging.basicConfig(level=logging.DEBUG)
+open_bracket_list = ["[","{","("]
+close_bracket_list = ["]","}",")"]
+
+
+def parse_cmdline(params='', chained=None, chained_status=None):
+    try:
+        if not params:
+            ret = {'Failure': 'invalid input, no params provided'}
+            return False, ret
+
+        if not params.get('key_aliases'):
+            log.error("No key_aliases provided in params to parse_cmdline, returning False")
+            return False, ''
+        else:
+            key_aliases = params.get('key_aliases')
+
+        if not chained:
+            log.error("No chained value provided to parse_cmdline function, returning False")
+            return False, ''
+        elif not chained.get('cmdline'):
+            log.error("cmdline not provided to parse_cmdline function, returning False")
+            return False, ''
+        else:
+            command_line = chained.get('cmdline')
+
+        if not params.get('delimiter') or len(params.get('delimiter')) > 1:
+            log.info("Either length of delimiter exceeds 1 or no delimiter provided with "
+                     "command line '%s'", command_line)
+            return False, ''
+        else:
+            delimiter = params.get('delimiter')
+
+        log.debug("value of command_line is %s", command_line)
+        log.debug("value of key_aliases is %s", key_aliases)
+        log.debug("value of delimiter is '%s'", delimiter)
+        ret_match_list = []
+
+        for key_alias in key_aliases:
+            log.debug("looping with key_alias %s", key_alias)
+            key_alias = key_alias.lstrip("-")
+
+            if key_alias not in command_line:
+                log.info("key_alias %s not found in command line %s", key_alias, command_line)
+                continue
+
+            regex_list = []
+            regex_pattern = "(?<=(\s|{))-{0,2}\"{0,1}\'{0,1}" + key_alias + "\"{0,1}\'{0,1}\s?" + delimiter + "\s?openingbracket.*closingbracket(?=(\s|$))"
+            braces_list = [('\[','\]'), ('\{','\}'), ('\(','\)')]
+            for item in braces_list:
+                regex = re.sub("openingbracket", item[0], regex_pattern)
+                regex = re.sub("closingbracket", item[1], regex)
+                regex_list.append(regex)
+            regex1 = "(?<=(\s|{))-{0,2}\"{0,1}\'{0,1}" + key_alias + "\"{0,1}\'{0,1}\s?" + delimiter + "\s?([\",\']).*?\\2"
+            regex2 = "(?<=(\s|{))-{0,2}\"{0,1}\'{0,1}" + key_alias + "\"{0,1}\'{0,1}\s?" + delimiter + "\s?.+?(?=(\s|$))"
+            regex_list.append(regex1)
+            regex_list.append(regex2)
+
+            for regex in regex_list:
+                log.debug("looping with regex : %s", regex)
+                match_list = _get_match_list(regex, key_alias, command_line, delimiter)
+                if match_list:
+                    ret_match_list.extend(match_list)
+                    break
+
+        return True, ret_match_list
+    except Exception as e:
+        log.exception("Some exception occurred in command_line_parser's parse_cmdline function %s", e)
+        return False, ''
+
+
+def _get_match_list(regex, key_alias, command_line, delimiter):
+    """
+
+    :param regex: search for this pattern in command_line
+    :param key_alias: The key whose value is to be found out
+    :param command_line: command_line from where the value is to be fetched
+    :param delimiter: assignment operator between key and value
+    :return: List of all matching patterns
+
+    This function will fetch all matching patterns of regex in command_line and will then strip the
+    matched value to remove the leading and trailing hyphens (-), <spaces> and quotes.
+    Since the regex also contains the 'key' and 'delimiter', that is also stripped away to get the final value.
+    """
+    match_list = []
+
+    matches = re.finditer(regex, command_line)
+    for matchNum, match in enumerate(matches, start=1):
+        log.info("Match {matchNum} was found at {start}-{end}: {match}".format(matchNum=matchNum,
+                                                                                   start=match.start(), end=match.end(),
+                                                                                   match=match.group()))
+        value = match.group().lstrip("-")
+        value = value.replace("\"" + key_alias + "\"", key_alias)
+        value = value.replace("\'" + key_alias + "\'", key_alias)
+        prefix = key_alias + delimiter
+        value = value.replace(prefix, '')
+        value = value.rstrip('\"\' ')
+        value = value.lstrip('\"\' ')
+        if value[0] in open_bracket_list:
+            value = _fetch_bracketed_value(value)
+
+        match_list.append(value)
+
+    return match_list
+
+
+def _fetch_bracketed_value(value):
+    """
+    Loops over the string value passed and return the first bracket balanced string.
+    :param value: input string value
+    :return: return a substring that has balanced brackets starting with the first opening bracket
+    """
+    stack = []
+    char_pos = 0
+    stacked_once = False
+    for i in value:
+        if i in open_bracket_list:
+            stack.append(i)
+            stacked_once = True
+        elif i in close_bracket_list:
+            pos = close_bracket_list.index(i)
+            if ((len(stack) > 0) and
+                    (open_bracket_list[pos] == stack[len(stack) - 1])):
+                stack.pop()
+        if stacked_once and len(stack) == 0:
+            return value[:char_pos+1]
+        char_pos += 1
+
+    return ''

--- a/hubblestack/extmods/fdg/command_line_parser.py
+++ b/hubblestack/extmods/fdg/command_line_parser.py
@@ -129,6 +129,9 @@ def parse_cmdline(params=None, chained=None, chained_status=None):
                     ret_match_list.extend(match_list)
                     break
 
+        if not ret_match_list:
+            log.info("No Match was found for %s in %s, returning False", key_aliases, command_line)
+            return False, ret_match_list
         return True, ret_match_list
     except Exception as e:
         log.exception("Some exception occurred in command_line_parser's parse_cmdline function %s", e)

--- a/hubblestack/extmods/fdg/command_line_parser.py
+++ b/hubblestack/extmods/fdg/command_line_parser.py
@@ -151,10 +151,8 @@ def _get_match_list(regex, key_alias, command_line, delimiter):
     match_list = []
 
     matches = re.finditer(regex, command_line)
-    for matchNum, match in enumerate(matches, start=1):
-        log.info("Match {matchNum} was found at {start}-{end}: {match}".format(matchNum=matchNum,
-                                                                                   start=match.start(), end=match.end(),
-                                                                                   match=match.group()))
+    for match_num, match in enumerate(matches, start=1):
+        log.info("Match %d was found at %d-%d: %s", match_num, match.start(), match.end(), match.group())
         value = match.group().lstrip("-")
         value = value.replace("".join(["\"", key_alias, "\""]), key_alias)
         value = value.replace("".join(["\'", key_alias, "\'"]), key_alias)

--- a/hubblestack/extmods/fdg/command_line_parser.py
+++ b/hubblestack/extmods/fdg/command_line_parser.py
@@ -129,9 +129,6 @@ def parse_cmdline(params=None, chained=None, chained_status=None):
                     ret_match_list.extend(match_list)
                     break
 
-        if not ret_match_list:
-            log.info("No Match was found for %s in %s, returning False", key_aliases, command_line)
-            return False, ret_match_list
         return True, ret_match_list
     except Exception as e:
         log.exception("Some exception occurred in command_line_parser's parse_cmdline function %s", e)

--- a/tests/unittests/test_command_line_parser.py
+++ b/tests/unittests/test_command_line_parser.py
@@ -17,7 +17,7 @@ def test_match_key_alias_in_middle_of_cmdline():
         'delimiter': '='
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    log.debug("return value is {0}".format(val))
+    log.debug("return value is %s", val)
     expected_value = (True, ["/etc/docker/daemon.json"])
     assert val == expected_value
 
@@ -35,7 +35,7 @@ def test_match_key_alias_at_end_of_cmdline():
         'delimiter': '='
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    log.debug("return value is {0}".format(val))
+    log.debug("return value is %s", val)
     expected_value = (True, ["debug"])
     assert val == expected_value
 
@@ -53,7 +53,7 @@ def test_key_alias_not_found_in_cmdline():
         'delimiter': '='
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    log.debug("return value is {0}".format(val))
+    log.debug("return value is %s", val)
     expected_value = (True, [])
     assert val == expected_value
 
@@ -71,7 +71,7 @@ def test_multiple_return_values():
               'delimiter': '='
               }
     val = command_line_parser.parse_cmdline(params = params, chained=command_line)
-    log.debug("return value is {0}".format(val))
+    log.debug("return value is %s", val)
     expected_value = (True, ["a:b", "d:e"])
     assert val == expected_value
 
@@ -89,7 +89,7 @@ def test_multiple_key_aliases():
         'delimiter': '='
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    log.debug("return value is {0}".format(val))
+    log.debug("return value is %s", val)
     expected_value = (True, ["a:b", "d:e"])
     assert val == expected_value
 
@@ -107,7 +107,7 @@ def test_values_with_single_quotes():
         'delimiter': '='
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    log.debug("return value is {0}".format(val))
+    log.debug("return value is %s", val)
     expected_value = (True, ["a:b", "d:e"])
     assert val[0] == expected_value[0]
     assert val[1] == expected_value[1]
@@ -126,7 +126,7 @@ def test_second_regex():
         'delimiter': ' '
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    log.debug("return value is {0}".format(val))
+    log.debug("return value is %s", val)
     expected_value = (True, ["a:b", "d:e"])
     assert val == expected_value
 
@@ -144,7 +144,7 @@ def test_do_not_match_partial_matching_key_alias():
         'delimiter': '='
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    log.debug("return value is {0}".format(val))
+    log.debug("return value is %s", val)
     expected_value = (True, [])
     assert val == expected_value
 
@@ -162,7 +162,7 @@ def test_do_not_match_partial_matching_key_alias_short():
         'delimiter': '='
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    log.debug("return value is {0}".format(val))
+    log.debug("return value is %s", val)
     expected_value = (True, [])
     assert val == expected_value
 
@@ -180,7 +180,7 @@ def test_curl_example():
         'delimiter': ' '
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    log.debug("return value is {0}".format(val))
+    log.debug("return value is %s", val)
     expected_value = (True, ["username=yourusername&password=yourpassword"])
     assert val == expected_value
 
@@ -198,7 +198,7 @@ def test_curl_example_different_position():
         'delimiter': ' '
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    log.debug("return value is {0}".format(val))
+    log.debug("return value is %s", val)
     expected_value = (True, ["username=yourusername&password=yourpassword"])
     assert val == expected_value
 
@@ -216,7 +216,7 @@ def test_curl_quote_in_value():
         'delimiter': ' '
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    log.debug("return value is {0}".format(val))
+    log.debug("return value is %s", val)
     expected_value = (True, ["username=your'susername&password=yourpassword"])
     assert val == expected_value
 
@@ -234,7 +234,7 @@ def test_with_special_chars_in_value():
         'delimiter': ' '
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    log.debug("return value is {0}".format(val))
+    log.debug("return value is %s", val)
     expected_value = (True, ["X-Header: value"])
     assert val == expected_value
 
@@ -252,7 +252,7 @@ def test_key_alias_with_space():
         'delimiter': ' '
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    log.debug("return value is {0}".format(val))
+    log.debug("return value is %s", val)
     expected_value = (True, ["9f9408b2d29e"])
     assert val == expected_value
 
@@ -270,7 +270,7 @@ def test_long_option_with_complex_value():
         'delimiter': ' '
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    log.debug("return value is {0}".format(val))
+    log.debug("return value is %s", val)
     expected_value = (True, ["/tmp/docker_test.cid"])
     assert val == expected_value
 
@@ -288,7 +288,7 @@ def test_value_with_assignment_operator():
         'delimiter': ' '
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    log.debug("return value is {0}".format(val))
+    log.debug("return value is %s", val)
     expected_value = (True, ["size=120G"])
     assert val == expected_value
 
@@ -306,7 +306,7 @@ def test_value_is_a_list():
         'delimiter': ':'
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    log.debug("return value is {0}".format(val))
+    log.debug("return value is %s", val)
     expected_value = (True, ["[\"value1\", \"value2\"]"])
     assert val == expected_value
 
@@ -324,7 +324,7 @@ def test_java_example1():
         'delimiter': ':'
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    log.debug("return value is {0}".format(val))
+    log.debug("return value is %s", val)
     expected_value = (True, ["/var/run/nlserver6.pid"])
     assert val == expected_value
 
@@ -343,7 +343,7 @@ def test_java_example2():
         'delimiter': '='
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    log.debug("return value is {0}".format(val))
+    log.debug("return value is %s", val)
     expected_value = (True, ["10"])
     assert val == expected_value
 
@@ -361,7 +361,7 @@ def test_java_example3():
         'delimiter': '='
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    log.debug("return value is {0}".format(val))
+    log.debug("return value is %s", val)
     expected_value = (True, ["128m"])
     assert val == expected_value
 
@@ -379,7 +379,7 @@ def test_java_example4():
         'delimiter': ' '
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    log.debug("return value is {0}".format(val))
+    log.debug("return value is %s", val)
     expected_value = (True, ["/apps/api-etms/usage-tracking-services-launchpad.jar"])
     assert val == expected_value
 
@@ -414,7 +414,7 @@ def test_java_example5():
         'delimiter': '='
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    log.debug("return value is {0}".format(val))
+    log.debug("return value is %s", val)
     expected_value = (True, ["2048"])
     assert val == expected_value
 
@@ -432,7 +432,7 @@ def test_value_with_multiple_special_chars():
         'delimiter': ' '
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    log.debug("return value is {0}".format(val))
+    log.debug("return value is %s", val)
     expected_value = (True, ["/run:rw,noexec,nosuid,size=65536k"])
     assert val == expected_value
 
@@ -450,7 +450,7 @@ def test_key_value_inside_dict():
         'delimiter': ':'
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    log.debug("return value is {0}".format(val))
+    log.debug("return value is %s", val)
     expected_value = (True, ["value1"])
     assert val == expected_value
 
@@ -468,7 +468,7 @@ def test_value_with_special_char():
         'delimiter': '='
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    log.debug("return value is {0}".format(val))
+    log.debug("return value is %s", val)
     expected_value = (True, ["http://localhost:9090/-/reload"])
     assert val == expected_value
 
@@ -486,7 +486,7 @@ def test_value_with_brackets():
         'delimiter': '='
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    log.debug("return value is {0}".format(val))
+    log.debug("return value is %s", val)
     expected_value = (True, ['{"labels":[{"key":"DCOS_PACKAGE_IS_FRAMEWORK","value":"false"}]}'])
     assert val == expected_value
 
@@ -504,7 +504,7 @@ def test_value_has_regex():
         'delimiter': '='
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    log.debug("return value is {0}".format(val))
+    log.debug("return value is %s", val)
     expected_value = (True, ['^(dm-\d+|ram|loop|fd|(h|s|v|xv)d[a-z]|nvme\d+n\d+p)\d+$'])
     assert val == expected_value
 
@@ -522,7 +522,7 @@ def test_value_has_regex2():
         'delimiter': '='
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    log.debug("return value is {0}".format(val))
+    log.debug("return value is %s", val)
     expected_value = (True, ['^/proc|^/sys|^/dev|^/mnt|^/export|^/var/lib/mysql|^/volr'])
     assert val == expected_value
 
@@ -534,7 +534,7 @@ def test_fetch_bracketed_value():
     log.info("Executing test_fetch_bracketed_value")
     value = "[dummy]"
     val = command_line_parser._fetch_bracketed_value(value)
-    log.debug("return value is {0}".format(val))
+    log.debug("return value is %s", val)
     expected_value = ('[dummy]')
     assert val == expected_value
 
@@ -547,7 +547,7 @@ def test_no_params():
     log.info("Executing test_no_params")
     command_line = {"cmdline" : ""}
     val = command_line_parser.parse_cmdline(params='', chained=command_line)
-    log.debug("return value is {0}".format(val))
+    log.debug("return value is %s", val)
     assert not val[0]
 
 
@@ -563,7 +563,7 @@ def test_no_keys_given():
         'delimiter': '='
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    log.debug("return value is {0}".format(val))
+    log.debug("return value is %s", val)
     assert not val[0]
 
 
@@ -579,7 +579,7 @@ def test_no_chained_value_given():
         'delimiter': '='
     }
     val = command_line_parser.parse_cmdline(params=params, chained='')
-    log.debug("return value is {0}".format(val))
+    log.debug("return value is %s", val)
     assert not val[0]
 
 
@@ -596,7 +596,7 @@ def test_wrong_chained_value_format():
         'delimiter': '='
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    log.debug("return value is {0}".format(val))
+    log.debug("return value is %s", val)
     assert not val[0]
 
 
@@ -612,7 +612,7 @@ def test_no_delimiter():
         'key_aliases': key_aliases
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    log.debug("return value is {0}".format(val))
+    log.debug("return value is %s", val)
     assert not val[0]
 
 
@@ -629,7 +629,7 @@ def test_extra_spaces():
         'delimiter': ' '
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    log.debug("return value is {0}".format(val))
+    log.debug("return value is %s", val)
     expected_value = (True, [('a:b')])
     assert val == expected_value
 
@@ -647,7 +647,7 @@ def test_extra_spaces_different_delimiter():
         'delimiter': '='
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    log.debug("return value is {0}".format(val))
+    log.debug("return value is %s", val)
     expected_value = (True, [('a:b')])
     assert val == expected_value
 

--- a/tests/unittests/test_command_line_parser.py
+++ b/tests/unittests/test_command_line_parser.py
@@ -54,7 +54,7 @@ def test_key_alias_not_found_in_cmdline():
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
     log.debug("return value is {0}".format(val))
-    expected_value = (False, [])
+    expected_value = (True, [])
     assert val == expected_value
 
 
@@ -145,7 +145,7 @@ def test_do_not_match_partial_matching_key_alias():
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
     log.debug("return value is {0}".format(val))
-    expected_value = (False, [])
+    expected_value = (True, [])
     assert val == expected_value
 
 
@@ -163,7 +163,7 @@ def test_do_not_match_partial_matching_key_alias_short():
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
     log.debug("return value is {0}".format(val))
-    expected_value = (False, [])
+    expected_value = (True, [])
     assert val == expected_value
 
 

--- a/tests/unittests/test_command_line_parser.py
+++ b/tests/unittests/test_command_line_parser.py
@@ -5,7 +5,11 @@ log = logging.getLogger(__name__)
 
 
 def test_match_key_alias_in_middle_of_cmdline():
-    log.info("\n Executing test_match_key_alias_in_middle_of_cmdline")
+    """
+    Key alias is in the middle of commandLine
+    Expected Status : True
+    """
+    log.info("Executing test_match_key_alias_in_middle_of_cmdline")
     command_line = {"cmdline" : "dockerd --config-file=\"/etc/docker/daemon.json\" --log-level=\"debug\""}
     key_aliases = ["config-file"]
     params = {
@@ -13,13 +17,17 @@ def test_match_key_alias_in_middle_of_cmdline():
         'delimiter': '='
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    print("return value is {0}".format(val))
+    log.debug("return value is {0}".format(val))
     expected_value = (True, ["/etc/docker/daemon.json"])
     assert val == expected_value
 
 
 def test_match_key_alias_at_end_of_cmdline():
-    log.info("\n Executing test_match_key_alias_at_end_of_cmdline")
+    """
+        Key alias is at the end of commandLine
+        Expected Status : True
+    """
+    log.info("Executing test_match_key_alias_at_end_of_cmdline")
     command_line = {"cmdline":"dockerd --config-file=\"/etc/docker/daemon.json\" --log-level=\"debug\""}
     key_aliases = ["log-level"]
     params = {
@@ -27,13 +35,17 @@ def test_match_key_alias_at_end_of_cmdline():
         'delimiter': '='
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    print("return value is {0}".format(val))
+    log.debug("return value is {0}".format(val))
     expected_value = (True, ["debug"])
     assert val == expected_value
 
 
 def test_key_alias_not_found_in_cmdline():
-    log.info("\n Executing test_key_alias_not_found_in_cmdline")
+    """
+        Key alias is not found in the commandLine
+        Expected Status : True
+    """
+    log.info("Executing test_key_alias_not_found_in_cmdline")
     command_line = {"cmdline":"dockerd --config-file=\"/etc/docker/daemon.json\" --log-level=\"debug\""}
     key_aliases = ["not_found"]
     params = {
@@ -41,13 +53,17 @@ def test_key_alias_not_found_in_cmdline():
         'delimiter': '='
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    print("return value is {0}".format(val))
+    log.debug("return value is {0}".format(val))
     expected_value = (True, [])
     assert val == expected_value
 
 
 def test_multiple_return_values():
-    log.info("\n Executing test_multiple_return_values")
+    """
+        commandline has multiple values corresponding to the key
+        Expected Status : True
+    """
+    log.info("Executing test_multiple_return_values")
     command_line = {"cmdline" : "docker run -v=\"a:b\" --volume=\"d:e\" --log-level=\"debug\""}
     key_aliases = ["v", "volume"]
     params = {
@@ -55,13 +71,17 @@ def test_multiple_return_values():
               'delimiter': '='
               }
     val = command_line_parser.parse_cmdline(params = params, chained=command_line)
-    print("return value is {0}".format(val))
+    log.debug("return value is {0}".format(val))
     expected_value = (True, ["a:b", "d:e"])
     assert val == expected_value
 
 
 def test_multiple_key_aliases():
-    log.info("\n Executing test_multiple_key_aliases")
+    """
+        result has results for multiple keys
+        Expected Status : True
+    """
+    log.info("Executing test_multiple_key_aliases")
     command_line = {"cmdline":"docker run -v=\"a:b\" -v=\"d:e\" --log-level=\"debug\""}
     key_aliases = ["volume", "v"]
     params = {
@@ -69,13 +89,17 @@ def test_multiple_key_aliases():
         'delimiter': '='
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    print("return value is {0}".format(val))
+    log.debug("return value is {0}".format(val))
     expected_value = (True, ["a:b", "d:e"])
     assert val == expected_value
 
 
 def test_values_with_single_quotes():
-    log.info("\n Executing test_values_with_single_quotes")
+    """
+        values in command line have single-quotes
+        Expected Status : True
+    """
+    log.info("Executing test_values_with_single_quotes")
     command_line = {"cmdline":"docker run -v=\'a:b\' -v=\'d:e\' --log-level=\'debug\'"}
     key_aliases = ["volume", "v"]
     params = {
@@ -83,14 +107,18 @@ def test_values_with_single_quotes():
         'delimiter': '='
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    print("return value is {0}".format(val))
+    log.debug("return value is {0}".format(val))
     expected_value = (True, ["a:b", "d:e"])
     assert val[0] == expected_value[0]
     assert val[1] == expected_value[1]
 
 
 def test_second_regex():
-    log.info("\n Executing test_second_regex")
+    """
+        Match is done through second regex in code
+        Expected Status : True
+    """
+    log.info("Executing test_second_regex")
     command_line = {"cmdline" : "docker run -it -v a:b -v d:e"}
     key_aliases = ["volume", "v"]
     params = {
@@ -98,13 +126,17 @@ def test_second_regex():
         'delimiter': ' '
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    print("return value is {0}".format(val))
+    log.debug("return value is {0}".format(val))
     expected_value = (True, ["a:b", "d:e"])
     assert val == expected_value
 
 
 def test_do_not_match_partial_matching_key_alias():
-    log.info("\n Executing test_do_not_match_partial_matching_key_alias")
+    """
+        Partial match of key is not done. Here the commandline string is substring of key
+        Expected Status : True
+    """
+    log.info("Executing test_do_not_match_partial_matching_key_alias")
     command_line = {"cmdline" : "dockerd --config-file=\"/etc/docker/daemon.json\" --log-level=\"debug\""}
     key_aliases = ["prefix_log-level"]
     params = {
@@ -112,13 +144,17 @@ def test_do_not_match_partial_matching_key_alias():
         'delimiter': '='
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    print("return value is {0}".format(val))
+    log.debug("return value is {0}".format(val))
     expected_value = (True, [])
     assert val == expected_value
 
 
 def test_do_not_match_partial_matching_key_alias_short():
-    log.info("\n Executing test_do_not_match_partial_matching_key_alias")
+    """
+        Partial match of key is not done. Here the key is substring of commandline string
+        Expected Status : True
+    """
+    log.info("Executing test_do_not_match_partial_matching_key_alias")
     command_line = {"cmdline" : "dockerd --config-file=\"/etc/docker/daemon.json\" --log-level=\"debug\""}
     key_aliases = ["level"]
     params = {
@@ -126,13 +162,17 @@ def test_do_not_match_partial_matching_key_alias_short():
         'delimiter': '='
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    print("return value is {0}".format(val))
+    log.debug("return value is {0}".format(val))
     expected_value = (True, [])
     assert val == expected_value
 
 
 def test_curl_example():
-    log.info("\n Executing test_curl_example")
+    """
+        Test performed on curl syntax
+        Expected Status : True
+    """
+    log.info("Executing test_curl_example")
     command_line = {"cmdline" : "curl -X POST http://www.yourwebsite.com/login/ -d 'username=yourusername&password=yourpassword'"}
     key_aliases = ["d"]
     params = {
@@ -140,13 +180,17 @@ def test_curl_example():
         'delimiter': ' '
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    print("return value is {0}".format(val))
+    log.debug("return value is {0}".format(val))
     expected_value = (True, ["username=yourusername&password=yourpassword"])
     assert val == expected_value
 
 
 def test_curl_example_different_position():
-    log.info("\n Executing test_curl_example")
+    """
+        Test performed on curl syntax. Tweaking commandline
+        Expected Status : True
+    """
+    log.info("Executing test_curl_example")
     command_line = {"cmdline" : "curl -X POST -d 'username=yourusername&password=yourpassword' http://www.yourwebsite.com/login/"}
     key_aliases = ["d"]
     params = {
@@ -154,13 +198,17 @@ def test_curl_example_different_position():
         'delimiter': ' '
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    print("return value is {0}".format(val))
+    log.debug("return value is {0}".format(val))
     expected_value = (True, ["username=yourusername&password=yourpassword"])
     assert val == expected_value
 
 
 def test_curl_quote_in_value():
-    log.info("\n Executing test_curl_example")
+    """
+        The value has a single quote and must be present in final result.
+        Expected Status : True
+    """
+    log.info("Executing test_curl_example")
     command_line = {"cmdline" : "curl -X POST -d \"username=your'susername&password=yourpassword\" http://www.yourwebsite.com/login/"}
     key_aliases = ["d"]
     params = {
@@ -168,13 +216,17 @@ def test_curl_quote_in_value():
         'delimiter': ' '
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    print("return value is {0}".format(val))
+    log.debug("return value is {0}".format(val))
     expected_value = (True, ["username=your'susername&password=yourpassword"])
     assert val == expected_value
 
 
 def test_with_special_chars_in_value():
-    log.info("\n Executing test_curl_example")
+    """
+        Test done with header value in Curl
+        Expected Status : True
+    """
+    log.info("Executing test_curl_example")
     command_line = {"cmdline" : "curl -H \"X-Header: value\" https://www.keycdn.com"}
     key_aliases = ["-H"]
     params = {
@@ -182,13 +234,17 @@ def test_with_special_chars_in_value():
         'delimiter': ' '
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    print("return value is {0}".format(val))
+    log.debug("return value is {0}".format(val))
     expected_value = (True, ["X-Header: value"])
     assert val == expected_value
 
 
 def test_key_alias_with_space():
-    log.info("\n Executing test_key_alias_with_space")
+    """
+        Key alias has spaces
+        Expected Status : True
+    """
+    log.info("Executing test_key_alias_with_space")
     command_line = {"cmdline" : "docker network inspect 9f9408b2d29e"}
     key_aliases = ["network inspect"]
     params = {
@@ -196,13 +252,17 @@ def test_key_alias_with_space():
         'delimiter': ' '
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    print("return value is {0}".format(val))
+    log.debug("return value is {0}".format(val))
     expected_value = (True, ["9f9408b2d29e"])
     assert val == expected_value
 
 
-def test_long_option_with_space():
-    log.info("\n Executing test_long_option_with_space")
+def test_long_option_with_complex_value():
+    """
+        value has special chars
+        Expected Status : True
+    """
+    log.info("Executing test_long_option_with_space")
     command_line = {"cmdline" : "docker run --cidfile /tmp/docker_test.cid ubuntu echo \"test\""}
     key_aliases = ["cidfile"]
     params = {
@@ -210,13 +270,17 @@ def test_long_option_with_space():
         'delimiter': ' '
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    print("return value is {0}".format(val))
+    log.debug("return value is {0}".format(val))
     expected_value = (True, ["/tmp/docker_test.cid"])
     assert val == expected_value
 
 
-def test_value_with_assigment_operator():
-    log.info("\n Executing test_value_with_assigment_operator")
+def test_value_with_assignment_operator():
+    """
+        Value has assignment operator.
+        Expected Status : True
+    """
+    log.info("Executing test_value_with_assignment_operator")
     command_line = {"cmdline" : "docker run -it --storage-opt size=120G fedora /bin/bash"}
     key_aliases = ["storage-opt"]
     params = {
@@ -224,13 +288,17 @@ def test_value_with_assigment_operator():
         'delimiter': ' '
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    print("return value is {0}".format(val))
+    log.debug("return value is {0}".format(val))
     expected_value = (True, ["size=120G"])
     assert val == expected_value
 
 
 def test_value_is_a_list():
-    log.info("\n Executing test_value_is_a_list")
+    """
+        Value is a list
+        Expected Status : True
+    """
+    log.info("Executing test_value_is_a_list")
     command_line = {"cmdline" : "tool_name --key:[\"value1\", \"value2\"]"}
     key_aliases = ["key"]
     params = {
@@ -238,13 +306,17 @@ def test_value_is_a_list():
         'delimiter': ':'
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    print("return value is {0}".format(val))
+    log.debug("return value is {0}".format(val))
     expected_value = (True, ["[\"value1\", \"value2\"]"])
     assert val == expected_value
 
 
 def test_java_example1():
-    log.info("\n Executing test_java_example1")
+    """
+        Test done on java syntax.
+        Expected Status : True
+    """
+    log.info("Executing test_java_example1")
     command_line = {"cmdline" : "nlserver watchdog -svc -noconsole -pidfile:/var/run/nlserver6.pid"}
     key_aliases = ["pidfile"]
     params = {
@@ -252,13 +324,17 @@ def test_java_example1():
         'delimiter': ':'
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    print("return value is {0}".format(val))
+    log.debug("return value is {0}".format(val))
     expected_value = (True, ["/var/run/nlserver6.pid"])
     assert val == expected_value
 
 
 def test_java_example2():
-    log.info("\n Executing test_java_example2")
+    """
+        Test done on java syntax. Key has colon.
+        Expected Status : True
+    """
+    log.info("Executing test_java_example2")
     command_line = {"cmdline" : "/etc/alternatives/jre/bin/java -Xmx1024m -XX:OnOutOfMemoryError=kill -9 %p -XX:MinHeapFreeRatio=10 -server " \
                    "-cp /usr/share/aws/emr/instance-controller/lib/*:/home/hadoop/conf -Dlog4j.defaultInitOverride aws157.instancecontroller.Main"}
     key_aliases = ["XX:MinHeapFreeRatio"]
@@ -267,13 +343,17 @@ def test_java_example2():
         'delimiter': '='
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    print("return value is {0}".format(val))
+    log.debug("return value is {0}".format(val))
     expected_value = (True, ["10"])
     assert val == expected_value
 
 
 def test_java_example3():
-    log.info("\n Executing test_java_example3")
+    """
+        Test done on java syntax. Value has assignment operator
+        Expected Status : True
+    """
+    log.info("Executing test_java_example3")
     command_line = {"cmdline" : "/apps/api-etms/jdk1.8.0_241/bin/java -XX:PermSize=128m -XX:MaxPermSize=256m -jar /apps/api-etms/usage-tracking-services-launchpad.jar"}
     key_aliases = ["XX:PermSize"]
     params = {
@@ -281,13 +361,17 @@ def test_java_example3():
         'delimiter': '='
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    print("return value is {0}".format(val))
+    log.debug("return value is {0}".format(val))
     expected_value = (True, ["128m"])
     assert val == expected_value
 
 
 def test_java_example4():
-    log.info("\n Executing test_java_example4")
+    """
+        Test done on java syntax. value has extension
+        Expected Status : True
+    """
+    log.info("Executing test_java_example4")
     command_line = {"cmdline" : "/apps/api-etms/jdk1.8.0_241/bin/java -XX:PermSize=128m -XX:MaxPermSize=256m -jar /apps/api-etms/usage-tracking-services-launchpad.jar"}
     key_aliases = ["jar"]
     params = {
@@ -295,13 +379,17 @@ def test_java_example4():
         'delimiter': ' '
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    print("return value is {0}".format(val))
+    log.debug("return value is {0}".format(val))
     expected_value = (True, ["/apps/api-etms/usage-tracking-services-launchpad.jar"])
     assert val == expected_value
 
 
 def test_java_example5():
-    log.info("\n Executing test_java_example5")
+    """
+        Test done on java syntax. commandline has many other similar key value pairs.
+        Expected Status : True
+    """
+    log.info("Executing test_java_example5")
     command_line = {"cmdline" : "/opt/oobe/jdk1.8.0_202/bin/java -Djava.util.logging.config.file=/opt/oobe/oobe-tomcat-9.0.31/conf/logging.properties " \
                    "-Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager -Djdk.tls.ephemeralDHKeySize=2048 " \
                    "-Djava.protocol.handler.pkgs=org.apache.catalina.webresources -Dorg.apache.catalina.security.SecurityListener.UMASK=0027 " \
@@ -326,13 +414,17 @@ def test_java_example5():
         'delimiter': '='
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    print("return value is {0}".format(val))
+    log.debug("return value is {0}".format(val))
     expected_value = (True, ["2048"])
     assert val == expected_value
 
 
 def test_value_with_multiple_special_chars():
-    log.info("\n Executing test_value_with_multiple_special_chars")
+    """
+        Value has word separator (comma)
+        Expected Status : True
+    """
+    log.info("Executing test_value_with_multiple_special_chars")
     command_line = {"cmdline" : "docker run -d --tmpfs /run:rw,noexec,nosuid,size=65536k my_image"}
     key_aliases = ["tmpfs"]
     params = {
@@ -340,13 +432,17 @@ def test_value_with_multiple_special_chars():
         'delimiter': ' '
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    print("return value is {0}".format(val))
+    log.debug("return value is {0}".format(val))
     expected_value = (True, ["/run:rw,noexec,nosuid,size=65536k"])
     assert val == expected_value
 
 
 def test_key_value_inside_dict():
-    log.info("\n Executing test_key_value_inside_dict")
+    """
+        key value pair is inside a dict
+        Expected Status : True
+    """
+    log.info("Executing test_key_value_inside_dict")
     command_line = {"cmdline" : "tool_name --key={\"subkey1\":\"value1\", \"subkey2\":\"value2\"}"}
     key_aliases = ["subkey1"]
     params = {
@@ -354,13 +450,17 @@ def test_key_value_inside_dict():
         'delimiter': ':'
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    print("return value is {0}".format(val))
+    log.debug("return value is {0}".format(val))
     expected_value = (True, ["value1"])
     assert val == expected_value
 
 
 def test_value_with_special_char():
-    log.info("\n Executing test_value_with_special_char")
+    """
+        value is a URL
+        Expected Status : True
+    """
+    log.info("Executing test_value_with_special_char")
     command_line = {"cmdline" : "/configmap-reload --volume-dir=/etc/prometheus --webhook-url=http://localhost:9090/-/reload"}
     key_aliases = ["webhook-url"]
     params = {
@@ -368,13 +468,17 @@ def test_value_with_special_char():
         'delimiter': '='
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    print("return value is {0}".format(val))
+    log.debug("return value is {0}".format(val))
     expected_value = (True, ["http://localhost:9090/-/reload"])
     assert val == expected_value
 
 
 def test_value_with_brackets():
-    log.info("\n Executing test_value_with_regex")
+    """
+        Value is a dict
+        Expected Status : True
+    """
+    log.info("Executing test_value_with_regex")
     command_line = {"cmdline" : 'mesos-journald-logger --journald_labels={"labels":[{"key":"DCOS_PACKAGE_IS_FRAMEWORK","value":"false"}]} --logrotate_max_size={"size":"50MB"}'}
     key_aliases = ["journald_labels"]
     params = {
@@ -382,13 +486,17 @@ def test_value_with_brackets():
         'delimiter': '='
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    print("return value is {0}".format(val))
+    log.debug("return value is {0}".format(val))
     expected_value = (True, ['{"labels":[{"key":"DCOS_PACKAGE_IS_FRAMEWORK","value":"false"}]}'])
     assert val == expected_value
 
 
 def test_value_has_regex():
-    log.info("\n Executing test_value_with_regex")
+    """
+        Value is a regex
+        Expected Status : True
+    """
+    log.info("Executing test_value_with_regex")
     command_line = {"cmdline" : '/bin/node_exporter --collector.diskstats.ignored-devices=^(dm-\d+|ram|loop|fd|(h|s|v|xv)d[a-z]|nvme\d+n\d+p)\d+$'}
     key_aliases = ["collector.diskstats.ignored-devices"]
     params = {
@@ -396,13 +504,17 @@ def test_value_has_regex():
         'delimiter': '='
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    print("return value is {0}".format(val))
+    log.debug("return value is {0}".format(val))
     expected_value = (True, ['^(dm-\d+|ram|loop|fd|(h|s|v|xv)d[a-z]|nvme\d+n\d+p)\d+$'])
     assert val == expected_value
 
 
 def test_value_has_regex2():
-    log.info("\n Executing test_value_with_regex")
+    """
+        Value is a regex (test2)
+        Expected Status : True
+    """
+    log.info("Executing test_value_with_regex")
     command_line = {"cmdline" : "/bin/sh -c nice -n 15 ionice -c2 -n7 clamscan -r -d /var/lib/clamav --infected --exclude-dir='^/proc|^/sys|^/dev|^/mnt|^/export|^/var/lib/mysql|^/volr' / > /var/log/clamav/clamscan.log"}
     key_aliases = ["exclude-dir"]
     params = {
@@ -410,54 +522,73 @@ def test_value_has_regex2():
         'delimiter': '='
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    print("return value is {0}".format(val))
+    log.debug("return value is {0}".format(val))
     expected_value = (True, ['^/proc|^/sys|^/dev|^/mnt|^/export|^/var/lib/mysql|^/volr'])
     assert val == expected_value
 
 
 def test_fetch_bracketed_value():
-    log.info("\n Executing test_fetch_bracketed_value")
+    """
+        fetch_bracketed_value function is tested against a positive value.
+    """
+    log.info("Executing test_fetch_bracketed_value")
     value = "[dummy]"
     val = command_line_parser._fetch_bracketed_value(value)
-    print("return value is {0}".format(val))
+    log.debug("return value is {0}".format(val))
     expected_value = ('[dummy]')
     assert val == expected_value
 
 
 def test_no_params():
-    log.info("\n Executing test_no_params")
+    """
+        Params are not given
+        Expected Status : False
+    """
+    log.info("Executing test_no_params")
     command_line = {"cmdline" : ""}
     val = command_line_parser.parse_cmdline(params='', chained=command_line)
-    print("return value is {0}".format(val))
-    assert val[0] == False
+    log.debug("return value is {0}".format(val))
+    assert not val[0]
 
 
 def test_no_keys_given():
-    log.info("\n Executing test_no_keys_given")
+    """
+        Keys are not given
+        Expected Status : False
+    """
+    log.info("Executing test_no_keys_given")
     command_line = {"cmdline" : ""}
     params = {
         'key_aliases': '',
         'delimiter': '='
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    print("return value is {0}".format(val))
-    assert val[0] == False
+    log.debug("return value is {0}".format(val))
+    assert not val[0]
 
 
 def test_no_chained_value_given():
-    log.info("\n Executing test_no_chained_value_given")
+    """
+        chained value is not given
+        Expected Status : False
+    """
+    log.info("Executing test_no_chained_value_given")
     key_aliases = ["exclude-dir"]
     params = {
         'key_aliases': key_aliases,
         'delimiter': '='
     }
     val = command_line_parser.parse_cmdline(params=params, chained='')
-    print("return value is {0}".format(val))
-    assert val[0] == False
+    log.debug("return value is {0}".format(val))
+    assert not val[0]
 
 
 def test_wrong_chained_value_format():
-    log.info("\n Executing test_wrong_chained_value_format")
+    """
+        command_line dict has no key 'cmdline'
+        Expected Status : False
+    """
+    log.info("Executing test_wrong_chained_value_format")
     command_line = {"command_line": "docker run -d --tmpfs /run:rw,noexec,nosuid,size=65536k my_image"}
     key_aliases = ["exclude-dir"]
     params = {
@@ -465,17 +596,58 @@ def test_wrong_chained_value_format():
         'delimiter': '='
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    print("return value is {0}".format(val))
-    assert val[0] == False
+    log.debug("return value is {0}".format(val))
+    assert not val[0]
 
 
 def test_no_delimiter():
-    log.info("\n Executing test_match_key_alias_in_middle_of_cmdline")
+    """
+        No delimiter given
+        Expected Status : False
+    """
+    log.info("Executing test_match_key_alias_in_middle_of_cmdline")
     command_line = {"cmdline" : "dockerd --config-file=\"/etc/docker/daemon.json\" --log-level=\"debug\""}
     key_aliases = ["config-file"]
     params = {
         'key_aliases': key_aliases
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
-    print("return value is {0}".format(val))
-    assert val[0] == False
+    log.debug("return value is {0}".format(val))
+    assert not val[0]
+
+
+def test_extra_spaces():
+    """
+        Extra spaces present between key value
+        Expected Status : True
+    """
+    log.info("Executing test_extra_spaces")
+    command_line = {"cmdline" : "docker run -v        a:b"}
+    key_aliases = ["v"]
+    params = {
+        'key_aliases': key_aliases,
+        'delimiter': ' '
+    }
+    val = command_line_parser.parse_cmdline(params=params, chained=command_line)
+    log.debug("return value is {0}".format(val))
+    expected_value = (True, [('a:b')])
+    assert val == expected_value
+
+
+def test_extra_spaces_different_delimiter():
+    """
+        Extra spaces present between key value
+        Expected Status : True
+    """
+    log.info("Executing test_extra_spaces")
+    command_line = {"cmdline" : "docker run -v    =     a:b"}
+    key_aliases = ["v"]
+    params = {
+        'key_aliases': key_aliases,
+        'delimiter': '='
+    }
+    val = command_line_parser.parse_cmdline(params=params, chained=command_line)
+    log.debug("return value is {0}".format(val))
+    expected_value = (True, [('a:b')])
+    assert val == expected_value
+

--- a/tests/unittests/test_command_line_parser.py
+++ b/tests/unittests/test_command_line_parser.py
@@ -54,7 +54,7 @@ def test_key_alias_not_found_in_cmdline():
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
     log.debug("return value is {0}".format(val))
-    expected_value = (True, [])
+    expected_value = (False, [])
     assert val == expected_value
 
 
@@ -145,7 +145,7 @@ def test_do_not_match_partial_matching_key_alias():
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
     log.debug("return value is {0}".format(val))
-    expected_value = (True, [])
+    expected_value = (False, [])
     assert val == expected_value
 
 
@@ -163,7 +163,7 @@ def test_do_not_match_partial_matching_key_alias_short():
     }
     val = command_line_parser.parse_cmdline(params=params, chained=command_line)
     log.debug("return value is {0}".format(val))
-    expected_value = (True, [])
+    expected_value = (False, [])
     assert val == expected_value
 
 

--- a/tests/unittests/test_command_line_parser.py
+++ b/tests/unittests/test_command_line_parser.py
@@ -1,0 +1,481 @@
+import hubblestack.extmods.fdg.command_line_parser as command_line_parser
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def test_match_key_alias_in_middle_of_cmdline():
+    log.info("\n Executing test_match_key_alias_in_middle_of_cmdline")
+    command_line = {"cmdline" : "dockerd --config-file=\"/etc/docker/daemon.json\" --log-level=\"debug\""}
+    key_aliases = ["config-file"]
+    params = {
+        'key_aliases': key_aliases,
+        'delimiter': '='
+    }
+    val = command_line_parser.parse_cmdline(params=params, chained=command_line)
+    print("return value is {0}".format(val))
+    expected_value = (True, ["/etc/docker/daemon.json"])
+    assert val == expected_value
+
+
+def test_match_key_alias_at_end_of_cmdline():
+    log.info("\n Executing test_match_key_alias_at_end_of_cmdline")
+    command_line = {"cmdline":"dockerd --config-file=\"/etc/docker/daemon.json\" --log-level=\"debug\""}
+    key_aliases = ["log-level"]
+    params = {
+        'key_aliases': key_aliases,
+        'delimiter': '='
+    }
+    val = command_line_parser.parse_cmdline(params=params, chained=command_line)
+    print("return value is {0}".format(val))
+    expected_value = (True, ["debug"])
+    assert val == expected_value
+
+
+def test_key_alias_not_found_in_cmdline():
+    log.info("\n Executing test_key_alias_not_found_in_cmdline")
+    command_line = {"cmdline":"dockerd --config-file=\"/etc/docker/daemon.json\" --log-level=\"debug\""}
+    key_aliases = ["not_found"]
+    params = {
+        'key_aliases': key_aliases,
+        'delimiter': '='
+    }
+    val = command_line_parser.parse_cmdline(params=params, chained=command_line)
+    print("return value is {0}".format(val))
+    expected_value = (True, [])
+    assert val == expected_value
+
+
+def test_multiple_return_values():
+    log.info("\n Executing test_multiple_return_values")
+    command_line = {"cmdline" : "docker run -v=\"a:b\" --volume=\"d:e\" --log-level=\"debug\""}
+    key_aliases = ["v", "volume"]
+    params = {
+              'key_aliases': key_aliases,
+              'delimiter': '='
+              }
+    val = command_line_parser.parse_cmdline(params = params, chained=command_line)
+    print("return value is {0}".format(val))
+    expected_value = (True, ["a:b", "d:e"])
+    assert val == expected_value
+
+
+def test_multiple_key_aliases():
+    log.info("\n Executing test_multiple_key_aliases")
+    command_line = {"cmdline":"docker run -v=\"a:b\" -v=\"d:e\" --log-level=\"debug\""}
+    key_aliases = ["volume", "v"]
+    params = {
+        'key_aliases': key_aliases,
+        'delimiter': '='
+    }
+    val = command_line_parser.parse_cmdline(params=params, chained=command_line)
+    print("return value is {0}".format(val))
+    expected_value = (True, ["a:b", "d:e"])
+    assert val == expected_value
+
+
+def test_values_with_single_quotes():
+    log.info("\n Executing test_values_with_single_quotes")
+    command_line = {"cmdline":"docker run -v=\'a:b\' -v=\'d:e\' --log-level=\'debug\'"}
+    key_aliases = ["volume", "v"]
+    params = {
+        'key_aliases': key_aliases,
+        'delimiter': '='
+    }
+    val = command_line_parser.parse_cmdline(params=params, chained=command_line)
+    print("return value is {0}".format(val))
+    expected_value = (True, ["a:b", "d:e"])
+    assert val[0] == expected_value[0]
+    assert val[1] == expected_value[1]
+
+
+def test_second_regex():
+    log.info("\n Executing test_second_regex")
+    command_line = {"cmdline" : "docker run -it -v a:b -v d:e"}
+    key_aliases = ["volume", "v"]
+    params = {
+        'key_aliases': key_aliases,
+        'delimiter': ' '
+    }
+    val = command_line_parser.parse_cmdline(params=params, chained=command_line)
+    print("return value is {0}".format(val))
+    expected_value = (True, ["a:b", "d:e"])
+    assert val == expected_value
+
+
+def test_do_not_match_partial_matching_key_alias():
+    log.info("\n Executing test_do_not_match_partial_matching_key_alias")
+    command_line = {"cmdline" : "dockerd --config-file=\"/etc/docker/daemon.json\" --log-level=\"debug\""}
+    key_aliases = ["prefix_log-level"]
+    params = {
+        'key_aliases': key_aliases,
+        'delimiter': '='
+    }
+    val = command_line_parser.parse_cmdline(params=params, chained=command_line)
+    print("return value is {0}".format(val))
+    expected_value = (True, [])
+    assert val == expected_value
+
+
+def test_do_not_match_partial_matching_key_alias_short():
+    log.info("\n Executing test_do_not_match_partial_matching_key_alias")
+    command_line = {"cmdline" : "dockerd --config-file=\"/etc/docker/daemon.json\" --log-level=\"debug\""}
+    key_aliases = ["level"]
+    params = {
+        'key_aliases': key_aliases,
+        'delimiter': '='
+    }
+    val = command_line_parser.parse_cmdline(params=params, chained=command_line)
+    print("return value is {0}".format(val))
+    expected_value = (True, [])
+    assert val == expected_value
+
+
+def test_curl_example():
+    log.info("\n Executing test_curl_example")
+    command_line = {"cmdline" : "curl -X POST http://www.yourwebsite.com/login/ -d 'username=yourusername&password=yourpassword'"}
+    key_aliases = ["d"]
+    params = {
+        'key_aliases': key_aliases,
+        'delimiter': ' '
+    }
+    val = command_line_parser.parse_cmdline(params=params, chained=command_line)
+    print("return value is {0}".format(val))
+    expected_value = (True, ["username=yourusername&password=yourpassword"])
+    assert val == expected_value
+
+
+def test_curl_example_different_position():
+    log.info("\n Executing test_curl_example")
+    command_line = {"cmdline" : "curl -X POST -d 'username=yourusername&password=yourpassword' http://www.yourwebsite.com/login/"}
+    key_aliases = ["d"]
+    params = {
+        'key_aliases': key_aliases,
+        'delimiter': ' '
+    }
+    val = command_line_parser.parse_cmdline(params=params, chained=command_line)
+    print("return value is {0}".format(val))
+    expected_value = (True, ["username=yourusername&password=yourpassword"])
+    assert val == expected_value
+
+
+def test_curl_quote_in_value():
+    log.info("\n Executing test_curl_example")
+    command_line = {"cmdline" : "curl -X POST -d \"username=your'susername&password=yourpassword\" http://www.yourwebsite.com/login/"}
+    key_aliases = ["d"]
+    params = {
+        'key_aliases': key_aliases,
+        'delimiter': ' '
+    }
+    val = command_line_parser.parse_cmdline(params=params, chained=command_line)
+    print("return value is {0}".format(val))
+    expected_value = (True, ["username=your'susername&password=yourpassword"])
+    assert val == expected_value
+
+
+def test_with_special_chars_in_value():
+    log.info("\n Executing test_curl_example")
+    command_line = {"cmdline" : "curl -H \"X-Header: value\" https://www.keycdn.com"}
+    key_aliases = ["-H"]
+    params = {
+        'key_aliases': key_aliases,
+        'delimiter': ' '
+    }
+    val = command_line_parser.parse_cmdline(params=params, chained=command_line)
+    print("return value is {0}".format(val))
+    expected_value = (True, ["X-Header: value"])
+    assert val == expected_value
+
+
+def test_key_alias_with_space():
+    log.info("\n Executing test_key_alias_with_space")
+    command_line = {"cmdline" : "docker network inspect 9f9408b2d29e"}
+    key_aliases = ["network inspect"]
+    params = {
+        'key_aliases': key_aliases,
+        'delimiter': ' '
+    }
+    val = command_line_parser.parse_cmdline(params=params, chained=command_line)
+    print("return value is {0}".format(val))
+    expected_value = (True, ["9f9408b2d29e"])
+    assert val == expected_value
+
+
+def test_long_option_with_space():
+    log.info("\n Executing test_long_option_with_space")
+    command_line = {"cmdline" : "docker run --cidfile /tmp/docker_test.cid ubuntu echo \"test\""}
+    key_aliases = ["cidfile"]
+    params = {
+        'key_aliases': key_aliases,
+        'delimiter': ' '
+    }
+    val = command_line_parser.parse_cmdline(params=params, chained=command_line)
+    print("return value is {0}".format(val))
+    expected_value = (True, ["/tmp/docker_test.cid"])
+    assert val == expected_value
+
+
+def test_value_with_assigment_operator():
+    log.info("\n Executing test_value_with_assigment_operator")
+    command_line = {"cmdline" : "docker run -it --storage-opt size=120G fedora /bin/bash"}
+    key_aliases = ["storage-opt"]
+    params = {
+        'key_aliases': key_aliases,
+        'delimiter': ' '
+    }
+    val = command_line_parser.parse_cmdline(params=params, chained=command_line)
+    print("return value is {0}".format(val))
+    expected_value = (True, ["size=120G"])
+    assert val == expected_value
+
+
+def test_value_is_a_list():
+    log.info("\n Executing test_value_is_a_list")
+    command_line = {"cmdline" : "tool_name --key:[\"value1\", \"value2\"]"}
+    key_aliases = ["key"]
+    params = {
+        'key_aliases': key_aliases,
+        'delimiter': ':'
+    }
+    val = command_line_parser.parse_cmdline(params=params, chained=command_line)
+    print("return value is {0}".format(val))
+    expected_value = (True, ["[\"value1\", \"value2\"]"])
+    assert val == expected_value
+
+
+def test_java_example1():
+    log.info("\n Executing test_java_example1")
+    command_line = {"cmdline" : "nlserver watchdog -svc -noconsole -pidfile:/var/run/nlserver6.pid"}
+    key_aliases = ["pidfile"]
+    params = {
+        'key_aliases': key_aliases,
+        'delimiter': ':'
+    }
+    val = command_line_parser.parse_cmdline(params=params, chained=command_line)
+    print("return value is {0}".format(val))
+    expected_value = (True, ["/var/run/nlserver6.pid"])
+    assert val == expected_value
+
+
+def test_java_example2():
+    log.info("\n Executing test_java_example2")
+    command_line = {"cmdline" : "/etc/alternatives/jre/bin/java -Xmx1024m -XX:OnOutOfMemoryError=kill -9 %p -XX:MinHeapFreeRatio=10 -server " \
+                   "-cp /usr/share/aws/emr/instance-controller/lib/*:/home/hadoop/conf -Dlog4j.defaultInitOverride aws157.instancecontroller.Main"}
+    key_aliases = ["XX:MinHeapFreeRatio"]
+    params = {
+        'key_aliases': key_aliases,
+        'delimiter': '='
+    }
+    val = command_line_parser.parse_cmdline(params=params, chained=command_line)
+    print("return value is {0}".format(val))
+    expected_value = (True, ["10"])
+    assert val == expected_value
+
+
+def test_java_example3():
+    log.info("\n Executing test_java_example3")
+    command_line = {"cmdline" : "/apps/api-etms/jdk1.8.0_241/bin/java -XX:PermSize=128m -XX:MaxPermSize=256m -jar /apps/api-etms/usage-tracking-services-launchpad.jar"}
+    key_aliases = ["XX:PermSize"]
+    params = {
+        'key_aliases': key_aliases,
+        'delimiter': '='
+    }
+    val = command_line_parser.parse_cmdline(params=params, chained=command_line)
+    print("return value is {0}".format(val))
+    expected_value = (True, ["128m"])
+    assert val == expected_value
+
+
+def test_java_example4():
+    log.info("\n Executing test_java_example4")
+    command_line = {"cmdline" : "/apps/api-etms/jdk1.8.0_241/bin/java -XX:PermSize=128m -XX:MaxPermSize=256m -jar /apps/api-etms/usage-tracking-services-launchpad.jar"}
+    key_aliases = ["jar"]
+    params = {
+        'key_aliases': key_aliases,
+        'delimiter': ' '
+    }
+    val = command_line_parser.parse_cmdline(params=params, chained=command_line)
+    print("return value is {0}".format(val))
+    expected_value = (True, ["/apps/api-etms/usage-tracking-services-launchpad.jar"])
+    assert val == expected_value
+
+
+def test_java_example5():
+    log.info("\n Executing test_java_example5")
+    command_line = {"cmdline" : "/opt/oobe/jdk1.8.0_202/bin/java -Djava.util.logging.config.file=/opt/oobe/oobe-tomcat-9.0.31/conf/logging.properties " \
+                   "-Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager -Djdk.tls.ephemeralDHKeySize=2048 " \
+                   "-Djava.protocol.handler.pkgs=org.apache.catalina.webresources -Dorg.apache.catalina.security.SecurityListener.UMASK=0027 " \
+                   "-javaagent:/opt/oobe/newrelic-java-5.10.0/newrelic.jar -Xmx10310m -Xms512m -XX:+UseG1GC -XX:+UseStringDeduplication " \
+                   "-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/mnt/efs/dumps/i-0b23463e49967f3e4/dumpOnExit.hprof -XX:+UnlockDiagnosticVMOptions " \
+                   "-XX:+DebugNonSafepoints -XX:+UnlockCommercialFeatures -XX:+FlightRecorder " \
+                   "-XX:FlightRecorderOptions=defaultrecording=true,disk=true,maxage=2h,dumponexit=true," \
+                   "dumponexitpath=/mnt/efs/dumps/i-0b23463e49967f3e4/JFRdump.jfr,loglevel=info,repository=/mnt/efs/dumps/i-0b23463e49967f3e4/temp/ " \
+                   "-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=15000 -Dcom.sun.management.jmxremote.ssl=false " \
+                   "-Dcom.sun.management.jmxremote.authenticate=false -Dsun.net.inetaddr.ttl=30 -Dinstance.id=tomcat " \
+                   "-Dcom.adobe.ffc.config=/opt/ffc/ffc-package/config/prod -Dcom.adobe.ffc.environment=prod -Dcom.adobe.ffc.scripts=/opt/ffc/ffc-package/scripts " \
+                   "-Dserver.log.dir=/opt/oobe/oobe-tomcat-9.0.31/logs -Djboss.server.log.dir=/opt/oobe/oobe-tomcat-9.0.31/logs " \
+                   "-Dlog4j.configurationFile=file:///opt/ffc/ffc-package/config/prod/log4j2.xml -DLog4jContextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector " \
+                   "-Dcom.netflix.servo.DefaultMonitorRegistry.registryClass=com.netflix.servo.jmx.JmxMonitorRegistry " \
+                   "-Dignore.endorsed.dirs= -classpath /opt/oobe/apache-tomcat-9.0.31/bin/bootstrap.jar:/opt/oobe/apache-tomcat-9.0.31/bin/tomcat-juli.jar " \
+                   "-Dcatalina.base=/opt/oobe/oobe-tomcat-9.0.31 -Dcatalina.home=/opt/oobe/apache-tomcat-9.0.31 " \
+                   "-Djava.io.tmpdir=/opt/oobe/oobe-tomcat-9.0.31/temp org.apache.catalina.startup.Bootstrap start"}
+
+    key_aliases = ["Djdk.tls.ephemeralDHKeySize"]
+    params = {
+        'key_aliases': key_aliases,
+        'delimiter': '='
+    }
+    val = command_line_parser.parse_cmdline(params=params, chained=command_line)
+    print("return value is {0}".format(val))
+    expected_value = (True, ["2048"])
+    assert val == expected_value
+
+
+def test_value_with_multiple_special_chars():
+    log.info("\n Executing test_value_with_multiple_special_chars")
+    command_line = {"cmdline" : "docker run -d --tmpfs /run:rw,noexec,nosuid,size=65536k my_image"}
+    key_aliases = ["tmpfs"]
+    params = {
+        'key_aliases': key_aliases,
+        'delimiter': ' '
+    }
+    val = command_line_parser.parse_cmdline(params=params, chained=command_line)
+    print("return value is {0}".format(val))
+    expected_value = (True, ["/run:rw,noexec,nosuid,size=65536k"])
+    assert val == expected_value
+
+
+def test_key_value_inside_dict():
+    log.info("\n Executing test_key_value_inside_dict")
+    command_line = {"cmdline" : "tool_name --key={\"subkey1\":\"value1\", \"subkey2\":\"value2\"}"}
+    key_aliases = ["subkey1"]
+    params = {
+        'key_aliases': key_aliases,
+        'delimiter': ':'
+    }
+    val = command_line_parser.parse_cmdline(params=params, chained=command_line)
+    print("return value is {0}".format(val))
+    expected_value = (True, ["value1"])
+    assert val == expected_value
+
+
+def test_value_with_special_char():
+    log.info("\n Executing test_value_with_special_char")
+    command_line = {"cmdline" : "/configmap-reload --volume-dir=/etc/prometheus --webhook-url=http://localhost:9090/-/reload"}
+    key_aliases = ["webhook-url"]
+    params = {
+        'key_aliases': key_aliases,
+        'delimiter': '='
+    }
+    val = command_line_parser.parse_cmdline(params=params, chained=command_line)
+    print("return value is {0}".format(val))
+    expected_value = (True, ["http://localhost:9090/-/reload"])
+    assert val == expected_value
+
+
+def test_value_with_brackets():
+    log.info("\n Executing test_value_with_regex")
+    command_line = {"cmdline" : 'mesos-journald-logger --journald_labels={"labels":[{"key":"DCOS_PACKAGE_IS_FRAMEWORK","value":"false"}]} --logrotate_max_size={"size":"50MB"}'}
+    key_aliases = ["journald_labels"]
+    params = {
+        'key_aliases': key_aliases,
+        'delimiter': '='
+    }
+    val = command_line_parser.parse_cmdline(params=params, chained=command_line)
+    print("return value is {0}".format(val))
+    expected_value = (True, ['{"labels":[{"key":"DCOS_PACKAGE_IS_FRAMEWORK","value":"false"}]}'])
+    assert val == expected_value
+
+
+def test_value_has_regex():
+    log.info("\n Executing test_value_with_regex")
+    command_line = {"cmdline" : '/bin/node_exporter --collector.diskstats.ignored-devices=^(dm-\d+|ram|loop|fd|(h|s|v|xv)d[a-z]|nvme\d+n\d+p)\d+$'}
+    key_aliases = ["collector.diskstats.ignored-devices"]
+    params = {
+        'key_aliases': key_aliases,
+        'delimiter': '='
+    }
+    val = command_line_parser.parse_cmdline(params=params, chained=command_line)
+    print("return value is {0}".format(val))
+    expected_value = (True, ['^(dm-\d+|ram|loop|fd|(h|s|v|xv)d[a-z]|nvme\d+n\d+p)\d+$'])
+    assert val == expected_value
+
+
+def test_value_has_regex2():
+    log.info("\n Executing test_value_with_regex")
+    command_line = {"cmdline" : "/bin/sh -c nice -n 15 ionice -c2 -n7 clamscan -r -d /var/lib/clamav --infected --exclude-dir='^/proc|^/sys|^/dev|^/mnt|^/export|^/var/lib/mysql|^/volr' / > /var/log/clamav/clamscan.log"}
+    key_aliases = ["exclude-dir"]
+    params = {
+        'key_aliases': key_aliases,
+        'delimiter': '='
+    }
+    val = command_line_parser.parse_cmdline(params=params, chained=command_line)
+    print("return value is {0}".format(val))
+    expected_value = (True, ['^/proc|^/sys|^/dev|^/mnt|^/export|^/var/lib/mysql|^/volr'])
+    assert val == expected_value
+
+
+def test_fetch_bracketed_value():
+    log.info("\n Executing test_fetch_bracketed_value")
+    value = "[dummy]"
+    val = command_line_parser._fetch_bracketed_value(value)
+    print("return value is {0}".format(val))
+    expected_value = ('[dummy]')
+    assert val == expected_value
+
+
+def test_no_params():
+    log.info("\n Executing test_no_params")
+    command_line = {"cmdline" : ""}
+    val = command_line_parser.parse_cmdline(params='', chained=command_line)
+    print("return value is {0}".format(val))
+    assert val[0] == False
+
+
+def test_no_keys_given():
+    log.info("\n Executing test_no_keys_given")
+    command_line = {"cmdline" : ""}
+    params = {
+        'key_aliases': '',
+        'delimiter': '='
+    }
+    val = command_line_parser.parse_cmdline(params=params, chained=command_line)
+    print("return value is {0}".format(val))
+    assert val[0] == False
+
+
+def test_no_chained_value_given():
+    log.info("\n Executing test_no_chained_value_given")
+    key_aliases = ["exclude-dir"]
+    params = {
+        'key_aliases': key_aliases,
+        'delimiter': '='
+    }
+    val = command_line_parser.parse_cmdline(params=params, chained='')
+    print("return value is {0}".format(val))
+    assert val[0] == False
+
+
+def test_wrong_chained_value_format():
+    log.info("\n Executing test_wrong_chained_value_format")
+    command_line = {"command_line": "docker run -d --tmpfs /run:rw,noexec,nosuid,size=65536k my_image"}
+    key_aliases = ["exclude-dir"]
+    params = {
+        'key_aliases': key_aliases,
+        'delimiter': '='
+    }
+    val = command_line_parser.parse_cmdline(params=params, chained=command_line)
+    print("return value is {0}".format(val))
+    assert val[0] == False
+
+
+def test_no_delimiter():
+    log.info("\n Executing test_match_key_alias_in_middle_of_cmdline")
+    command_line = {"cmdline" : "dockerd --config-file=\"/etc/docker/daemon.json\" --log-level=\"debug\""}
+    key_aliases = ["config-file"]
+    params = {
+        'key_aliases': key_aliases
+    }
+    val = command_line_parser.parse_cmdline(params=params, chained=command_line)
+    print("return value is {0}".format(val))
+    assert val[0] == False


### PR DESCRIPTION
The module can be used to fetch value of keys provided in command lines. 
Example:
"dockerd --config-file=/etc/docker/daemon.json --log-level=debug"
In the above command line, the module can be used to fetch the value of `config-file` and `log-level`.
