### PR TITLE
Updating pip to latest version - 21.0.1 on all platforms

### DIFF
--- a/.pipeline
+++ b/.pipeline
@@ -86,7 +86,6 @@ pipeline {
                     pip install --cache-dir .pip-cache -t ./vlib virtualenv
                     PYTHONPATH=./vlib ./vlib/bin/virtualenv ./venv
                     source ./venv/bin/activate
-                    pip install --cache-dir .pip-cache -U pip==21.0.1
                     echo no | ./mk-requires.sh
                     pip install --cache-dir .pip-cache -U -r requirements.txt
                     pip install --cache-dir .pip-cache -U -r tests/automation/requirements.txt

--- a/.pipeline
+++ b/.pipeline
@@ -86,7 +86,7 @@ pipeline {
                     pip install --cache-dir .pip-cache -t ./vlib virtualenv
                     PYTHONPATH=./vlib ./vlib/bin/virtualenv ./venv
                     source ./venv/bin/activate
-                    pip install --cache-dir .pip-cache -U pip==20.2
+                    pip install --cache-dir .pip-cache -U pip==21.0.1
                     echo no | ./mk-requires.sh
                     pip install --cache-dir .pip-cache -U -r requirements.txt
                     pip install --cache-dir .pip-cache -U -r tests/automation/requirements.txt

--- a/package-requirements.txt
+++ b/package-requirements.txt
@@ -1,3 +1,2 @@
 pyinstaller
-pyinstaller-hooks
 tornado

--- a/pkg/amazonlinux2016.09/entrypoint.sh
+++ b/pkg/amazonlinux2016.09/entrypoint.sh
@@ -74,7 +74,7 @@ cd /hubble_build
 
 # we may have preinstalled requirements that may need upgrading
 # pip install . might not upgrade/downgrade the requirements
-pip install pip==21.0.1 wheel
+pip install wheel
 python setup.py egg_info
 pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \

--- a/pkg/amazonlinux2016.09/entrypoint.sh
+++ b/pkg/amazonlinux2016.09/entrypoint.sh
@@ -74,7 +74,7 @@ cd /hubble_build
 
 # we may have preinstalled requirements that may need upgrading
 # pip install . might not upgrade/downgrade the requirements
-pip install pip==20.2 wheel
+pip install pip==21.0.1 wheel
 python setup.py egg_info
 pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \

--- a/pkg/centos6/entrypoint.sh
+++ b/pkg/centos6/entrypoint.sh
@@ -74,7 +74,7 @@ cd /hubble_build
 
 # we may have preinstalled requirements that may need upgrading
 # pip install . might not upgrade/downgrade the requirements
-pip install pip==21.0.1 wheel
+pip install wheel
 python setup.py egg_info
 pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \

--- a/pkg/centos6/entrypoint.sh
+++ b/pkg/centos6/entrypoint.sh
@@ -74,7 +74,7 @@ cd /hubble_build
 
 # we may have preinstalled requirements that may need upgrading
 # pip install . might not upgrade/downgrade the requirements
-pip install pip==20.2 wheel
+pip install pip==21.0.1 wheel
 python setup.py egg_info
 pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \

--- a/pkg/centos7/entrypoint.sh
+++ b/pkg/centos7/entrypoint.sh
@@ -74,7 +74,7 @@ cd /hubble_build
 
 # we may have preinstalled requirements that may need upgrading
 # pip install . might not upgrade/downgrade the requirements
-pip install pip==21.0.1 wheel
+pip install wheel
 python setup.py egg_info
 pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \

--- a/pkg/centos7/entrypoint.sh
+++ b/pkg/centos7/entrypoint.sh
@@ -74,7 +74,7 @@ cd /hubble_build
 
 # we may have preinstalled requirements that may need upgrading
 # pip install . might not upgrade/downgrade the requirements
-pip install pip==20.2 wheel
+pip install pip==21.0.1 wheel
 python setup.py egg_info
 pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \

--- a/pkg/centos8/entrypoint.sh
+++ b/pkg/centos8/entrypoint.sh
@@ -74,7 +74,7 @@ cd /hubble_build
 
 # we may have preinstalled requirements that may need upgrading
 # pip install . might not upgrade/downgrade the requirements
-pip install pip==21.0.1 wheel
+pip install wheel
 python setup.py egg_info
 pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \

--- a/pkg/centos8/entrypoint.sh
+++ b/pkg/centos8/entrypoint.sh
@@ -74,7 +74,7 @@ cd /hubble_build
 
 # we may have preinstalled requirements that may need upgrading
 # pip install . might not upgrade/downgrade the requirements
-pip install pip==20.2 wheel
+pip install pip==21.0.1 wheel
 python setup.py egg_info
 pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \

--- a/pkg/coreos/entrypoint.sh
+++ b/pkg/coreos/entrypoint.sh
@@ -74,7 +74,7 @@ cd /hubble_build
 
 # we may have preinstalled requirements that may need upgrading
 # pip install . might not upgrade/downgrade the requirements
-pip install pip==21.0.1 wheel
+pip install wheel
 python setup.py egg_info
 pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \

--- a/pkg/coreos/entrypoint.sh
+++ b/pkg/coreos/entrypoint.sh
@@ -74,7 +74,7 @@ cd /hubble_build
 
 # we may have preinstalled requirements that may need upgrading
 # pip install . might not upgrade/downgrade the requirements
-pip install pip==20.2 wheel
+pip install pip==21.0.1 wheel
 python setup.py egg_info
 pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \

--- a/pkg/debian10/entrypoint.sh
+++ b/pkg/debian10/entrypoint.sh
@@ -74,7 +74,7 @@ cd /hubble_build
 
 # we may have preinstalled requirements that may need upgrading
 # pip install . might not upgrade/downgrade the requirements
-pip install pip==21.0.1 wheel
+pip install wheel
 python setup.py egg_info
 pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \

--- a/pkg/debian10/entrypoint.sh
+++ b/pkg/debian10/entrypoint.sh
@@ -74,7 +74,7 @@ cd /hubble_build
 
 # we may have preinstalled requirements that may need upgrading
 # pip install . might not upgrade/downgrade the requirements
-pip install pip==20.2 wheel
+pip install pip==21.0.1 wheel
 python setup.py egg_info
 pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \

--- a/pkg/debian8/entrypoint.sh
+++ b/pkg/debian8/entrypoint.sh
@@ -74,7 +74,7 @@ cd /hubble_build
 
 # we may have preinstalled requirements that may need upgrading
 # pip install . might not upgrade/downgrade the requirements
-pip install pip==21.0.1 wheel
+pip install wheel
 python setup.py egg_info
 pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \

--- a/pkg/debian8/entrypoint.sh
+++ b/pkg/debian8/entrypoint.sh
@@ -74,7 +74,7 @@ cd /hubble_build
 
 # we may have preinstalled requirements that may need upgrading
 # pip install . might not upgrade/downgrade the requirements
-pip install pip==20.2 wheel
+pip install pip==21.0.1 wheel
 python setup.py egg_info
 pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \

--- a/pkg/debian9/entrypoint.sh
+++ b/pkg/debian9/entrypoint.sh
@@ -74,7 +74,7 @@ cd /hubble_build
 
 # we may have preinstalled requirements that may need upgrading
 # pip install . might not upgrade/downgrade the requirements
-pip install pip==21.0.1 wheel
+pip install wheel
 python setup.py egg_info
 pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \

--- a/pkg/debian9/entrypoint.sh
+++ b/pkg/debian9/entrypoint.sh
@@ -74,7 +74,7 @@ cd /hubble_build
 
 # we may have preinstalled requirements that may need upgrading
 # pip install . might not upgrade/downgrade the requirements
-pip install pip==20.2 wheel
+pip install pip==21.0.1 wheel
 python setup.py egg_info
 pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \

--- a/pkg/dev/amazonlinux2016.09/entrypoint.sh
+++ b/pkg/dev/amazonlinux2016.09/entrypoint.sh
@@ -74,7 +74,7 @@ cd /hubble_build
 
 # we may have preinstalled requirements that may need upgrading
 # pip install . might not upgrade/downgrade the requirements
-pip install pip==21.0.1 wheel
+pip install wheel
 python setup.py egg_info
 pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \

--- a/pkg/dev/amazonlinux2016.09/entrypoint.sh
+++ b/pkg/dev/amazonlinux2016.09/entrypoint.sh
@@ -74,7 +74,7 @@ cd /hubble_build
 
 # we may have preinstalled requirements that may need upgrading
 # pip install . might not upgrade/downgrade the requirements
-pip install pip==20.2 wheel
+pip install pip==21.0.1 wheel
 python setup.py egg_info
 pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \

--- a/pkg/dev/centos6/entrypoint.sh
+++ b/pkg/dev/centos6/entrypoint.sh
@@ -74,7 +74,7 @@ cd /hubble_build
 
 # we may have preinstalled requirements that may need upgrading
 # pip install . might not upgrade/downgrade the requirements
-pip install pip==21.0.1 wheel
+pip install wheel
 python setup.py egg_info
 pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \

--- a/pkg/dev/centos6/entrypoint.sh
+++ b/pkg/dev/centos6/entrypoint.sh
@@ -74,7 +74,7 @@ cd /hubble_build
 
 # we may have preinstalled requirements that may need upgrading
 # pip install . might not upgrade/downgrade the requirements
-pip install pip==20.2 wheel
+pip install pip==21.0.1 wheel
 python setup.py egg_info
 pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \

--- a/pkg/dev/centos7/entrypoint.sh
+++ b/pkg/dev/centos7/entrypoint.sh
@@ -74,7 +74,7 @@ cd /hubble_build
 
 # we may have preinstalled requirements that may need upgrading
 # pip install . might not upgrade/downgrade the requirements
-pip install pip==21.0.1 wheel
+pip install wheel
 python setup.py egg_info
 pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \

--- a/pkg/dev/centos7/entrypoint.sh
+++ b/pkg/dev/centos7/entrypoint.sh
@@ -74,7 +74,7 @@ cd /hubble_build
 
 # we may have preinstalled requirements that may need upgrading
 # pip install . might not upgrade/downgrade the requirements
-pip install pip==20.2 wheel
+pip install pip==21.0.1 wheel
 python setup.py egg_info
 pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \

--- a/pkg/dev/centos8/entrypoint.sh
+++ b/pkg/dev/centos8/entrypoint.sh
@@ -74,7 +74,7 @@ cd /hubble_build
 
 # we may have preinstalled requirements that may need upgrading
 # pip install . might not upgrade/downgrade the requirements
-pip install pip==21.0.1 wheel
+pip install wheel
 python setup.py egg_info
 pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \

--- a/pkg/dev/centos8/entrypoint.sh
+++ b/pkg/dev/centos8/entrypoint.sh
@@ -74,7 +74,7 @@ cd /hubble_build
 
 # we may have preinstalled requirements that may need upgrading
 # pip install . might not upgrade/downgrade the requirements
-pip install pip==20.2 wheel
+pip install pip==21.0.1 wheel
 python setup.py egg_info
 pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \

--- a/pkg/dev/coreos/entrypoint.sh
+++ b/pkg/dev/coreos/entrypoint.sh
@@ -74,7 +74,7 @@ cd /hubble_build
 
 # we may have preinstalled requirements that may need upgrading
 # pip install . might not upgrade/downgrade the requirements
-pip install pip==21.0.1 wheel
+pip install wheel
 python setup.py egg_info
 pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \

--- a/pkg/dev/coreos/entrypoint.sh
+++ b/pkg/dev/coreos/entrypoint.sh
@@ -74,7 +74,7 @@ cd /hubble_build
 
 # we may have preinstalled requirements that may need upgrading
 # pip install . might not upgrade/downgrade the requirements
-pip install pip==20.2 wheel
+pip install pip==21.0.1 wheel
 python setup.py egg_info
 pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \

--- a/pkg/dev/debian10/entrypoint.sh
+++ b/pkg/dev/debian10/entrypoint.sh
@@ -74,7 +74,7 @@ cd /hubble_build
 
 # we may have preinstalled requirements that may need upgrading
 # pip install . might not upgrade/downgrade the requirements
-pip install pip==21.0.1 wheel
+pip install wheel
 python setup.py egg_info
 pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \

--- a/pkg/dev/debian10/entrypoint.sh
+++ b/pkg/dev/debian10/entrypoint.sh
@@ -74,7 +74,7 @@ cd /hubble_build
 
 # we may have preinstalled requirements that may need upgrading
 # pip install . might not upgrade/downgrade the requirements
-pip install pip==20.2 wheel
+pip install pip==21.0.1 wheel
 python setup.py egg_info
 pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \

--- a/pkg/dev/debian8/entrypoint.sh
+++ b/pkg/dev/debian8/entrypoint.sh
@@ -74,7 +74,7 @@ cd /hubble_build
 
 # we may have preinstalled requirements that may need upgrading
 # pip install . might not upgrade/downgrade the requirements
-pip install pip==21.0.1 wheel
+pip install wheel
 python setup.py egg_info
 pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \

--- a/pkg/dev/debian8/entrypoint.sh
+++ b/pkg/dev/debian8/entrypoint.sh
@@ -74,7 +74,7 @@ cd /hubble_build
 
 # we may have preinstalled requirements that may need upgrading
 # pip install . might not upgrade/downgrade the requirements
-pip install pip==20.2 wheel
+pip install pip==21.0.1 wheel
 python setup.py egg_info
 pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \

--- a/pkg/dev/debian9/entrypoint.sh
+++ b/pkg/dev/debian9/entrypoint.sh
@@ -74,7 +74,7 @@ cd /hubble_build
 
 # we may have preinstalled requirements that may need upgrading
 # pip install . might not upgrade/downgrade the requirements
-pip install pip==21.0.1 wheel
+pip install wheel
 python setup.py egg_info
 pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \

--- a/pkg/dev/debian9/entrypoint.sh
+++ b/pkg/dev/debian9/entrypoint.sh
@@ -74,7 +74,7 @@ cd /hubble_build
 
 # we may have preinstalled requirements that may need upgrading
 # pip install . might not upgrade/downgrade the requirements
-pip install pip==20.2 wheel
+pip install pip==21.0.1 wheel
 python setup.py egg_info
 pip install --upgrade \
     -r hubblestack.egg-info/requires.txt \

--- a/pkg/windows/Dockerfile
+++ b/pkg/windows/Dockerfile
@@ -54,8 +54,6 @@ RUN $url = ('https://www.python.org/ftp/python/{0}/python-{1}-amd64.exe' -f $env
 	\
 	Write-Host 'Complete.'
 
-# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 21.0.1
 # https://github.com/pypa/get-pip
 ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/d59197a3c169cef378a22428a3fa99d33e080a5d/get-pip.py
 ENV PYTHON_GET_PIP_SHA256 421ac1d44c0cf9730a088e337867d974b91bdce4ea2636099275071878cc189e
@@ -69,11 +67,10 @@ RUN Write-Host ('Downloading get-pip.py ({0}) ...' -f $env:PYTHON_GET_PIP_URL); 
 		exit 1; \
 	}; \
 	\
-	Write-Host ('Installing pip=={0} ...' -f $env:PYTHON_PIP_VERSION); \
+	Write-Host ('Installing pip ...'); \
 	python get-pip.py \
 		--disable-pip-version-check \
 		--no-cache-dir \
-		('pip=={0}' -f $env:PYTHON_PIP_VERSION) \
 	; \
 	Remove-Item get-pip.py -Force; \
 	\

--- a/pkg/windows/Dockerfile
+++ b/pkg/windows/Dockerfile
@@ -55,7 +55,7 @@ RUN $url = ('https://www.python.org/ftp/python/{0}/python-{1}-amd64.exe' -f $env
 	Write-Host 'Complete.'
 
 # if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
-ENV PYTHON_PIP_VERSION 20.2
+ENV PYTHON_PIP_VERSION 21.0.1
 # https://github.com/pypa/get-pip
 ENV PYTHON_GET_PIP_URL https://github.com/pypa/get-pip/raw/d59197a3c169cef378a22428a3fa99d33e080a5d/get-pip.py
 ENV PYTHON_GET_PIP_SHA256 421ac1d44c0cf9730a088e337867d974b91bdce4ea2636099275071878cc189e

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,6 @@ pycryptodome
 pygit2
 pyinotify
 pyinstaller
-pyinstaller-hooks
 pylint
 pyopenssl
 pyparsing


### PR DESCRIPTION
Updating pip to latest version - 21.0.1 on all platforms

This is after the azurefs changes.
Now, we have the latest azurefs libraries, and the latest pip

For pyinstaller-hooks, now it comes pre-bundled with pyinstaller. No need for extra install.