### PR TITLE
Changing rc0 from version

### DIFF
--- a/hubblestack/version.py
+++ b/hubblestack/version.py
@@ -1,4 +1,4 @@
 # coding: utf-8
 
-__version__ = '4.5.0_rc0'
+__version__ = '4.5.0'
 

--- a/pkg/amazonlinux2016.09/Dockerfile
+++ b/pkg/amazonlinux2016.09/Dockerfile
@@ -122,7 +122,7 @@ RUN /opt/osquery/osqueryi --version
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
 ARG HUBBLE_CHECKOUT=v4.0.0
-ARG HUBBLE_VERSION=4.5.0_rc0
+ARG HUBBLE_VERSION=4.5.0
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_URL=https://github.com/hubblestack/hubble
 ENV HUBBLE_DESCRIPTION="Hubble is a modular, open-source, security & compliance auditing framework which is built in python, using SaltStack as a library."

--- a/pkg/amazonlinux2016.09/entrypoint.sh
+++ b/pkg/amazonlinux2016.09/entrypoint.sh
@@ -80,6 +80,7 @@ pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \
     -r optional-requirements.txt \
     -r package-requirements.txt
+pip freeze > /data/requirements.txt
 
 [ -f ${_HOOK_DIR:-./pkg}/hook-hubblestack.py ] || exit 1
 

--- a/pkg/centos6/Dockerfile
+++ b/pkg/centos6/Dockerfile
@@ -124,7 +124,7 @@ RUN /opt/osquery/osqueryi --version
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
 ARG HUBBLE_CHECKOUT=v4.0.0
-ARG HUBBLE_VERSION=4.5.0_rc0
+ARG HUBBLE_VERSION=4.5.0
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_URL=https://github.com/hubblestack/hubble
 ENV HUBBLE_DESCRIPTION="Hubble is a modular, open-source, security & compliance auditing framework which is built in python, using SaltStack as a library."

--- a/pkg/centos6/entrypoint.sh
+++ b/pkg/centos6/entrypoint.sh
@@ -80,6 +80,7 @@ pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \
     -r optional-requirements.txt \
     -r package-requirements.txt
+pip freeze > /data/requirements.txt
 
 [ -f ${_HOOK_DIR:-./pkg}/hook-hubblestack.py ] || exit 1
 

--- a/pkg/centos7/Dockerfile
+++ b/pkg/centos7/Dockerfile
@@ -122,7 +122,7 @@ RUN /opt/osquery/osqueryi --version
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
 ARG HUBBLE_CHECKOUT=v4.0.0
-ARG HUBBLE_VERSION=4.5.0_rc0
+ARG HUBBLE_VERSION=4.5.0
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_URL=https://github.com/hubblestack/hubble
 ENV HUBBLE_DESCRIPTION="Hubble is a modular, open-source, security & compliance auditing framework which is built in python, using SaltStack as a library."

--- a/pkg/centos7/entrypoint.sh
+++ b/pkg/centos7/entrypoint.sh
@@ -80,6 +80,7 @@ pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \
     -r optional-requirements.txt \
     -r package-requirements.txt
+pip freeze > /data/requirements.txt
 
 [ -f ${_HOOK_DIR:-./pkg}/hook-hubblestack.py ] || exit 1
 

--- a/pkg/centos8/Dockerfile
+++ b/pkg/centos8/Dockerfile
@@ -125,7 +125,7 @@ RUN /opt/osquery/osqueryi --version
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
 ARG HUBBLE_CHECKOUT=v4.0.0
-ARG HUBBLE_VERSION=4.5.0_rc0
+ARG HUBBLE_VERSION=4.5.0
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_URL=https://github.com/hubblestack/hubble
 ENV HUBBLE_DESCRIPTION="Hubble is a modular, open-source, security & compliance auditing framework which is built in python, using SaltStack as a library."

