### PR TITLE
Build changes for Centos8 and Debian8

### DIFF
--- a/pkg/centos8/Dockerfile
+++ b/pkg/centos8/Dockerfile
@@ -97,7 +97,7 @@ RUN dnf -y update && dnf install -y ruby ruby-devel rpm-build rubygems gcc make 
 
 # install fpm
 RUN gem install --no-ri --no-rdoc ffi --version 1.12.2 \
- && gem install --no-ri --no-rdoc fpm
+ && gem install --no-ri --no-rdoc fpm --version 1.11
 
 # use pyenv
 ARG PYENV_VERSION=3.7.0

--- a/pkg/debian8/Dockerfile
+++ b/pkg/debian8/Dockerfile
@@ -98,7 +98,7 @@ RUN apt-get install -y libbz2-dev libsqlite3-dev \
  && rm -rf /var/cache/apt
 
 # use pyenv
-ARG PYENV_VERSION=3.7.0
+ARG PYENV_VERSION=3.6.10
 ENV PYENV_INSTALLER_URL=https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer
 ENV PYENV_ROOT=/opt/hubble/pyenv
 ENV PATH=$PYENV_ROOT/bin:$PATH


### PR DESCRIPTION
Build changes for Centos8 and Debian8

On CentOS-8, fpm 1.12 (latest) is broken. So 1.11 is being used.
For Debian8, its already EOL. And, to build Python >=3.7, we need to build openssl first.