### PR TITLE
Salt-less work: Adding more test cases

### DIFF
--- a/hubblestack/utils/path.py
+++ b/hubblestack/utils/path.py
@@ -15,7 +15,7 @@ import hubblestack.utils.stringutils
 import hubblestack.utils.args
 import hubblestack.utils.data
 from hubblestack.utils.decorators.memoize import memoize
-
+from hubblestack.utils.exceptions import CommandNotFoundError
 log = logging.getLogger(__name__)
 
 def which(exe=None):
@@ -159,3 +159,29 @@ def os_walk(top, *args, **kwargs):
     for item in os.walk(top_query, *args, **kwargs):
         yield hubblestack.utils.data.decode(item, preserve_tuples=True)
 
+def sanitize_win_path(winpath):
+    '''
+    Remove illegal path characters for windows
+    '''
+    intab = '<>:|?*'
+    if isinstance(winpath, str):
+        winpath = winpath.translate(dict((ord(c), '_') for c in intab))
+    elif isinstance(winpath, str):
+        outtab = '_' * len(intab)
+        trantab = ''.maketrans(intab, outtab)
+        winpath = winpath.translate(trantab)
+    return winpath
+
+def check_or_die(command):
+    '''
+    Simple convenience function for modules to use for gracefully blowing up
+    if a required tool is not available in the system path.
+
+    Lazily import `hubblestack.modules.cmdmod` to avoid any sort of circular
+    dependencies.
+    '''
+    if command is None:
+        raise CommandNotFoundError('\'None\' is not a valid command.')
+
+    if not which(command):
+        raise CommandNotFoundError('\'{0}\' is not in the path'.format(command))

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -994,6 +994,8 @@ class WithTempdir(object):
         )
 
     def wrap(self, testcase, *args, **kwargs):
+        if not os.path.exists(self.kwargs['dir']):
+            os.makedirs(self.kwargs['dir'])
         tempdir = tempfile.mkdtemp(**self.kwargs)
         if not self.create:
             os.rmdir(tempdir)

--- a/tests/unittests/utils/test_args.py
+++ b/tests/unittests/utils/test_args.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+# Import python libs
+from __future__ import absolute_import, print_function, unicode_literals
+from collections import namedtuple
+import logging
+
+import hubblestack.utils.args
+
+# Import Salt Testing Libs
+from tests.support.unit import TestCase, skipIf
+from tests.support.mock import (
+    DEFAULT,
+    NO_MOCK,
+    NO_MOCK_REASON,
+    patch
+)
+
+log = logging.getLogger(__name__)
+
+
+class ArgsTestCase(TestCase):
+    '''
+    TestCase for hubblestack.utils.args module
+    '''
+
+    def test_clean_kwargs(self):
+        self.assertDictEqual(hubblestack.utils.args.clean_kwargs(foo='bar'), {'foo': 'bar'})
+        self.assertDictEqual(hubblestack.utils.args.clean_kwargs(__pub_foo='bar'), {})
+        self.assertDictEqual(hubblestack.utils.args.clean_kwargs(__foo_bar='gwar'), {})
+        self.assertDictEqual(hubblestack.utils.args.clean_kwargs(foo_bar='gwar'), {'foo_bar': 'gwar'})