--- a/pkg/centos8/entrypoint.sh
+++ b/pkg/centos8/entrypoint.sh
@@ -80,6 +80,7 @@ pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \
     -r optional-requirements.txt \
     -r package-requirements.txt
+pip freeze > /data/requirements.txt
 
 [ -f ${_HOOK_DIR:-./pkg}/hook-hubblestack.py ] || exit 1
 

--- a/pkg/coreos/Dockerfile
+++ b/pkg/coreos/Dockerfile
@@ -116,7 +116,7 @@ RUN /opt/osquery/osqueryi --version
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
 ARG HUBBLE_CHECKOUT=v4.0.0
-ARG HUBBLE_VERSION=4.5.0_rc0
+ARG HUBBLE_VERSION=4.5.0
 ARG HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_URL=https://github.com/hubblestack/hubble

--- a/pkg/coreos/entrypoint.sh
+++ b/pkg/coreos/entrypoint.sh
@@ -80,6 +80,7 @@ pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \
     -r optional-requirements.txt \
     -r package-requirements.txt
+pip freeze > /data/requirements.txt
 
 [ -f ${_HOOK_DIR:-./pkg}/hook-hubblestack.py ] || exit 1
 

--- a/pkg/debian10/Dockerfile
+++ b/pkg/debian10/Dockerfile
@@ -124,7 +124,7 @@ RUN /opt/osquery/osqueryi --version
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
 ARG HUBBLE_CHECKOUT=v4.0.0
-ARG HUBBLE_VERSION=4.5.0_rc0
+ARG HUBBLE_VERSION=4.5.0
 ARG HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_URL=https://github.com/hubblestack/hubble

--- a/pkg/debian10/entrypoint.sh
+++ b/pkg/debian10/entrypoint.sh
@@ -80,6 +80,7 @@ pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \
     -r optional-requirements.txt \
     -r package-requirements.txt
+pip freeze > /data/requirements.txt
 
 [ -f ${_HOOK_DIR:-./pkg}/hook-hubblestack.py ] || exit 1
 

--- a/pkg/debian8/Dockerfile
+++ b/pkg/debian8/Dockerfile
@@ -123,7 +123,7 @@ RUN /opt/osquery/osqueryi --version
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
 ARG HUBBLE_CHECKOUT=v4.0.0
-ARG HUBBLE_VERSION=4.5.0_rc0
+ARG HUBBLE_VERSION=4.5.0
 ARG HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_URL=https://github.com/hubblestack/hubble

--- a/pkg/debian8/entrypoint.sh
+++ b/pkg/debian8/entrypoint.sh
@@ -80,6 +80,7 @@ pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \
     -r optional-requirements.txt \
     -r package-requirements.txt
+pip freeze > /data/requirements.txt
 
 [ -f ${_HOOK_DIR:-./pkg}/hook-hubblestack.py ] || exit 1
 

--- a/pkg/debian9/Dockerfile
+++ b/pkg/debian9/Dockerfile
@@ -124,7 +124,7 @@ RUN /opt/osquery/osqueryi --version
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
 ARG HUBBLE_CHECKOUT=v4.0.0
-ARG HUBBLE_VERSION=4.5.0_rc0
+ARG HUBBLE_VERSION=4.5.0
 ARG HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_URL=https://github.com/hubblestack/hubble

--- a/pkg/debian9/entrypoint.sh
+++ b/pkg/debian9/entrypoint.sh
@@ -80,6 +80,7 @@ pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \
     -r optional-requirements.txt \
     -r package-requirements.txt
+pip freeze > /data/requirements.txt
 
 [ -f ${_HOOK_DIR:-./pkg}/hook-hubblestack.py ] || exit 1
 

--- a/pkg/dev/amazonlinux2016.09/Dockerfile
+++ b/pkg/dev/amazonlinux2016.09/Dockerfile
@@ -122,7 +122,7 @@ RUN /opt/osquery/osqueryi --version
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
 ARG HUBBLE_CHECKOUT=v4.0.0
