### PR TITLE
fixing bug

### DIFF
--- a/hubblestack/comparators/dict.py
+++ b/hubblestack/comparators/dict.py
@@ -291,7 +291,8 @@ def match_any_if_keyvalue_matches(audit_id, result_to_compare, args):
     key_found_once = False
     for to_match_dict in args['match_any_if_keyvalue_matches']['args']:
         errors = []
-        if not to_match_dict.get(key_name, None):
+        key_found = to_match_dict.get(key_name, None)
+        if key_found is None:
             return True, "pass_as_keyvalue_not_found"
         if result_to_compare[key_name] == to_match_dict[key_name]:
             key_found_once = True

--- a/hubblestack/utils/signing.py
+++ b/hubblestack/utils/signing.py
@@ -322,6 +322,7 @@ class X509AwareCertBucket:
                     str_ca, status, digest)
 
         for i in untrusted_crt:
+            log_level = log.debug
             digest = i.digest('sha1')
             if digest in already:
                 continue
@@ -332,7 +333,6 @@ class X509AwareCertBucket:
                 self.store.add_cert(i) # add to trusted keyring
                 self.trusted.append(digest)
                 status = STATUS.VERIFIED
-                log_level = log.debug
             except ossl.X509StoreContextError as exception_object:
                 # log at either log.error or log.critical according to the error code
                 status = STATUS.FAIL


### PR DESCRIPTION
This is a corner case where the value of **to_match_dict.get(key_name, None)** was **0 (zero)**, which is not **None**, but eventually python treats it as **`false`** and entered the if statement even when we did not wanted it to. Fixed it to explicitly enter the if statement only if the value is **None**

Also log_level is defined at a wrong place.