### PR TITLE
fix time_sync

### DIFF
--- a/hubblestack/extmods/fdg/time_sync.py
+++ b/hubblestack/extmods/fdg/time_sync.py
@@ -96,7 +96,7 @@ def _query_ntp_server(ntp_server):
         ntp_client = ntplib.NTPClient()
         response = ntp_client.request(ntp_server, version=3)
         ret = response.offset
-    except Exception:
+    except (Exception, ntplib.NTPException):
         log.error("Unexpected error occured while querying the server.", exc_info=True)
 
     return ret


### PR DESCRIPTION
The `NTPException` doesn't inherit from `Exception`, so it wouldn't be caught by the `except` in the case of a socket timeout, causing the test to fail sometimes.