--- a/tests/unittests/utils/test_data.py
+++ b/tests/unittests/utils/test_data.py
@@ -1,0 +1,457 @@
+# -*- coding: utf-8 -*-
+'''
+Tests for hubblestack.utils.data
+'''
+
+# Import Python libs
+from __future__ import absolute_import, print_function, unicode_literals
+import logging
+import builtins
+
+# Import Salt libs
+import hubblestack.utils.data
+import hubblestack.utils.stringutils
+from hubblestack.utils.odict import OrderedDict
+from tests.support.unit import TestCase, skipIf, LOREM_IPSUM
+from tests.support.mock import patch, NO_MOCK, NO_MOCK_REASON
+
+log = logging.getLogger(__name__)
+_b = lambda x: x.encode('utf-8')
+_s = lambda x: hubblestack.utils.stringutils.to_str(x, normalize=True)
+# Some randomized data that will not decode
+BYTES = b'1\x814\x10'
+
+# This is an example of a unicode string with й constructed using two separate
+# code points. Do not modify it.
+EGGS = '\u044f\u0438\u0306\u0446\u0430'
+
+
+class DataTestCase(TestCase):
+    test_data = [
+        'unicode_str',
+        _b('питон'),
+        123,
+        456.789,
+        True,
+        False,
+        None,
+        EGGS,
+        BYTES,
+        [123, 456.789, _b('спам'), True, False, None, EGGS, BYTES],
+        (987, 654.321, _b('яйца'), EGGS, None, (True, EGGS, BYTES)),
+        {_b('str_key'): _b('str_val'),
+         None: True,
+         123: 456.789,
+         EGGS: BYTES,
+         _b('subdict'): {'unicode_key': EGGS,
+                         _b('tuple'): (123, 'hello', _b('world'), True, EGGS, BYTES),
+                         _b('list'): [456, _b('спам'), False, EGGS, BYTES]}},
+        OrderedDict([(_b('foo'), 'bar'), (123, 456), (EGGS, BYTES)])
+    ]
+
+    def test_traverse_dict_and_list(self):
+        test_two_level_dict = {'foo': {'bar': 'baz'}}
+        test_two_level_dict_and_list = {
+            'foo': ['bar', 'baz', {'lorem': {'ipsum': [{'dolor': 'sit'}]}}]
+        }
+
+        # Check traversing too far: hubblestack.utils.data.traverse_dict_and_list() returns
+        # the value corresponding to a given key path, and baz is a value
+        # corresponding to the key path foo:bar.
+        self.assertDictEqual(
+            {'not_found': 'nope'},
+            hubblestack.utils.data.traverse_dict_and_list(
+                test_two_level_dict, 'foo:bar:baz', {'not_found': 'nope'}
+            )
+        )
+        # Now check to ensure that foo:bar corresponds to baz
+        self.assertEqual(
+            'baz',
+            hubblestack.utils.data.traverse_dict_and_list(
+                test_two_level_dict, 'foo:bar', {'not_found': 'not_found'}
+            )
+        )
+        # Check traversing too far
+        self.assertDictEqual(
+            {'not_found': 'nope'},
+            hubblestack.utils.data.traverse_dict_and_list(
+                test_two_level_dict_and_list, 'foo:bar', {'not_found': 'nope'}
+            )
+        )
+        # Check index 1 (2nd element) of list corresponding to path 'foo'
+        self.assertEqual(
+            'baz',
+            hubblestack.utils.data.traverse_dict_and_list(
+                test_two_level_dict_and_list, 'foo:1', {'not_found': 'not_found'}
+            )
+        )
+        # Traverse a couple times into dicts embedded in lists
+        self.assertEqual(
+            'sit',
+            hubblestack.utils.data.traverse_dict_and_list(
+                test_two_level_dict_and_list,
+                'foo:lorem:ipsum:dolor',
+                {'not_found': 'not_found'}
+            )
+        )
+
+    def test_compare_dicts(self):
+        ret = hubblestack.utils.data.compare_dicts(old={'foo': 'bar'}, new={'foo': 'bar'})
+        self.assertEqual(ret, {})
+
+        ret = hubblestack.utils.data.compare_dicts(old={'foo': 'bar'}, new={'foo': 'woz'})
+        expected_ret = {'foo': {'new': 'woz', 'old': 'bar'}}
+        self.assertDictEqual(ret, expected_ret)
+
+    def test_decode(self):
+        '''
+        Companion to test_decode_to_str, they should both be kept up-to-date
+        with one another.
+
+        NOTE: This uses the lambda "_b" defined above in the global scope,
+        which encodes a string to a bytestring, assuming utf-8.
+        '''
+        expected = [
+            'unicode_str',
+            'питон',
+            123,
+            456.789,
+            True,
+            False,
+            None,
+            'яйца',
+            BYTES,
+            [123, 456.789, 'спам', True, False, None, 'яйца', BYTES],
+            (987, 654.321, 'яйца', 'яйца', None, (True, 'яйца', BYTES)),
+            {'str_key': 'str_val',
+             None: True,
+             123: 456.789,
+             'яйца': BYTES,
+             'subdict': {'unicode_key': 'яйца',
+                         'tuple': (123, 'hello', 'world', True, 'яйца', BYTES),
+                         'list': [456, 'спам', False, 'яйца', BYTES]}},
+            OrderedDict([('foo', 'bar'), (123, 456), ('яйца', BYTES)])
+        ]
+
+        ret = hubblestack.utils.data.decode(
+            self.test_data,
+            keep=True,
+            normalize=True,
+            preserve_dict_class=True,
+            preserve_tuples=True)
+        self.assertEqual(ret, expected)
+
+        # The binary data in the data structure should fail to decode, even
+        # using the fallback, and raise an exception.
+        self.assertRaises(
+            UnicodeDecodeError,
+            hubblestack.utils.data.decode,
+            self.test_data,
+            keep=False,
+            normalize=True,
+            preserve_dict_class=True,
+            preserve_tuples=True)
+
+        # Now munge the expected data so that we get what we would expect if we
+        # disable preservation of dict class and tuples
+        expected[10] = [987, 654.321, 'яйца', 'яйца', None, [True, 'яйца', BYTES]]
+        expected[11]['subdict']['tuple'] = [123, 'hello', 'world', True, 'яйца', BYTES]
+        expected[12] = {'foo': 'bar', 123: 456, 'яйца': BYTES}
+
+        ret = hubblestack.utils.data.decode(
+            self.test_data,
+            keep=True,
+            normalize=True,
+            preserve_dict_class=False,
+            preserve_tuples=False)
+        self.assertEqual(ret, expected)
+
+        # Now test single non-string, non-data-structure items, these should
+        # return the same value when passed to this function
+        for item in (123, 4.56, True, False, None):
+            log.debug('Testing decode of %s', item)
+            self.assertEqual(hubblestack.utils.data.decode(item), item)
+
+        # Test single strings (not in a data structure)
+        self.assertEqual(hubblestack.utils.data.decode('foo'), 'foo')
+        self.assertEqual(hubblestack.utils.data.decode(_b('bar')), 'bar')
+        self.assertEqual(hubblestack.utils.data.decode(EGGS, normalize=True), 'яйца')
+        self.assertEqual(hubblestack.utils.data.decode(EGGS, normalize=False), EGGS)
+
+        # Test binary blob
+        self.assertEqual(hubblestack.utils.data.decode(BYTES, keep=True), BYTES)
+        self.assertRaises(
+            UnicodeDecodeError,
+            hubblestack.utils.data.decode,
+            BYTES,
+            keep=False)
+
+    def test_decode_to_str(self):
+        '''
+        Companion to test_decode, they should both be kept up-to-date with one
+        another.
+
+        NOTE: This uses the lambda "_s" defined above in the global scope,
+        which converts the string/bytestring to a str type.
+        '''
+        expected = [
+            _s('unicode_str'),
+            _s('питон'),
+            123,
+            456.789,
+            True,
+            False,
+            None,
+            _s('яйца'),
+            BYTES,
+            [123, 456.789, _s('спам'), True, False, None, _s('яйца'), BYTES],
+            (987, 654.321, _s('яйца'), _s('яйца'), None, (True, _s('яйца'), BYTES)),
+            {_s('str_key'): _s('str_val'),
+             None: True,
+             123: 456.789,
+             _s('яйца'): BYTES,
+             _s('subdict'): {
+                 _s('unicode_key'): _s('яйца'),
+                 _s('tuple'): (123, _s('hello'), _s('world'), True, _s('яйца'), BYTES),
+                 _s('list'): [456, _s('спам'), False, _s('яйца'), BYTES]}},
+            OrderedDict([(_s('foo'), _s('bar')), (123, 456), (_s('яйца'), BYTES)])
+        ]
+
+        ret = hubblestack.utils.data.decode(
+            self.test_data,
+            keep=True,
+            normalize=True,
+            preserve_dict_class=True,
+            preserve_tuples=True,
+            to_str=True)
+        self.assertEqual(ret, expected)
+
+        # The binary data in the data structure should fail to decode, even
+        # using the fallback, and raise an exception.
+        self.assertRaises(
+            UnicodeDecodeError,
+            hubblestack.utils.data.decode,
+            self.test_data,
+            keep=False,
+            normalize=True,
+            preserve_dict_class=True,
+            preserve_tuples=True,
+            to_str=True)
+
+        # Now munge the expected data so that we get what we would expect if we
+        # disable preservation of dict class and tuples
+        expected[10] = [987, 654.321, _s('яйца'), _s('яйца'), None, [True, _s('яйца'), BYTES]]
+        expected[11][_s('subdict')][_s('tuple')] = [123, _s('hello'), _s('world'), True, _s('яйца'), BYTES]
+        expected[12] = {_s('foo'): _s('bar'), 123: 456, _s('яйца'): BYTES}
+
+        ret = hubblestack.utils.data.decode(
+            self.test_data,
+            keep=True,
+            normalize=True,
+            preserve_dict_class=False,
+            preserve_tuples=False,
+            to_str=True)
+        self.assertEqual(ret, expected)
+
+        # Now test single non-string, non-data-structure items, these should
+        # return the same value when passed to this function
+        for item in (123, 4.56, True, False, None):
+            log.debug('Testing decode of %s', item)
+            self.assertEqual(hubblestack.utils.data.decode(item, to_str=True), item)
+
+        # Test single strings (not in a data structure)
+        self.assertEqual(hubblestack.utils.data.decode('foo', to_str=True), _s('foo'))
+        self.assertEqual(hubblestack.utils.data.decode(_b('bar'), to_str=True), _s('bar'))
+
+        # Test binary blob
+        self.assertEqual(
+            hubblestack.utils.data.decode(BYTES, keep=True, to_str=True),
+            BYTES
+        )
+        self.assertRaises(
+            UnicodeDecodeError,
+            hubblestack.utils.data.decode,
+            BYTES,
+            keep=False,
+            to_str=True)
+
+    @skipIf(NO_MOCK, NO_MOCK_REASON)
+    def test_decode_fallback(self):
+        '''
+        Test fallback to utf-8
+        '''
+        with patch.object(builtins, '__salt_system_encoding__', 'ascii'):
+            self.assertEqual(hubblestack.utils.data.decode(_b('яйца')), 'яйца')
+
+    def test_encode(self):
+        '''
+        NOTE: This uses the lambda "_b" defined above in the global scope,
+        which encodes a string to a bytestring, assuming utf-8.
+        '''
+        expected = [
+            _b('unicode_str'),
+            _b('питон'),
+            123,
+            456.789,
+            True,
+            False,
+            None,
+            _b(EGGS),
+            BYTES,
+            [123, 456.789, _b('спам'), True, False, None, _b(EGGS), BYTES],
+            (987, 654.321, _b('яйца'), _b(EGGS), None, (True, _b(EGGS), BYTES)),
+            {_b('str_key'): _b('str_val'),
+             None: True,
+             123: 456.789,
+             _b(EGGS): BYTES,
+             _b('subdict'): {_b('unicode_key'): _b(EGGS),
+                             _b('tuple'): (123, _b('hello'), _b('world'), True, _b(EGGS), BYTES),
+                             _b('list'): [456, _b('спам'), False, _b(EGGS), BYTES]}},
+             OrderedDict([(_b('foo'), _b('bar')), (123, 456), (_b(EGGS), BYTES)])
+        ]
+
+        # Both keep=True and keep=False should work because the BYTES data is
+        # already bytes.
+        ret = hubblestack.utils.data.encode(
+            self.test_data,
+            keep=True,
+            preserve_dict_class=True,
+            preserve_tuples=True)
+        self.assertEqual(ret, expected)
+        ret = hubblestack.utils.data.encode(
+            self.test_data,
+            keep=False,
+            preserve_dict_class=True,
+            preserve_tuples=True)
+        self.assertEqual(ret, expected)
+
+        # Now munge the expected data so that we get what we would expect if we
+        # disable preservation of dict class and tuples
+        expected[10] = [987, 654.321, _b('яйца'), _b(EGGS), None, [True, _b(EGGS), BYTES]]
+        expected[11][_b('subdict')][_b('tuple')] = [
+            123, _b('hello'), _b('world'), True, _b(EGGS), BYTES
+        ]
+        expected[12] = {_b('foo'): _b('bar'), 123: 456, _b(EGGS): BYTES}
+
+        ret = hubblestack.utils.data.encode(
+            self.test_data,
+            keep=True,
+            preserve_dict_class=False,
+            preserve_tuples=False)
+        self.assertEqual(ret, expected)
+        ret = hubblestack.utils.data.encode(
+            self.test_data,
+            keep=False,
+            preserve_dict_class=False,
+            preserve_tuples=False)
+        self.assertEqual(ret, expected)
+
+        # Now test single non-string, non-data-structure items, these should
+        # return the same value when passed to this function
+        for item in (123, 4.56, True, False, None):
+            log.debug('Testing encode of %s', item)
+            self.assertEqual(hubblestack.utils.data.encode(item), item)
+
+        # Test single strings (not in a data structure)
+        self.assertEqual(hubblestack.utils.data.encode('foo'), _b('foo'))
+        self.assertEqual(hubblestack.utils.data.encode(_b('bar')), _b('bar'))
+
+        # Test binary blob, nothing should happen even when keep=False since
+        # the data is already bytes
+        self.assertEqual(hubblestack.utils.data.encode(BYTES, keep=True), BYTES)
+        self.assertEqual(hubblestack.utils.data.encode(BYTES, keep=False), BYTES)
+
+    def test_encode_keep(self):
+        '''
+        Whereas we tested the keep argument in test_decode, it is much easier
+        to do a more comprehensive test of keep in its own function where we
+        can force the encoding.
+        '''
+        unicode_str = 'питон'
+        encoding = 'ascii'
+
+        # Test single string
+        self.assertEqual(
+            hubblestack.utils.data.encode(unicode_str, encoding, keep=True),
+            unicode_str)
+        self.assertRaises(
+            UnicodeEncodeError,
+            hubblestack.utils.data.encode,
+            unicode_str,
+            encoding,
+            keep=False)
+
+        data = [
+            unicode_str,
+            [b'foo', [unicode_str], {b'key': unicode_str}, (unicode_str,)],
+            {b'list': [b'foo', unicode_str],
+             b'dict': {b'key': unicode_str},
+             b'tuple': (b'foo', unicode_str)},
+            ([b'foo', unicode_str], {b'key': unicode_str}, (unicode_str,))
+        ]
+
+        # Since everything was a bytestring aside from the bogus data, the
+        # return data should be identical. We don't need to test recursive
+        # decoding, that has already been tested in test_encode.
+        self.assertEqual(
+            hubblestack.utils.data.encode(data, encoding,
+                                   keep=True, preserve_tuples=True),
+            data
+        )
+        self.assertRaises(
+            UnicodeEncodeError,
+            hubblestack.utils.data.encode,
+            data,
+            encoding,
+            keep=False,
+            preserve_tuples=True)
+
+        for index, item in enumerate(data):
+            self.assertEqual(
+                hubblestack.utils.data.encode(data[index], encoding,
+                                       keep=True, preserve_tuples=True),
+                data[index]
+            )
+            self.assertRaises(
+                UnicodeEncodeError,
+                hubblestack.utils.data.encode,
+                data[index],
+                encoding,
+                keep=False,
+                preserve_tuples=True)
+
+    @skipIf(NO_MOCK, NO_MOCK_REASON)
+    def test_encode_fallback(self):
+        '''
+        Test fallback to utf-8
+        '''
+        with patch.object(builtins, '__salt_system_encoding__', 'ascii'):
+            self.assertEqual(hubblestack.utils.data.encode('яйца'), _b('яйца'))
+        with patch.object(builtins, '__salt_system_encoding__', 'CP1252'):
+            self.assertEqual(hubblestack.utils.data.encode('Ψ'), _b('Ψ'))
+
+    def test_repack_dict(self):
+        list_of_one_element_dicts = [{'dict_key_1': 'dict_val_1'},
+                                     {'dict_key_2': 'dict_val_2'},
+                                     {'dict_key_3': 'dict_val_3'}]
+        expected_ret = {'dict_key_1': 'dict_val_1',
+                        'dict_key_2': 'dict_val_2',
+                        'dict_key_3': 'dict_val_3'}
+        ret = hubblestack.utils.data.repack_dictlist(list_of_one_element_dicts)
+        self.assertDictEqual(ret, expected_ret)
+
+        # Try with yaml
+        yaml_key_val_pair = '- key1: val1'
+        ret = hubblestack.utils.data.repack_dictlist(yaml_key_val_pair)
+        self.assertDictEqual(ret, {'key1': 'val1'})
+
+        # Make sure we handle non-yaml junk data
+        ret = hubblestack.utils.data.repack_dictlist(LOREM_IPSUM)
+        self.assertDictEqual(ret, {})
+
+    def test_stringify(self):
+        self.assertRaises(TypeError, hubblestack.utils.data.stringify, 9)
+        self.assertEqual(
+            hubblestack.utils.data.stringify(['one', 'two', str('three'), 4, 5]),  # future lint: disable=blacklisted-function
+            ['one', 'two', 'three', '4', '5']
+        )

