### PR TITLE
Empty audit issue

### DIFF
--- a/hubblestack/extmods/modules/hubble.py
+++ b/hubblestack/extmods/modules/hubble.py
@@ -294,7 +294,8 @@ def _run_audit(configs, tags, debug, labels, **kwargs):
     # have available with the data list, so data will be processed multiple
     # times. However, for the scale we're working at this should be fine.
     # We can revisit if this ever becomes a big bottleneck
-    for key, func in __nova__._dict.items():
+
+    for key, func in __nova__.items():
         try:
             ret = func(data_list, tags, labels, **kwargs)
         except Exception:
@@ -670,9 +671,9 @@ def load():
     global __nova__
     __nova__ = NovaLazyLoader(_hubble_dir(), __opts__, __mods__)
 
-    ret = {'loaded': list(__nova__._dict.keys()),
+    ret = {'loaded': list(__nova__)),
            'missing': __nova__.missing_modules,
-           'data': list(__nova__.__data__.keys()),
+           'data': list(__nova__.__data__),
            'missing_data': __nova__.__missing_data__}
 
     return True, ret

--- a/hubblestack/extmods/modules/hubble.py
+++ b/hubblestack/extmods/modules/hubble.py
@@ -671,7 +671,7 @@ def load():
     global __nova__
     __nova__ = NovaLazyLoader(_hubble_dir(), __opts__, __mods__)
 
-    ret = {'loaded': list(__nova__)),
+    ret = {'loaded': list(__nova__),
            'missing': __nova__.missing_modules,
            'data': list(__nova__.__data__),
            'missing_data': __nova__.__missing_data__}


### PR DESCRIPTION
This took a sec to track down. I assumed at first it must be a problem with the data_list, but that was spurious -- I did leave some tuning in there anyway, but it's harmless.

The real problem was that since the dunder nova dict is a proper lazy loader and not a kludged loader, accessing the cache in the property under-dict is spurious now. The correct way is to iterate the items and keys of the dictionary itself.