### PR TITLE
Modifying pidfile path: nebula_osqueryd_monitor

### DIFF
--- a/conf/hubble
+++ b/conf/hubble
@@ -88,7 +88,7 @@ fileserver_backend:
 #      flagfile: /path/to/confbase/osquery/osquery.flags
 #      logdir: /var/log/hubble_osquery
 #      databasepath: /var/cache/hubble/osquery
-#      pidfile: /var/run/osquery.pidfile
+#      pidfile: /var/run/hubble_osquery.pidfile
 #      hashfile: /var/cache/hubble/osquery/hash_of_flagfile.txt
 #    run_on_start: True
 #  nebula_osqueryd_log_parser:

--- a/conf/hubble
+++ b/conf/hubble
@@ -88,7 +88,7 @@ fileserver_backend:
 #      flagfile: /path/to/confbase/osquery/osquery.flags
 #      logdir: /var/log/hubble_osquery
 #      databasepath: /var/cache/hubble/osquery
-#      pidfile: /var/run/hubble_osquery/osquery.pidfile
+#      pidfile: /var/run/osquery.pidfile
 #      hashfile: /var/cache/hubble/osquery/hash_of_flagfile.txt
 #    run_on_start: True
 #  nebula_osqueryd_log_parser:


### PR DESCRIPTION
hello, 

While trying to install and test the 4.0.0 debian 10 release, I noticed that the default path listed for the `nebula_osqueryd_monitor:pidfile` is pointed at a folder that doesn't exist. When enabling this schedule, its not clear in debug logs why this is failing without manually running the following command: 

```
root@ip-172-31-12-24:/opt/osquery# /opt/osquery/hubble_osqueryd --pidfile=/var/run/hubble_osquery/osquery.pidfile --logger_path=/var/log/hubble_osquery --config_path=/etc/hubble/osquery.conf --flagfile=/etc/hubble/osquery.flags --database_path=/var/cache/hubble/osquery 

E0804 18:42:01.685073 10098 init.cpp:384] osqueryd initialize failed: Could not create file: /var/run/hubble_osquery/osquery.pidfile
```
I propose we point this to `/var/run/osquery.pidfile` by default so it works out of the gate and let users modify that if they wish.

 https://github.com/hubblestack/hubble/releases/download/v4.0.0/hubblestack-4.0.0-10.deb10.amd64.deb