--- a/tests/unittests/utils/test_files.py
+++ b/tests/unittests/utils/test_files.py
@@ -1,0 +1,145 @@
+# -*- coding: utf-8 -*-
+'''
+Unit Tests for functions located in salt/utils/files.py
+'''
+
+# Import python libs
+from __future__ import absolute_import, unicode_literals, print_function
+import copy
+import os
+
+import hubblestack.utils.files
+
+# Import Testing libs
+from tests.support.helpers import with_tempdir
+from tests.support.unit import TestCase, skipIf
+from tests.support.mock import (
+    patch,
+    NO_MOCK,
+    NO_MOCK_REASON
+)
+
+
+class FilesTestCase(TestCase):
+    '''
+    Test case for files util.
+    '''
+
+    @skipIf(NO_MOCK, NO_MOCK_REASON)
+    def test_safe_rm(self):
+        with patch('os.remove') as os_remove_mock:
+            hubblestack.utils.files.safe_rm('dummy_tgt')
+            self.assertTrue(os_remove_mock.called)
+
+    @skipIf(os.path.exists('/tmp/no_way_this_is_a_file_nope.sh'), 'Test file exists! Skipping safe_rm_exceptions test!')
+    def test_safe_rm_exceptions(self):
+        error = False
+        try:
+            hubblestack.utils.files.safe_rm('/tmp/no_way_this_is_a_file_nope.sh')
+        except (IOError, OSError):
+            error = True
+        self.assertFalse(error, 'hubblestack.utils.files.safe_rm raised exception when it should not have')
+
+    @with_tempdir()
+    def test_safe_walk_symlink_recursion(self, tmp):
+        if os.stat(tmp).st_ino == 0:
+            self.skipTest('inodes not supported in {0}'.format(tmp))
+        os.mkdir(os.path.join(tmp, 'fax'))
+        os.makedirs(os.path.join(tmp, 'foo', 'bar'))
+        os.symlink(os.path.join('..', '..'), os.path.join(tmp, 'foo', 'bar', 'baz'))
+        os.symlink('foo', os.path.join(tmp, 'root'))
+        expected = [
+            (os.path.join(tmp, 'root'), ['bar'], []),
+            (os.path.join(tmp, 'root', 'bar'), ['baz'], []),
+            (os.path.join(tmp, 'root', 'bar', 'baz'), ['fax', 'foo', 'root'], []),
+            (os.path.join(tmp, 'root', 'bar', 'baz', 'fax'), [], []),
+        ]
+        paths = []
+        for root, dirs, names in hubblestack.utils.files.safe_walk(os.path.join(tmp, 'root')):
+            paths.append((root, sorted(dirs), names))
+        if paths != expected:
+            raise AssertionError(
+                '\n'.join(
+                    ['got:'] + [repr(p) for p in paths] +
+                    ['', 'expected:'] + [repr(p) for p in expected]
+                )
+            )
+
+    def test_fopen_with_disallowed_fds(self):
+        '''
+        This is safe to have as a unit test since we aren't going to actually
+        try to read or write. We want to ensure that we are raising a
+        TypeError. Python 3's open() builtin will treat the booleans as file
+        descriptor numbers and try to open stdin/stdout. We also want to test
+        fd 2 which is stderr.
+        '''
+        for invalid_fn in (False, True, 0, 1, 2):
+            try:
+                with hubblestack.utils.files.fopen(invalid_fn):
+                    pass
+            except TypeError:
+                # This is expected. We aren't using an assertRaises here
+                # because we want to ensure that if we did somehow open the
+                # filehandle, that it doesn't remain open.
+                pass
+            else:
+                # We probably won't even get this far if we actually opened
+                # stdin/stdout as a file descriptor. It is likely to cause the
+                # integration suite to die since, news flash, closing
+                # stdin/stdout/stderr is usually not a wise thing to do in the
+                # middle of a program's execution.
+                self.fail(
+                    'fopen() should have been prevented from opening a file '
+                    'using {0} as the filename'.format(invalid_fn)
+                )
+
+    def _create_temp_structure(self, temp_directory, structure):
+        for folder, files in iter(structure.items()):
+            current_directory = os.path.join(temp_directory, folder)
+            os.makedirs(current_directory)
+            for name, content in iter(files.items()):
+                path = os.path.join(temp_directory, folder, name)
+                with hubblestack.utils.files.fopen(path, 'w+') as fh:
+                    fh.write(content)
+
+    def _validate_folder_structure_and_contents(self, target_directory,
+                                                desired_structure):
+        for folder, files in iter(desired_structure.items()):
+            for name, content in iter(files.items()):
+                path = os.path.join(target_directory, folder, name)
+                with hubblestack.utils.files.fopen(path) as fh:
+                    assert fh.read().strip() == content
+
+    @with_tempdir()
+    @with_tempdir()
+    def test_recursive_copy(self, src, dest):
+        src_structure = {
+            'foo': {
+                'foofile.txt': 'fooSTRUCTURE'
+            },
+            'bar': {
+                'barfile.txt': 'barSTRUCTURE'
+            }
+        }
+        dest_structure = {
+            'foo': {
+                'foo.txt': 'fooTARGET_STRUCTURE'
+            },
+            'baz': {
+                'baz.txt': 'bazTARGET_STRUCTURE'
+            }
+        }
+
+        # Create the file structures in both src and dest dirs
+        self._create_temp_structure(src, src_structure)
+        self._create_temp_structure(dest, dest_structure)
+
+        # Perform the recursive copy
+        hubblestack.utils.files.recursive_copy(src, dest)
+
+        # Confirm results match expected results
+        desired_structure = copy.copy(dest_structure)
+        desired_structure.update(src_structure)
+        self._validate_folder_structure_and_contents(
+            dest,
+            desired_structure)

