### PR TITLE
remove invalid test requirement pprint

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,5 @@
 argparse
 daemon
-pprint
 backports-abc
 bandit
 certifi


### PR DESCRIPTION
This is one of the errors causing the jenkins build to fail. `pprint` is part of the standard library and shouldn't be present in requirements.