### PR TITLE
Updating hook-hubblestack as python files under hubblestack were not …

### DIFF
--- a/pkg/hook-hubblestack.py
+++ b/pkg/hook-hubblestack.py
@@ -40,6 +40,7 @@ HIDDEN_IMPORTS = [
 ]
 
 LOADERS = [
+    'hubblestack',
     'hubblestack.audit',
     'hubblestack.comparators',
     'hubblestack.fdg',


### PR DESCRIPTION
Updating hook-hubblestack as python files under hubblestack (like daemon.py) were not coming in build