--- a/tests/unittests/utils/test_path.py
+++ b/tests/unittests/utils/test_path.py
@@ -1,0 +1,226 @@
+# -*- coding: utf-8 -*-
+'''
+Tests for hubblestack.utils.path
+'''
+
+# Import Python libs
+from __future__ import absolute_import, print_function, unicode_literals
+import os
+import sys
+import posixpath
+import ntpath
+import platform
+import tempfile
+
+from tests.support.unit import TestCase, skipIf
+from tests.support.mock import patch, NO_MOCK, NO_MOCK_REASON
+
+import importlib
+import hubblestack.utils.path
+import hubblestack.utils.platform
+from hubblestack.utils.exceptions import CommandNotFoundError
+
+
+class PathJoinTestCase(TestCase):
+
+    PLATFORM_FUNC = platform.system
+    BUILTIN_MODULES = sys.builtin_module_names
+
+    NIX_PATHS = (
+        (('/', 'key'), '/key'),
+        (('/etc/salt', '/etc/salt/pki'), '/etc/salt/etc/salt/pki'),
+        (('/usr/local', '/etc/salt/pki'), '/usr/local/etc/salt/pki')
+
+    )
+
+    WIN_PATHS = (
+        (('c:', 'temp', 'foo'), 'c:\\temp\\foo'),
+        (('c:', r'\temp', r'\foo'), 'c:\\temp\\foo'),
+        (('c:\\', r'\temp', r'\foo'), 'c:\\temp\\foo'),
+        ((r'c:\\', r'\temp', r'\foo'), 'c:\\temp\\foo'),
+        (('c:', r'\temp', r'\foo', 'bar'), 'c:\\temp\\foo\\bar'),
+        (('c:', r'\temp', r'\foo\bar'), 'c:\\temp\\foo\\bar'),
+    )
+
+    def test_nix_paths(self):
+        if platform.system().lower() == "windows":
+            self.skipTest(
+                "Windows platform found. not running *nix hubblestack.utils.path.join tests"
+            )
+        for idx, (parts, expected) in enumerate(self.NIX_PATHS):
+            path = hubblestack.utils.path.join(*parts)
+            self.assertEqual(
+                '{0}: {1}'.format(idx, path),
+                '{0}: {1}'.format(idx, expected)
+            )
+
+    def test_windows_paths(self):
+        if platform.system().lower() != "windows":
+            self.skipTest(
+                'Non windows platform found. not running non patched os.path '
+                'hubblestack.utils.path.join tests'
+            )
+
+        for idx, (parts, expected) in enumerate(self.WIN_PATHS):
+            path = hubblestack.utils.path.join(*parts)
+            self.assertEqual(
+                '{0}: {1}'.format(idx, path),
+                '{0}: {1}'.format(idx, expected)
+            )
+
+    @skipIf(hubblestack.utils.platform.is_windows(), '*nix-only test')
+    def test_mixed_unicode_and_binary(self):
+        '''
+        This tests joining paths that contain a mix of components with unicode
+        strings and non-unicode strings with the unicode characters as binary.
+
+        This is no longer something we need to concern ourselves with in
+        Python 3, but the test should nonetheless pass on Python 3. Really what
+        we're testing here is that we don't get a UnicodeDecodeError when
+        running on Python 2.
+        '''
+        a = u'/foo/bar'
+        b = 'Д'
+        expected = u'/foo/bar/\u0414'
+        actual = hubblestack.utils.path.join(a, b)
+        self.assertEqual(actual, expected)
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class PathTestCase(TestCase):
+    def test_which_bin(self):
+        ret = hubblestack.utils.path.which_bin('str')
+        self.assertIs(None, ret)
+
+        test_exes = ['ls', 'echo']
+        with patch('hubblestack.utils.path.which', return_value='/tmp/dummy_path'):
+            ret = hubblestack.utils.path.which_bin(test_exes)
+            self.assertEqual(ret, '/tmp/dummy_path')
+
+            ret = hubblestack.utils.path.which_bin([])
+            self.assertIs(None, ret)
+
+        with patch('hubblestack.utils.path.which', return_value=''):
+            ret = hubblestack.utils.path.which_bin(test_exes)
+            self.assertIs(None, ret)
+
+    def test_sanitize_win_path(self):
+        p = '\\windows\\system'
+        self.assertEqual(hubblestack.utils.path.sanitize_win_path('\\windows\\system'), '\\windows\\system')
+        self.assertEqual(hubblestack.utils.path.sanitize_win_path('\\bo:g|us\\p?at*h>'), '\\bo_g_us\\p_at_h_')
+
+    @skipIf(NO_MOCK, NO_MOCK_REASON)
+    def test_check_or_die(self):
+        self.assertRaises(CommandNotFoundError, hubblestack.utils.path.check_or_die, None)
+
+        with patch('hubblestack.utils.path.which', return_value=False):
+            self.assertRaises(CommandNotFoundError, hubblestack.utils.path.check_or_die, 'FAKE COMMAND')
+
+    @skipIf(NO_MOCK, NO_MOCK_REASON)
+    def test_join(self):
+        with patch('hubblestack.utils.platform.is_windows', return_value=False) as is_windows_mock:
+            self.assertFalse(is_windows_mock.return_value)
+            expected_path = os.path.join(os.sep + 'a', 'b', 'c', 'd')
+            ret = hubblestack.utils.path.join('/a/b/c', 'd')
+            self.assertEqual(ret, expected_path)
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class TestWhich(TestCase):
+    '''
+    Tests hubblestack.utils.path.which function to ensure that it returns True as
+    expected.
+    '''
+
+    # The mock patch below will make sure that ALL calls to the which function
+    # returns None
+    def test_missing_binary_in_linux(self):
+        with patch('hubblestack.utils.path.which', lambda exe: None):
+            self.assertTrue(
+                hubblestack.utils.path.which('this-binary-does-not-exist') is None
+            )
+
+    # The mock patch below will make sure that ALL calls to the which function
+    # return whatever is sent to it
+    def test_existing_binary_in_linux(self):
+        with patch('hubblestack.utils.path.which', lambda exe: exe):
+            self.assertTrue(hubblestack.utils.path.which('this-binary-exists-under-linux'))
+
+    def test_existing_binary_in_windows(self):
+        with patch('os.access') as osaccess:
+            # We define the side_effect attribute on the mocked object in order to
+            # specify which calls return which values. First call to os.access
+            # returns X, the second Y, the third Z, etc...
+            osaccess.side_effect = [
+                # The first os.access should return False(the abspath one)
+                False,
+                # The second, iterating through $PATH, should also return False,
+                # still checking for Linux
+                False,
+                # We will now also return False once so we get a .EXE back from
+                # the function, see PATHEXT below.
+                False,
+                # Lastly return True, this is the windows check.
+                True
+            ]
+            # Let's patch os.environ to provide a custom PATH variable
+            with patch.dict(os.environ, {'PATH': os.sep + 'bin',
+                                         'PATHEXT': '.COM;.EXE;.BAT;.CMD'}):
+                # Let's also patch is_windows to return True
+                with patch('hubblestack.utils.platform.is_windows', lambda: True):
+                    with patch('os.path.isfile', lambda x: True):
+                        self.assertEqual(
+                            hubblestack.utils.path.which('this-binary-exists-under-windows'),
+                            os.path.join(os.sep + 'bin', 'this-binary-exists-under-windows.EXE')
+                        )
+
+    def test_missing_binary_in_windows(self):
+        with patch('os.access') as osaccess:
+            osaccess.side_effect = [
+                # The first os.access should return False(the abspath one)
+                False,
+                # The second, iterating through $PATH, should also return False,
+                # still checking for Linux
+                # which() will add 4 extra paths to the given one, os.access will
+                # be called 5 times
+                False, False, False, False, False
+            ]
+            # Let's patch os.environ to provide a custom PATH variable
+            with patch.dict(os.environ, {'PATH': os.sep + 'bin'}):
+                # Let's also patch is_widows to return True
+                with patch('hubblestack.utils.platform.is_windows', lambda: True):
+                    self.assertEqual(
+                        # Since we're passing the .exe suffix, the last True above
+                        # will not matter. The result will be None
+                        hubblestack.utils.path.which('this-binary-is-missing-in-windows.exe'),
+                        None
+                    )
+
+    def test_existing_binary_in_windows_pathext(self):
+        with patch('os.access') as osaccess:
+            # We define the side_effect attribute on the mocked object in order to
+            # specify which calls return which values. First call to os.access
+            # returns X, the second Y, the third Z, etc...
+            osaccess.side_effect = [
+                # The first os.access should return False(the abspath one)
+                False,
+                # The second, iterating through $PATH, should also return False,
+                # still checking for Linux
+                False,
+                # We will now also return False 3 times so we get a .CMD back from
+                # the function, see PATHEXT below.
+                # Lastly return True, this is the windows check.
+                False, False, False,
+                True
+            ]
+            # Let's patch os.environ to provide a custom PATH variable
+            with patch.dict(os.environ, {'PATH': os.sep + 'bin',
+                                         'PATHEXT': '.COM;.EXE;.BAT;.CMD;.VBS;'
+                                         '.VBE;.JS;.JSE;.WSF;.WSH;.MSC;.PY'}):
+                # Let's also patch is_windows to return True
+                with patch('hubblestack.utils.platform.is_windows', lambda: True):
+                    with patch('os.path.isfile', lambda x: True):
+                        self.assertEqual(
+                            hubblestack.utils.path.which('this-binary-exists-under-windows'),
+                            os.path.join(os.sep + 'bin', 'this-binary-exists-under-windows.CMD')
+                        )

