### PR TITLE
Minor loader changes

### DIFF
--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -685,33 +685,32 @@ def _setup_dirs():
 
     this_dir = os.path.dirname(__file__)
 
+    # XXX: remove any section that nolonger needs an 'extmods' dir
     module_dirs = __opts__.get('module_dirs', [])
-    module_dirs.append(os.path.join(this_dir, 'modules'))
-    module_dirs.append(os.path.join(this_dir, 'extmods', 'modules')) # XXX
+    module_dirs.append(os.path.join(this_dir, 'extmods', 'modules'))
     __opts__['module_dirs'] = module_dirs
-    grains_dirs = __opts__.get('grains_dirs', [])
-    grains_dirs.append(os.path.join(this_dir, 'grains'))
-    __opts__['grains_dirs'] = grains_dirs
+
     returner_dirs = __opts__.get('returner_dirs', [])
-    returner_dirs.append(os.path.join(this_dir, 'returners'))
-    returner_dirs.append(os.path.join(this_dir, 'extmods', 'returners')) # XXX
+    returner_dirs.append(os.path.join(this_dir, 'extmods', 'returners'))
     __opts__['returner_dirs'] = returner_dirs
+
     fileserver_dirs = __opts__.get('fileserver_dirs', [])
-    fileserver_dirs.append(os.path.join(this_dir, 'fileserver'))
-    fileserver_dirs.append(os.path.join(this_dir, 'extmods', 'fileserver')) # XXX
+    fileserver_dirs.append(os.path.join(this_dir, 'extmods', 'fileserver'))
     __opts__['fileserver_dirs'] = fileserver_dirs
+
     utils_dirs = __opts__.get('utils_dirs', [])
-    utils_dirs.append(os.path.join(this_dir, 'utils'))
-    utils_dirs.append(os.path.join(this_dir, 'extmods', 'utils')) # XXX
+    utils_dirs.append(os.path.join(this_dir, 'extmods', 'utils'))
     __opts__['utils_dirs'] = utils_dirs
+
     fdg_dirs = __opts__.get('fdg_dirs', [])
-    fdg_dirs.append(os.path.join(this_dir, 'fdg'))
-    fdg_dirs.append(os.path.join(this_dir, 'extmods', 'fdg')) # XXX
+    fdg_dirs.append(os.path.join(this_dir, 'extmods', 'fdg'))
     __opts__['fdg_dirs'] = fdg_dirs
+
     audit_dirs = __opts__.get('audit_dirs', [])
-    audit_dirs.append(os.path.join(this_dir, 'audit'))
-    audit_dirs.append(os.path.join(this_dir, 'extmods', 'audit')) # XXX
+    audit_dirs.append(os.path.join(this_dir, 'extmods', 'audit'))
     __opts__['audit_dirs'] = audit_dirs
+
+    # /XXX
 
     if 'file_roots' not in __opts__:
         __opts__['file_roots'] = dict(base=list())


### PR DESCRIPTION
@Tenebriso and I were debugging something and discovered if a module exists in salt and in hubble, the salt module "wins" if the module isn't external ...

Turns out the paths the loader uses are most authoritative last, so any path occurring after hubble in the load list will overwrite what hubble is providing... so I reordered the paths to prefer hubble over salt.

I then taught the path type detector to return 'ext' for salt and 'int' for hubble ... and then relented and taught it to return 'salt' for salt, 'int' for hubble, and 'e_int' for old extmods/modules (eg) ...

So if you use `__mods__['test.ping']` you'll probably get `<function hubble.loaded.salt.module.test.ping()>`; and `__mods__['hubble.audit']` should give `<function hubble.loaded.e_int.module.hubble.audit…` ; and lastly, `__mods__['cmd.run']` should give `hubble.loaded.int.module.cmdmod.run(cmd,…`