-ARG HUBBLE_VERSION=4.5.0_rc0
+ARG HUBBLE_VERSION=4.5.0
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_URL=https://github.com/hubblestack/hubble
 ENV HUBBLE_DESCRIPTION="Hubble is a modular, open-source, security & compliance auditing framework which is built in python, using SaltStack as a library."

--- a/pkg/dev/amazonlinux2016.09/entrypoint.sh
+++ b/pkg/dev/amazonlinux2016.09/entrypoint.sh
@@ -80,6 +80,7 @@ pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \
     -r optional-requirements.txt \
     -r package-requirements.txt
+pip freeze > /data/requirements.txt
 
 [ -f ${_HOOK_DIR:-./pkg}/hook-hubblestack.py ] || exit 1
 

--- a/pkg/dev/centos6/Dockerfile
+++ b/pkg/dev/centos6/Dockerfile
@@ -124,7 +124,7 @@ RUN /opt/osquery/osqueryi --version
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
 ARG HUBBLE_CHECKOUT=v4.0.0
-ARG HUBBLE_VERSION=4.5.0_rc0
+ARG HUBBLE_VERSION=4.5.0
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_URL=https://github.com/hubblestack/hubble
 ENV HUBBLE_DESCRIPTION="Hubble is a modular, open-source, security & compliance auditing framework which is built in python, using SaltStack as a library."

--- a/pkg/dev/centos6/entrypoint.sh
+++ b/pkg/dev/centos6/entrypoint.sh
@@ -80,6 +80,7 @@ pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \
     -r optional-requirements.txt \
     -r package-requirements.txt
+pip freeze > /data/requirements.txt
 
 [ -f ${_HOOK_DIR:-./pkg}/hook-hubblestack.py ] || exit 1
 

--- a/pkg/dev/centos7/Dockerfile
+++ b/pkg/dev/centos7/Dockerfile
@@ -122,7 +122,7 @@ RUN /opt/osquery/osqueryi --version
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
 ARG HUBBLE_CHECKOUT=v4.0.0
-ARG HUBBLE_VERSION=4.5.0_rc0
+ARG HUBBLE_VERSION=4.5.0
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_URL=https://github.com/hubblestack/hubble
 ENV HUBBLE_DESCRIPTION="Hubble is a modular, open-source, security & compliance auditing framework which is built in python, using SaltStack as a library."

--- a/pkg/dev/centos7/entrypoint.sh
+++ b/pkg/dev/centos7/entrypoint.sh
@@ -80,6 +80,7 @@ pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \
     -r optional-requirements.txt \
     -r package-requirements.txt
+pip freeze > /data/requirements.txt
 
 [ -f ${_HOOK_DIR:-./pkg}/hook-hubblestack.py ] || exit 1
 

--- a/pkg/dev/centos8/Dockerfile
+++ b/pkg/dev/centos8/Dockerfile
@@ -125,7 +125,7 @@ RUN /opt/osquery/osqueryi --version
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
 ARG HUBBLE_CHECKOUT=v4.0.0
-ARG HUBBLE_VERSION=4.5.0_rc0
+ARG HUBBLE_VERSION=4.5.0
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_URL=https://github.com/hubblestack/hubble
 ENV HUBBLE_DESCRIPTION="Hubble is a modular, open-source, security & compliance auditing framework which is built in python, using SaltStack as a library."

--- a/pkg/dev/centos8/entrypoint.sh
+++ b/pkg/dev/centos8/entrypoint.sh
@@ -80,6 +80,7 @@ pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \
     -r optional-requirements.txt \
     -r package-requirements.txt
+pip freeze > /data/requirements.txt
 
 [ -f ${_HOOK_DIR:-./pkg}/hook-hubblestack.py ] || exit 1
 

--- a/pkg/dev/coreos/Dockerfile
+++ b/pkg/dev/coreos/Dockerfile
@@ -117,7 +117,7 @@ RUN /opt/osquery/osqueryi --version
 #use the following variables to choose the version of hubble
 ARG HUBBLE_CHECKOUT=v4.0.0
 ARG HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