--- a/tests/unittests/utils/test_stringutils.py
+++ b/tests/unittests/utils/test_stringutils.py
@@ -1,0 +1,192 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, print_function, unicode_literals
+import re
+import sys
+import textwrap
+import builtins
+
+# Import Salt libs
+from tests.support.mock import patch
+from tests.support.unit import TestCase, LOREM_IPSUM
+import hubblestack.utils.stringutils
+
+UNICODE = '中国語 (繁体)'
+STR = BYTES = UNICODE.encode('utf-8')
+# This is an example of a unicode string with й constructed using two separate
+# code points. Do not modify it.
+EGGS = '\u044f\u0438\u0306\u0446\u0430'
+
+LATIN1_UNICODE = 'räksmörgås'
+LATIN1_BYTES = LATIN1_UNICODE.encode('latin-1')
+
+DOUBLE_TXT = '''\
+# set variable identifying the chroot you work in (used in the prompt below)
+if [ -z "$debian_chroot" ] && [ -r /etc/debian_chroot ]; then
+    debian_chroot=$(cat /etc/debian_chroot)
+fi
+'''
+
+SINGLE_TXT = '''\
+# set variable identifying the chroot you work in (used in the prompt below)
+if [ -z '$debian_chroot' ] && [ -r /etc/debian_chroot ]; then
+    debian_chroot=$(cat /etc/debian_chroot)
+fi
+'''
+
+SINGLE_DOUBLE_TXT = '''\
+# set variable identifying the chroot you work in (used in the prompt below)
+if [ -z '$debian_chroot' ] && [ -r /etc/debian_chroot ]; then
+    debian_chroot=$(cat /etc/debian_chroot)
+fi
+
+# set variable identifying the chroot you work in (used in the prompt below)
+if [ -z "$debian_chroot" ] && [ -r /etc/debian_chroot ]; then
+    debian_chroot=$(cat /etc/debian_chroot)
+fi
+'''
+
+SINGLE_DOUBLE_SAME_LINE_TXT = '''\
+# set variable identifying the chroot you work in (used in the prompt below)
+if [ -z '$debian_chroot' ] && [ -r "/etc/debian_chroot" ]; then
+    debian_chroot=$(cat /etc/debian_chroot)
+fi
+'''
+
+MATCH = '''\
+# set variable identifying the chroot you work in (used in the prompt below)
+if [ -z '$debian_chroot' ] && [ -r /etc/debian_chroot ]; then
+    debian_chroot=$(cat /etc/debian_chroot)
+fi
+
+
+# set variable identifying the chroot you work in (used in the prompt below)
+if [ -z "$debian_chroot" ] && [ -r /etc/debian_chroot ]; then
+    debian_chroot=$(cat /etc/debian_chroot)
+fi
+
+
+# set variable identifying the chroot you work in (used in the prompt below)
+if [ -z "$debian_chroot" ] && [ -r /etc/debian_chroot ]; then
+    debian_chroot=$(cat /etc/debian_chroot)
+fi
+
+
+# set variable identifying the chroot you work in (used in the prompt below)
+if [ -z '$debian_chroot' ] && [ -r /etc/debian_chroot ]; then
+    debian_chroot=$(cat /etc/debian_chroot)
+fi
+
+
+# set variable identifying the chroot you work in (used in the prompt below)
+if [ -z '$debian_chroot' ] && [ -r "/etc/debian_chroot" ]; then
+    debian_chroot=$(cat /etc/debian_chroot)
+fi
+'''
+
+class StringutilsTestCase(TestCase):
+    def test_to_num(self):
+        self.assertEqual(7, hubblestack.utils.stringutils.to_num('7'))
+        self.assertIsInstance(hubblestack.utils.stringutils.to_num('7'), int)
+        self.assertEqual(7, hubblestack.utils.stringutils.to_num('7.0'))
+        self.assertIsInstance(hubblestack.utils.stringutils.to_num('7.0'), float)
+        self.assertEqual(hubblestack.utils.stringutils.to_num('Seven'), 'Seven')
+        self.assertIsInstance(hubblestack.utils.stringutils.to_num('Seven'), str)
+
+    def test_is_binary(self):
+        self.assertFalse(hubblestack.utils.stringutils.is_binary(LOREM_IPSUM))
+        # Also test bytestring
+        self.assertFalse(
+            hubblestack.utils.stringutils.is_binary(
+                hubblestack.utils.stringutils.is_binary(LOREM_IPSUM)
+            )
+        )
+
+        zero_str = '{0}{1}'.format(LOREM_IPSUM, '\0')
+        self.assertTrue(hubblestack.utils.stringutils.is_binary(zero_str))
+        # Also test bytestring
+        self.assertTrue(
+            hubblestack.utils.stringutils.is_binary(
+                hubblestack.utils.stringutils.to_bytes(zero_str)
+            )
+        )
+
+        # To to ensure safe exit if str passed doesn't evaluate to True
+        self.assertFalse(hubblestack.utils.stringutils.is_binary(''))
+        self.assertFalse(hubblestack.utils.stringutils.is_binary(b''))
+
+        nontext = 3 * (''.join([chr(x) for x in range(1, 32) if x not in (8, 9, 10, 12, 13)]))
+        almost_bin_str = '{0}{1}'.format(LOREM_IPSUM[:100], nontext[:42])
+        self.assertFalse(hubblestack.utils.stringutils.is_binary(almost_bin_str))
+        # Also test bytestring
+        self.assertFalse(
+            hubblestack.utils.stringutils.is_binary(
+                hubblestack.utils.stringutils.to_bytes(almost_bin_str)
+            )
+        )
+
+        bin_str = almost_bin_str + '\x01'
+        self.assertTrue(hubblestack.utils.stringutils.is_binary(bin_str))
+        # Also test bytestring
+        self.assertTrue(
+            hubblestack.utils.stringutils.is_binary(
+                hubblestack.utils.stringutils.to_bytes(bin_str)
+            )
+        )
+
+    def test_to_str(self):
+        for x in (123, (1, 2, 3), [1, 2, 3], {1: 23}, None):
+            self.assertRaises(TypeError, hubblestack.utils.stringutils.to_str, x)
+        self.assertEqual(hubblestack.utils.stringutils.to_str('plugh'), 'plugh')
+        self.assertEqual(hubblestack.utils.stringutils.to_str('áéíóúý', 'utf-8'), 'áéíóúý')
+        self.assertEqual(hubblestack.utils.stringutils.to_str(BYTES, 'utf-8'), UNICODE)
+        self.assertEqual(hubblestack.utils.stringutils.to_str(bytearray(BYTES), 'utf-8'), UNICODE)
+        # Test situation when a minion returns incorrect utf-8 string because of... million reasons
+        ut2 = b'\x9c'
+        self.assertRaises(UnicodeDecodeError, hubblestack.utils.stringutils.to_str, ut2, 'utf-8')
+        self.assertEqual(hubblestack.utils.stringutils.to_str(ut2, 'utf-8', 'replace'), u'\ufffd')
+        self.assertRaises(UnicodeDecodeError, hubblestack.utils.stringutils.to_str, bytearray(ut2), 'utf-8')
+        self.assertEqual(hubblestack.utils.stringutils.to_str(bytearray(ut2), 'utf-8', 'replace'), u'\ufffd')
+
+    def test_to_bytes(self):
+        for x in (123, (1, 2, 3), [1, 2, 3], {1: 23}, None):
+            self.assertRaises(TypeError, hubblestack.utils.stringutils.to_bytes, x)
+        self.assertEqual(hubblestack.utils.stringutils.to_bytes('xyzzy'), b'xyzzy')
+        self.assertEqual(hubblestack.utils.stringutils.to_bytes(BYTES), BYTES)
+        self.assertEqual(hubblestack.utils.stringutils.to_bytes(bytearray(BYTES)), BYTES)
+        self.assertEqual(hubblestack.utils.stringutils.to_bytes(UNICODE, 'utf-8'), BYTES)
+
+        # Test utf-8 fallback with ascii default encoding
+        with patch.object(builtins, '__salt_system_encoding__', 'ascii'):
+            self.assertEqual(hubblestack.utils.stringutils.to_bytes('Ψ'), b'\xce\xa8')
+
+    def test_to_unicode(self):
+        self.assertEqual(
+            hubblestack.utils.stringutils.to_unicode(
+                EGGS,
+                normalize=True
+            ),
+            'яйца'
+        )
+        self.assertNotEqual(
+            hubblestack.utils.stringutils.to_unicode(
+                EGGS,
+                normalize=False
+            ),
+            'яйца'
+        )
+
+        self.assertEqual(
+            hubblestack.utils.stringutils.to_unicode(
+                LATIN1_BYTES, encoding='latin-1'
+            ),
+            LATIN1_UNICODE
+        )
+
+        self.assertEqual(hubblestack.utils.stringutils.to_unicode('plugh'), 'plugh')
+        self.assertEqual(hubblestack.utils.stringutils.to_unicode('áéíóúý'), 'áéíóúý')
+        self.assertEqual(hubblestack.utils.stringutils.to_unicode(BYTES, 'utf-8'), UNICODE)
+        self.assertEqual(hubblestack.utils.stringutils.to_unicode(bytearray(BYTES), 'utf-8'), UNICODE)
+
+    def test_to_unicode_multi_encoding(self):
+        result = hubblestack.utils.stringutils.to_unicode(LATIN1_BYTES, encoding=('utf-8', 'latin1'))
+        assert result == LATIN1_UNICODE


### PR DESCRIPTION
  - moved test cases for salt.utils.files
    - tests/unittests/utils/test_files.py
  - moved test cases for salt.utils.data
    - tests/unittests/utils/test_data.py
  - moved test cases for salt.utils.args
    - tests/unittests/utils/test_args.py
  - moved test cases for salt.utils.path
    - tests/unittests/utils/test_path.py
  - moved test cases for salt.utils.stringutils
    - tests/unittests/utils/test_stringutils.py