### PR TITLE
pytest_pyfunc_call is the wrong hook for prof.enable()

### DIFF
--- a/hubblestack/utils/signing.py
+++ b/hubblestack/utils/signing.py
@@ -142,7 +142,7 @@ class Options(object):
             pass
         try:
             default = getattr(self.Defaults, name)
-            return __mods__['config.get']('repo_signing:{}'.format(name), default)
+            return __salt__['config.get']('repo_signing:{}'.format(name), default)
         except AttributeError:
             raise
 

--- a/tests/unittests/conftest.py
+++ b/tests/unittests/conftest.py
@@ -188,7 +188,7 @@ def __opts__(salt_loaders):
 prof = None
 
 @pytest.hookimpl(hookwrapper=True)
-def pytest_pyfunc_call(pyfuncitem):
+def pytest_runtest_call(item):
     if prof:
         prof.enable()
 


### PR DESCRIPTION
We get crashes from empty profile pstat files pretty frequently. This repairs the problem.

After this merges and #936 rebases to develop, it should pass the annoying test failures it's having.