### PR TITLE
Nova connector consolidation

### DIFF
--- a/hubblestack/files/hubblestack_nova/fdg.py
+++ b/hubblestack/files/hubblestack_nova/fdg.py
@@ -18,6 +18,7 @@ fdg:
         starting_chained: 'value'  # value for fdg `starting_chained` (optional)
         true_for_success: True  # Whether a "truthy" value constitues success
         use_status: False  # Use the status result of the fdg run.
+        consolidation_operator: and/or
       '*':  # wildcard, will be run if no direct osfinger match
         fdg_file: 'salt://fdg/my_fdg_file.fdg'  # filename for fdg routine
         tag: 'CIS-1.1.1'  # audit tag
@@ -39,6 +40,10 @@ result returned from fdg will be used. If this is True, only the status result o
 the fdg run will be considered. If it is False, only the actual result of the
 fdg run will be considered. Regardless, the ``true_for_success`` argument
 will be respected.
+
+The consolidation_operator is used when chaining is done using xpipe and the
+returned result is a list. If the list contains more than one tuple, the
+result is consolidated based on the consolidation operator.
 """
 
 import logging

--- a/hubblestack/files/hubblestack_nova/fdg.py
+++ b/hubblestack/files/hubblestack_nova/fdg.py
@@ -139,11 +139,14 @@ def _get_consolidated_result(fdg_run, consolidation_operator):
                   "unexpected structure of %s found, it is not a list", fdg_run)
         return fdg_run, False
 
-    if consolidation_operator and consolidation_operator != "and" and consolidation_operator != "or":
+    if not consolidation_operator:
+        log.error("invalid value of consolidation operator %s found, returning False", consolidation_operator)
+        return fdg_run, False
+    if consolidation_operator != "and" and consolidation_operator != "or":
         log.error("operator %s not supported, returning False", consolidation_operator)
         return fdg_run, False
-    overall_result = consolidation_operator == 'and'
 
+    overall_result = consolidation_operator == 'and'
     for item in fdg_run_copy:
         if not isinstance(item, tuple):
             log.error("something went wrong while consolidating fdg_result, "
@@ -151,7 +154,7 @@ def _get_consolidated_result(fdg_run, consolidation_operator):
             return fdg_run, False
 
         fdg_result, fdg_status = item
-        if "and" in consolidation_operator:
+        if consolidation_operator == "and":
             overall_result = overall_result and fdg_status
         else:
             overall_result = overall_result or fdg_status


### PR DESCRIPTION
Currently the nova connector does not work when the chaining is done using xpipe, because the return object is a list instead of a tuple. This code handles that workflow and consolidates the result when there are more than one item in the returned list. The supported consolidation operators are 'and' and 'or' and can be passes through the nova profile.