### PR TITLE
add win_system

### DIFF
--- a/hubblestack/files/hubblestack_nova/win_gp.py
+++ b/hubblestack/files/hubblestack_nova/win_gp.py
@@ -164,7 +164,7 @@ def _get_tags(data):
 
 
 def _get_gp_templates():
-    domain_check = __salt__['system.get_domain_workgroup']()
+    domain_check = __mods__['system.get_domain_workgroup']()
     if 'Workgroup' in domain_check:
         return []
 

--- a/hubblestack/modules/win_system.py
+++ b/hubblestack/modules/win_system.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+"""
+Module for managing Windows systems and getting Windows system information.
+Support for reboot, shutdown, join domain, rename
+:depends:
+    - wmi
+    -pywin32
+"""
+try:
+    import wmi
+
+    HAS_WIN32NET_MODS = True
+except ImportError:
+    HAS_WIN32NET_MODS = False
+
+import hubblestack.utils.platform
+import hubblestack.utils.winapi
+
+# Define the module's virtual name
+__virtualname__ = "system"
+
+
+def __virtual__():
+    """
+    Only works on Windows Systems with Win32 Modules
+    """
+    if not hubblestack.utils.platform.is_windows():
+        return False, "Module win_system: Requires Windows"
+
+    if not HAS_WIN32NET_MODS:
+        return False, "Module win_system: Missing win32 modules"
+
+    return __virtualname__
+
+
+def get_domain_workgroup():
+    """
+    Get the domain or workgroup the computer belongs to.
+    .. versionadded:: 2015.5.7
+    .. versionadded:: 2015.8.2
+    Returns:
+        str: The name of the domain or workgroup
+    CLI Example:
+    .. code-block:: bash
+        salt 'minion-id' system.get_domain_workgroup
+    """
+    with hubblestack.utils.winapi.Com():
+        conn = wmi.WMI()
+        for computer in conn.Win32_ComputerSystem():
+            if computer.PartOfDomain:
+                return {"Domain": computer.Domain}
+            else:
+                return {"Workgroup": computer.Domain}

--- a/tests/unittests/modules/test_win_system.py
+++ b/tests/unittests/modules/test_win_system.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+"""
+    :codeauthor: Rahul Handay <rahulha@saltstack.com>
+"""
+# Import Salt Libs
+import hubblestack.modules.win_system as win_system
+import hubblestack.utils.platform
+
+# Import Salt Testing Libs
+from tests.support.mixins import LoaderModuleMockMixin
+from tests.support.mock import MagicMock, Mock, patch
+from tests.support.unit import TestCase, skipIf
+
+try:
+    import wmi
+
+    HAS_WMI = True
+except ImportError:
+    HAS_WMI = False
+
+
+class MockWMI_ComputerSystem(object):
+    """
+    Mock WMI Win32_ComputerSystem Class
+    """
+
+    BootupState = "Normal boot"
+    Caption = "SALT SERVER"
+    ChassisBootupState = 3
+    ChassisSKUNumber = "3.14159"
+    DNSHostname = "SALT SERVER"
+    Domain = "WORKGROUP"
+    DomainRole = 2
+    Manufacturer = "Dell Inc."
+    Model = "Dell 2980"
+    NetworkServerModeEnabled = True
+    PartOfDomain = False
+    PCSystemType = 4
+    PowerState = 0
+    Status = "OK"
+    SystemType = "x64-based PC"
+    TotalPhysicalMemory = 17078214656
+    ThermalState = 3
+    Workgroup = "WORKGROUP"
+
+    def __init__(self):
+        pass
+
+    @staticmethod
+    def Rename(Name):
+        return Name == Name
+
+    @staticmethod
+    def JoinDomainOrWorkgroup(Name):
+        return [0]
+
+    @staticmethod
+    def UnjoinDomainOrWorkgroup(Password, UserName, FUnjoinOptions):
+        return [0]
+
+
+@skipIf(not HAS_WMI, "WMI only available on Windows")
+@skipIf(not hubblestack.utils.platform.is_windows(), "System is not Windows")
+class WinSystemTestCase(TestCase, LoaderModuleMockMixin):
+    """
+        Test cases for hubblestack.modules.win_system
+    """
+    def test_get_domain_workgroup(self):
+        """
+        Test get_domain_workgroup
+        """
+        with patch.object(wmi, "WMI", Mock(return_value=self.WMI)), patch(
+            "hubblestack.utils.winapi.Com", MagicMock()
+        ), patch.object(
+            self.WMI, "Win32_ComputerSystem", return_value=[MockWMI_ComputerSystem()]
+        ):
+            self.assertDictEqual(
+                win_system.get_domain_workgroup(), {"Workgroup": "WORKGROUP"}
+            )


### PR DESCRIPTION
I have found only one usage of the `system` module in the codebase, specifically the `win_system.get_domain_workgroup`. 
I don't know if we're using `modules/system.py` or `modules/mac_system.py` anywhere, but I will bring those in as well if we need them. 