-ARG HUBBLE_VERSION=4.5.0_rc0
+ARG HUBBLE_VERSION=4.5.0
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_URL=https://github.com/hubblestack/hubble
 ENV HUBBLE_SRC_PATH=/hubble_src

--- a/pkg/dev/coreos/entrypoint.sh
+++ b/pkg/dev/coreos/entrypoint.sh
@@ -80,6 +80,7 @@ pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \
     -r optional-requirements.txt \
     -r package-requirements.txt
+pip freeze > /data/requirements.txt
 
 [ -f ${_HOOK_DIR:-./pkg}/hook-hubblestack.py ] || exit 1
 

--- a/pkg/dev/debian10/Dockerfile
+++ b/pkg/dev/debian10/Dockerfile
@@ -125,7 +125,7 @@ RUN /opt/osquery/osqueryi --version
 #use the following variables to choose the version of hubble
 ARG HUBBLE_CHECKOUT=v4.0.0
 ARG HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
-ARG HUBBLE_VERSION=4.5.0_rc0
+ARG HUBBLE_VERSION=4.5.0
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_URL=https://github.com/hubblestack/hubble
 ENV HUBBLE_SRC_PATH=/hubble_src

--- a/pkg/dev/debian10/entrypoint.sh
+++ b/pkg/dev/debian10/entrypoint.sh
@@ -80,6 +80,7 @@ pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \
     -r optional-requirements.txt \
     -r package-requirements.txt
+pip freeze > /data/requirements.txt
 
 [ -f ${_HOOK_DIR:-./pkg}/hook-hubblestack.py ] || exit 1
 

--- a/pkg/dev/debian8/Dockerfile
+++ b/pkg/dev/debian8/Dockerfile
@@ -124,7 +124,7 @@ RUN /opt/osquery/osqueryi --version
 #use the following variables to choose the version of hubble
 ARG HUBBLE_CHECKOUT=v4.0.0
 ARG HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
-ARG HUBBLE_VERSION=4.5.0_rc0
+ARG HUBBLE_VERSION=4.5.0
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_URL=https://github.com/hubblestack/hubble
 ENV HUBBLE_SRC_PATH=/hubble_src

--- a/pkg/dev/debian8/entrypoint.sh
+++ b/pkg/dev/debian8/entrypoint.sh
@@ -80,6 +80,7 @@ pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \
     -r optional-requirements.txt \
     -r package-requirements.txt
+pip freeze > /data/requirements.txt
 
 [ -f ${_HOOK_DIR:-./pkg}/hook-hubblestack.py ] || exit 1
 

--- a/pkg/dev/debian9/Dockerfile
+++ b/pkg/dev/debian9/Dockerfile
@@ -125,7 +125,7 @@ RUN /opt/osquery/osqueryi --version
 #use the following variables to choose the version of hubble
 ARG HUBBLE_CHECKOUT=v4.0.0
 ARG HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
-ARG HUBBLE_VERSION=4.5.0_rc0
+ARG HUBBLE_VERSION=4.5.0
 ENV HUBBLE_ITERATION=1
 ENV HUBBLE_URL=https://github.com/hubblestack/hubble
 ENV HUBBLE_SRC_PATH=/hubble_src

--- a/pkg/dev/debian9/entrypoint.sh
+++ b/pkg/dev/debian9/entrypoint.sh
@@ -80,6 +80,7 @@ pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \
     -r optional-requirements.txt \
     -r package-requirements.txt
+pip freeze > /data/requirements.txt
 
 [ -f ${_HOOK_DIR:-./pkg}/hook-hubblestack.py ] || exit 1
 


### PR DESCRIPTION
- Removing rc0 from version as '_' character with it is causing issues in creating hubble binaries for debian systems.
Instead of rc versioning scheme, we should just bump up the minor version.
- Exporting requirements file as it is required for Tessa posting