### PR TITLE
More build fixes again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# patch objects
+*.orig
+*.rej
+
 # C extensions
 *.so
 

--- a/pkg/amazonlinux2016.09/Dockerfile
+++ b/pkg/amazonlinux2016.09/Dockerfile
@@ -113,7 +113,7 @@ RUN wget -c https://bootstrap.pypa.io/3.4/get-pip.py \
 
 #fpm package making requirements start
 RUN yum install -y ruby ruby-devel rpmbuild rpm-build rubygems gcc make \
- && gem install --no-ri --no-rdoc fpm
+ && gem install --no-ri --no-rdoc --version 1.11.0 fpm
 
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built

--- a/pkg/amazonlinux2016.09/Dockerfile
+++ b/pkg/amazonlinux2016.09/Dockerfile
@@ -103,6 +103,8 @@ RUN mkdir -p "$LIBGIT2TEMP" \
  && make \
  && make install
 
+ENV LC_ALL=C.UTF-8
+
 #pyinstaller requirements start
 #must be preceded by libgit2 install
 COPY pyinstaller-requirements.txt /
@@ -118,7 +120,6 @@ RUN yum install -y ruby ruby-devel rpmbuild rpm-build rubygems gcc make \
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
-ENV LC_ALL=C.UTF-8
 ENV HUBBLE_CHECKOUT=v3.0.14
 ENV HUBBLE_VERSION=3.0.14
 ENV HUBBLE_ITERATION=1

--- a/pkg/centos6/Dockerfile
+++ b/pkg/centos6/Dockerfile
@@ -124,7 +124,7 @@ RUN wget -c https://bootstrap.pypa.io/3.4/get-pip.py \
 
 #fpm package making requirements start
 RUN yum install -y rpmbuild rpm-build gcc make rh-ruby23 rh-ruby23-ruby-devel \
- && scl enable rh-ruby23 "gem install --no-ri --no-rdoc fpm"
+ && scl enable rh-ruby23 "gem install --no-ri --no-rdoc --version 1.11.0 fpm"
  && yum clean all \
  && rm -rf /var/cache/yum
 

--- a/pkg/centos7/Dockerfile
+++ b/pkg/centos7/Dockerfile
@@ -108,7 +108,7 @@ RUN wget -c https://bootstrap.pypa.io/3.4/get-pip.py \
 
 #fpm package making requirements start
 RUN yum install -y ruby ruby-devel rpmbuild rpm-build rubygems gcc make \
- && gem install --no-ri --no-rdoc fpm
+ && gem install --no-ri --no-rdoc --version 1.11.0 fpm
 
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built

--- a/pkg/centos7/Dockerfile
+++ b/pkg/centos7/Dockerfile
@@ -98,7 +98,8 @@ RUN mkdir -p "$LIBGIT2TEMP" \
  && make \
  && make install
 
-ENV LC_ALL=C.UTF-8
+RUN localedef -i en_US -c -f UTF-8 en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
 
 #pyinstaller requirements start
 #must be preceded by libgit2 install

--- a/pkg/centos7/Dockerfile
+++ b/pkg/centos7/Dockerfile
@@ -98,6 +98,8 @@ RUN mkdir -p "$LIBGIT2TEMP" \
  && make \
  && make install
 
+ENV LC_ALL=C.UTF-8
+
 #pyinstaller requirements start
 #must be preceded by libgit2 install
 COPY pyinstaller-requirements.txt /
@@ -113,7 +115,6 @@ RUN yum install -y ruby ruby-devel rpmbuild rpm-build rubygems gcc make \
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
-ENV LC_ALL=C.UTF-8
 ENV HUBBLE_CHECKOUT=v3.0.14
 ENV HUBBLE_VERSION=3.0.14
 ENV HUBBLE_ITERATION=1

--- a/pkg/centos7/Dockerfile
+++ b/pkg/centos7/Dockerfile
@@ -110,8 +110,9 @@ RUN wget -c https://bootstrap.pypa.io/3.4/get-pip.py \
  && pip -v install -r pyinstaller-requirements.txt
 
 #fpm package making requirements start
-RUN yum install -y ruby ruby-devel rpmbuild rpm-build rubygems gcc make \
- && gem install --no-ri --no-rdoc --version 1.11.0 fpm
+RUN yum -y install centos-release-scl
+RUN yum install -y rh-ruby23 rh-ruby23-ruby-devel rpmbuild rpm-build rubygems gcc make libffi libffi-devel
+RUN scl enable rh-ruby23 "gem install --no-ri --no-rdoc --version 1.11.0 fpm"
 
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
@@ -165,7 +166,7 @@ CMD [ "if [ -f /data/hubble_buildinfo ] ; then echo \"\" >> /hubble_build/hubble
 #symlink to have hubble binary in path
     && ln -s /opt/hubble/hubble usr/bin/hubble \
 #fpm start
-    && fpm -s dir -t rpm \
+    && scl enable rh-ruby23 'fpm -s dir -t rpm \
        -n hubblestack \
        -v ${HUBBLE_VERSION} \
        --iteration ${HUBBLE_ITERATION} \
@@ -175,7 +176,7 @@ CMD [ "if [ -f /data/hubble_buildinfo ] ; then echo \"\" >> /hubble_build/hubble
        --after-install /hubble_build/conf/afterinstall-systemd.sh \
        --after-upgrade /hubble_build/conf/afterupgrade-systemd.sh \
        --before-remove /hubble_build/conf/beforeremove.sh \
-       etc/hubble opt usr /var/log/hubble_osquery/backuplogs \
+       etc/hubble opt usr /var/log/hubble_osquery/backuplogs' \
 #edit to change iteration number, if necessary
     && cp hubblestack-${HUBBLE_VERSION}-${HUBBLE_ITERATION}.x86_64.rpm /data/hubblestack-${HUBBLE_VERSION}-${HUBBLE_ITERATION}.el7.x86_64.rpm \
     && openssl dgst -sha256 /data/hubblestack-${HUBBLE_VERSION}-${HUBBLE_ITERATION}.el7.x86_64.rpm \

--- a/pkg/centos8/Dockerfile
+++ b/pkg/centos8/Dockerfile
@@ -103,6 +103,8 @@ RUN mkdir -p "$LIBGIT2TEMP" \
  && make \
  && make install
 
+ENV LC_ALL=C.UTF-8
+
 #pyinstaller requirements start
 #must be preceded by libgit2 install
 COPY pyinstaller-requirements.txt /
@@ -118,7 +120,6 @@ RUN dnf install -y ruby ruby-devel rpm-build rubygems gcc make \
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
-ENV LC_ALL=C.UTF-8
 ENV HUBBLE_CHECKOUT=v3.0.14
 ENV HUBBLE_VERSION=3.0.14
 ENV HUBBLE_ITERATION=1

--- a/pkg/centos8/Dockerfile
+++ b/pkg/centos8/Dockerfile
@@ -113,7 +113,7 @@ RUN wget -c https://bootstrap.pypa.io/3.4/get-pip.py \
 
 #fpm package making requirements start
 RUN dnf install -y ruby ruby-devel rpm-build rubygems gcc make \
- && gem install --no-ri --no-rdoc fpm
+ && gem install --no-ri --no-rdoc --version 1.11.0 fpm
 
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built

--- a/pkg/debian10/Dockerfile
+++ b/pkg/debian10/Dockerfile
@@ -119,6 +119,8 @@ RUN mkdir -p "$LIBGIT2TEMP" \
  && make \
  && make install
 
+ENV LC_ALL=C.UTF-8
+
 #pyinstaller requirements start
 #must be preceded by libgit2 install
 COPY pyinstaller-requirements.txt /
@@ -131,7 +133,6 @@ RUN apt-get install -y ruby ruby-dev rubygems gcc make \
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
-ENV LC_ALL=C.UTF-8
 ENV HUBBLE_CHECKOUT=v3.0.14
 ENV HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
 ENV HUBBLE_VERSION=3.0.14

--- a/pkg/debian10/Dockerfile
+++ b/pkg/debian10/Dockerfile
@@ -126,7 +126,7 @@ RUN pip -v install -r pyinstaller-requirements.txt
 
 #deb package making requirements start
 RUN apt-get install -y ruby ruby-dev rubygems gcc make \
- && gem install --no-ri --no-rdoc fpm
+ && gem install --no-ri --no-rdoc --version 1.11.0 fpm
 
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built

--- a/pkg/debian7/Dockerfile
+++ b/pkg/debian7/Dockerfile
@@ -187,7 +187,6 @@ RUN apt-get install -y ruby ruby-dev rubygems gcc make \
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
-ENV LC_ALL=C.UTF-8
 ENV HUBBLE_CHECKOUT=v3.0.14
 ENV HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
 ENV HUBBLE_VERSION=3.0.14

--- a/pkg/debian7/Dockerfile
+++ b/pkg/debian7/Dockerfile
@@ -55,11 +55,13 @@ RUN mkdir -p "$PATCHELF_TEMP" \
  && make \
  && make install
 
+RUN apt-get install -y build-essential zlib1g-dev libssl-dev libreadline-dev libgdbm-dev \
+    openssl gnupg2 locales python xz-utils sudo curl
+
 #osquery build start
 #osquery should be built first since requirements for other packages can interfere with osquery dependencies
 #to build, osquery scripts want sudo and a user to sudo with.
 ENV OSQUERY_BUILD_USER=osquerybuilder
-RUN apt-get -y install git make python ruby sudo locales curl
 RUN useradd --shell /bin/bash --create-home --user-group --groups sudo "$OSQUERY_BUILD_USER" \
  && sed -i 's/^%sudo.*/%sudo\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
 COPY --from=osquery /osquery /home/"$OSQUERY_BUILD_USER"/osquery
@@ -173,16 +175,21 @@ RUN mkdir -p "$LIBGIT2TEMP" \
  && make \
  && make install
 
+# we seem to need a modern-ish ruby>=2.3
+RUN curl -sSL https://rvm.io/mpapis.asc | gpg2 --import - \
+ && curl -sSL https://rvm.io/pkuczynski.asc | gpg2 --import - \
+ && curl -sSL https://get.rvm.io | bash -s stable
+RUN bash -c 'source /etc/profile.d/rvm.sh; rvm install 2.7'
+RUN bash -c 'source /etc/profile.d/rvm.sh; which ruby'
+ENV PATH=$PATH:/usr/local/rvm/rubies/ruby-2.7.2/bin
+RUN gem install --no-document --version 1.11.0 fpm
+
 #pyinstaller requirements start
 #must be preceded by libgit2 install
 COPY pyinstaller-requirements.txt /
 RUN wget -c https://bootstrap.pypa.io/3.4/get-pip.py \
  && python get-pip.py pip==20.2 \
  && pip -v install -r pyinstaller-requirements.txt
-
-#deb package making requirements start
-RUN apt-get install -y ruby ruby-dev rubygems gcc make \
- && gem install --no-ri --no-rdoc --version 1.11.0 fpm
 
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built

--- a/pkg/debian7/Dockerfile
+++ b/pkg/debian7/Dockerfile
@@ -182,7 +182,7 @@ RUN wget -c https://bootstrap.pypa.io/3.4/get-pip.py \
 
 #deb package making requirements start
 RUN apt-get install -y ruby ruby-dev rubygems gcc make \
- && gem install --no-ri --no-rdoc fpm
+ && gem install --no-ri --no-rdoc --version 1.11.0 fpm
 
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built

--- a/pkg/debian8/Dockerfile
+++ b/pkg/debian8/Dockerfile
@@ -129,7 +129,7 @@ RUN wget -c https://bootstrap.pypa.io/3.4/get-pip.py \
 
 #deb package making requirements start
 RUN apt-get install -y ruby ruby-dev rubygems gcc make \
- && gem install --no-ri --no-rdoc fpm
+ && gem install --no-ri --no-rdoc --version 1.11.0 fpm
 
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built

--- a/pkg/debian8/Dockerfile
+++ b/pkg/debian8/Dockerfile
@@ -36,6 +36,9 @@ RUN mkdir -p "$PATCHELF_TEMP" \
  && make \
  && make install
 
+RUN apt-get install -y build-essential zlib1g-dev libssl-dev libreadline-dev libgdbm-dev \
+    openssl gnupg2 locales python xz-utils sudo curl
+
 #osquery build start
 #osquery should be built first since requirements for other packages can interfere with osquery dependencies
 #to build, osquery scripts want sudo and a user to sudo with.
@@ -47,7 +50,6 @@ COPY osquery /osquery
 ENV OSQUERY_TAR_FILENAME=$OSQUERY_SRC_VERSION"_debian8.tar"
 COPY $OSQUERY_TAR_FILENAME /$OSQUERY_TAR_FILENAME
 
-RUN apt-get -y install git make python ruby sudo locales curl xz-utils
 RUN useradd --shell /bin/bash --create-home --user-group --groups sudo "$OSQUERY_BUILD_USER" \
  && sed -i 's/^%sudo.*/%sudo\ ALL=\(ALL\)\ NOPASSWD:\ ALL/' /etc/sudoers
 ADD osquerybuilder.sh /osquerybuilder.sh
@@ -119,6 +121,15 @@ RUN mkdir -p "$LIBGIT2TEMP" \
  && make \
  && make install
 
+# we seem to need a modern-ish ruby>=2.3
+RUN curl -sSL https://rvm.io/mpapis.asc | gpg2 --import - \
+ && curl -sSL https://rvm.io/pkuczynski.asc | gpg2 --import - \
+ && curl -sSL https://get.rvm.io | bash -s stable
+RUN bash -c 'source /etc/profile.d/rvm.sh; rvm install 2.7'
+RUN bash -c 'source /etc/profile.d/rvm.sh; which ruby'
+ENV PATH=$PATH:/usr/local/rvm/rubies/ruby-2.7.2/bin
+RUN gem install --no-document --version 1.11.0 fpm
+
 ENV LC_ALL=C.UTF-8
 
 #pyinstaller requirements start
@@ -128,10 +139,6 @@ COPY pyinstaller-requirements.txt /
 RUN wget -c https://bootstrap.pypa.io/3.4/get-pip.py \
  && python get-pip.py pip==20.2 \
  && pip -v install -r pyinstaller-requirements.txt
-
-#deb package making requirements start
-RUN apt-get install -y ruby ruby-dev rubygems gcc make \
- && gem install --no-ri --no-rdoc --version 1.11.0 fpm
 
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built

--- a/pkg/debian8/Dockerfile
+++ b/pkg/debian8/Dockerfile
@@ -119,6 +119,8 @@ RUN mkdir -p "$LIBGIT2TEMP" \
  && make \
  && make install
 
+ENV LC_ALL=C.UTF-8
+
 #pyinstaller requirements start
 #must be preceded by libgit2 install
 COPY pyinstaller-requirements.txt /
@@ -134,7 +136,6 @@ RUN apt-get install -y ruby ruby-dev rubygems gcc make \
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
-ENV LC_ALL=C.UTF-8
 ENV HUBBLE_CHECKOUT=v3.0.14
 ENV HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
 ENV HUBBLE_VERSION=3.0.14

--- a/pkg/debian9/Dockerfile
+++ b/pkg/debian9/Dockerfile
@@ -119,6 +119,8 @@ RUN mkdir -p "$LIBGIT2TEMP" \
  && make \
  && make install
 
+ENV LC_ALL=C.UTF-8
+
 #pyinstaller requirements start
 #must be preceded by libgit2 install
 COPY pyinstaller-requirements.txt /
@@ -131,7 +133,6 @@ RUN apt-get install -y ruby ruby-dev rubygems gcc make \
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
-ENV LC_ALL=C.UTF-8
 ENV HUBBLE_CHECKOUT=v3.0.14
 ENV HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
 ENV HUBBLE_VERSION=3.0.14

--- a/pkg/debian9/Dockerfile
+++ b/pkg/debian9/Dockerfile
@@ -126,7 +126,7 @@ RUN pip -v install -r pyinstaller-requirements.txt
 
 #deb package making requirements start
 RUN apt-get install -y ruby ruby-dev rubygems gcc make \
- && gem install --no-ri --no-rdoc fpm
+ && gem install --no-ri --no-rdoc --version 1.11.0 fpm
 
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built

--- a/pkg/dev/amazonlinux2016.09/Dockerfile
+++ b/pkg/dev/amazonlinux2016.09/Dockerfile
@@ -113,7 +113,7 @@ RUN wget -c https://bootstrap.pypa.io/3.4/get-pip.py \
 
 #fpm package making requirements start
 RUN yum install -y ruby ruby-devel rpmbuild rpm-build rubygems gcc make \
- && gem install --no-ri --no-rdoc fpm
+ && gem install --no-ri --no-rdoc --version 1.11.0 fpm
 
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built

--- a/pkg/dev/amazonlinux2016.09/Dockerfile
+++ b/pkg/dev/amazonlinux2016.09/Dockerfile
@@ -103,6 +103,8 @@ RUN mkdir -p "$LIBGIT2TEMP" \
  && make \
  && make install
 
+ENV LC_ALL=C.UTF-8
+
 #pyinstaller requirements start
 #must be preceded by libgit2 install
 COPY pyinstaller-requirements.txt /
@@ -118,7 +120,6 @@ RUN yum install -y ruby ruby-devel rpmbuild rpm-build rubygems gcc make \
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
-ENV LC_ALL=C.UTF-8
 ENV HUBBLE_CHECKOUT=v3.0.14
 ENV HUBBLE_VERSION=3.0.14
 ENV HUBBLE_ITERATION=1

--- a/pkg/dev/centos6/Dockerfile
+++ b/pkg/dev/centos6/Dockerfile
@@ -116,7 +116,7 @@ RUN wget -c https://bootstrap.pypa.io/3.4/get-pip.py \
 
 #fpm package making requirements start
 RUN yum install -y rpmbuild rpm-build gcc make rh-ruby23 rh-ruby23-ruby-devel \
- && scl enable rh-ruby23 "gem install --no-ri --no-rdoc fpm"
+ && scl enable rh-ruby23 "gem install --no-ri --no-rdoc --version 1.11.0 fpm"
 
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built

--- a/pkg/dev/centos6/Dockerfile
+++ b/pkg/dev/centos6/Dockerfile
@@ -15,7 +15,13 @@
 #--------------- ACTUAL DOCKERFILE FOR BUILD CREATION  --------------------------
 FROM centos:6
 
-RUN yum makecache fast && yum -y update
+COPY centos-vault.repo /etc/yum.repos.d/CentOS-Base.repo
+COPY centos-sclo.pub /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
+
+RUN yum makecache fast \
+ && yum -y update
+ && yum clean all \
+ && rm -rf /var/cache/yum
 
 #paths that hubble or hubble parts need in the package
 RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osquery/backuplogs 
@@ -110,13 +116,17 @@ COPY pyinstaller-requirements.txt /
 RUN wget -c https://bootstrap.pypa.io/3.4/get-pip.py \
  && yum -y install centos-release-scl \
  && yum -y install python27 \
+ && yum clean all \
+ && rm -rf /var/cache/yum
  && chmod u+x ./get-pip.py \
- && scl enable python27 "./get-pip.py" \
+ && scl enable python27 "./get-pip.py pip==20.2" \
  && scl enable python27 "pip -v install -r pyinstaller-requirements.txt"
 
 #fpm package making requirements start
 RUN yum install -y rpmbuild rpm-build gcc make rh-ruby23 rh-ruby23-ruby-devel \
  && scl enable rh-ruby23 "gem install --no-ri --no-rdoc --version 1.11.0 fpm"
+ && yum clean all \
+ && rm -rf /var/cache/yum
 
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built

--- a/pkg/dev/centos7/Dockerfile
+++ b/pkg/dev/centos7/Dockerfile
@@ -108,7 +108,7 @@ RUN wget -c https://bootstrap.pypa.io/3.4/get-pip.py \
 
 #fpm package making requirements start
 RUN yum install -y ruby ruby-devel rpmbuild rpm-build rubygems gcc make \
- && gem install --no-ri --no-rdoc fpm
+ && gem install --no-ri --no-rdoc --version 1.11.0 fpm
 
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built

--- a/pkg/dev/centos7/Dockerfile
+++ b/pkg/dev/centos7/Dockerfile
@@ -98,7 +98,8 @@ RUN mkdir -p "$LIBGIT2TEMP" \
  && make \
  && make install
 
-ENV LC_ALL=C.UTF-8
+RUN localedef -i en_US -c -f UTF-8 en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
 
 #pyinstaller requirements start
 #must be preceded by libgit2 install

--- a/pkg/dev/centos7/Dockerfile
+++ b/pkg/dev/centos7/Dockerfile
@@ -98,6 +98,8 @@ RUN mkdir -p "$LIBGIT2TEMP" \
  && make \
  && make install
 
+ENV LC_ALL=C.UTF-8
+
 #pyinstaller requirements start
 #must be preceded by libgit2 install
 COPY pyinstaller-requirements.txt /
@@ -113,7 +115,6 @@ RUN yum install -y ruby ruby-devel rpmbuild rpm-build rubygems gcc make \
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
-ENV LC_ALL=C.UTF-8
 ENV HUBBLE_CHECKOUT=v3.0.14
 ENV HUBBLE_VERSION=3.0.14
 ENV HUBBLE_ITERATION=1

--- a/pkg/dev/centos7/Dockerfile
+++ b/pkg/dev/centos7/Dockerfile
@@ -110,8 +110,9 @@ RUN wget -c https://bootstrap.pypa.io/3.4/get-pip.py \
  && pip -v install -r pyinstaller-requirements.txt
 
 #fpm package making requirements start
-RUN yum install -y ruby ruby-devel rpmbuild rpm-build rubygems gcc make \
- && gem install --no-ri --no-rdoc --version 1.11.0 fpm
+RUN yum -y install centos-release-scl
+RUN yum install -y rh-ruby23 rh-ruby23-ruby-devel rpmbuild rpm-build rubygems gcc make libffi libffi-devel
+RUN scl enable rh-ruby23 "gem install --no-ri --no-rdoc --version 1.11.0 fpm"
 
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
@@ -165,7 +166,7 @@ CMD [ "if [ -f /data/hubble_buildinfo ] ; then echo \"\" >> /hubble_build/hubble
 #symlink to have hubble binary in path
     && ln -s /opt/hubble/hubble usr/bin/hubble \
 #fpm start
-    && fpm -s dir -t rpm \
+    && scl enable rh-ruby23 'fpm -s dir -t rpm \
        -n hubblestack \
        -v ${HUBBLE_VERSION} \
        --iteration ${HUBBLE_ITERATION} \
@@ -175,7 +176,7 @@ CMD [ "if [ -f /data/hubble_buildinfo ] ; then echo \"\" >> /hubble_build/hubble
        --after-install /hubble_build/conf/afterinstall-systemd.sh \
        --after-upgrade /hubble_build/conf/afterupgrade-systemd.sh \
        --before-remove /hubble_build/conf/beforeremove.sh \
-       etc/hubble opt usr /var/log/hubble_osquery/backuplogs \
+       etc/hubble opt usr /var/log/hubble_osquery/backuplogs' \
 #edit to change iteration number, if necessary
     && cp hubblestack-${HUBBLE_VERSION}-${HUBBLE_ITERATION}.x86_64.rpm /data/hubblestack-${HUBBLE_VERSION}-${HUBBLE_ITERATION}.el7.x86_64.rpm \
     && openssl dgst -sha256 /data/hubblestack-${HUBBLE_VERSION}-${HUBBLE_ITERATION}.el7.x86_64.rpm \

--- a/pkg/dev/centos8/Dockerfile
+++ b/pkg/dev/centos8/Dockerfile
@@ -113,7 +113,7 @@ RUN wget -c https://bootstrap.pypa.io/3.4/get-pip.py \
 
 #fpm package making requirements start
 RUN dnf install -y ruby ruby-devel rpm-build rubygems gcc make \
- && gem install --no-ri --no-rdoc fpm
+ && gem install --no-ri --no-rdoc --version 1.11.0 fpm
 
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built

--- a/pkg/dev/centos8/Dockerfile
+++ b/pkg/dev/centos8/Dockerfile
@@ -24,7 +24,7 @@ RUN mkdir -p /etc/hubble/hubble.d /opt/hubble /opt/osquery /var/log/hubble_osque
 #to build, osquery scripts want sudo and a user to sudo with.
 ENV OSQUERY_BUILD_USER=osquerybuilder
 RUN dnf -y install dnf-plugins-core \
- && dnf config-manager --set-enabled PowerTools \
+ && dnf config-manager --set-enabled powertools \
  && dnf -y install python2 git make ruby sudo which doxygen \
  && ln -svf /usr/bin/python2 /usr/bin/python
 ENV OSQUERY_BUILD_USER=osquerybuilder
@@ -103,6 +103,8 @@ RUN mkdir -p "$LIBGIT2TEMP" \
  && make \
  && make install
 
+ENV LC_ALL=C.UTF-8
+
 #pyinstaller requirements start
 #must be preceded by libgit2 install
 COPY pyinstaller-requirements.txt /
@@ -118,7 +120,6 @@ RUN dnf install -y ruby ruby-devel rpm-build rubygems gcc make \
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
-ENV LC_ALL=C.UTF-8
 ENV HUBBLE_CHECKOUT=v3.0.14
 ENV HUBBLE_VERSION=3.0.14
 ENV HUBBLE_ITERATION=1

--- a/pkg/dev/debian10/Dockerfile
+++ b/pkg/dev/debian10/Dockerfile
@@ -119,6 +119,8 @@ RUN mkdir -p "$LIBGIT2TEMP" \
  && make \
  && make install
 
+ENV LC_ALL=C.UTF-8
+
 #pyinstaller requirements start
 #must be preceded by libgit2 install
 COPY pyinstaller-requirements.txt /
@@ -131,7 +133,6 @@ RUN apt-get install -y ruby ruby-dev rubygems gcc make \
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
-ENV LC_ALL=C.UTF-8
 ENV HUBBLE_CHECKOUT=v3.0.14
 ENV HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
 ENV HUBBLE_VERSION=3.0.14

--- a/pkg/dev/debian10/Dockerfile
+++ b/pkg/dev/debian10/Dockerfile
@@ -126,7 +126,7 @@ RUN pip -v install -r pyinstaller-requirements.txt
 
 #deb package making requirements start
 RUN apt-get install -y ruby ruby-dev rubygems gcc make \
- && gem install --no-ri --no-rdoc fpm
+ && gem install --no-ri --no-rdoc --version 1.11.0 fpm
 
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built

--- a/pkg/dev/debian7/Dockerfile
+++ b/pkg/dev/debian7/Dockerfile
@@ -187,7 +187,6 @@ RUN apt-get install -y ruby ruby-dev rubygems gcc make \
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
-ENV LC_ALL=C.UTF-8
 ENV HUBBLE_CHECKOUT=v3.0.14
 ENV HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
 ENV HUBBLE_VERSION=3.0.14

--- a/pkg/dev/debian7/Dockerfile
+++ b/pkg/dev/debian7/Dockerfile
@@ -182,7 +182,7 @@ RUN wget -c https://bootstrap.pypa.io/3.4/get-pip.py \
 
 #deb package making requirements start
 RUN apt-get install -y ruby ruby-dev rubygems gcc make \
- && gem install --no-ri --no-rdoc fpm
+ && gem install --no-ri --no-rdoc --version 1.11.0 fpm
 
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built

--- a/pkg/dev/debian8/Dockerfile
+++ b/pkg/dev/debian8/Dockerfile
@@ -129,7 +129,7 @@ RUN wget -c https://bootstrap.pypa.io/3.4/get-pip.py \
 
 #deb package making requirements start
 RUN apt-get install -y ruby ruby-dev rubygems gcc make \
- && gem install --no-ri --no-rdoc fpm
+ && gem install --no-ri --no-rdoc --version 1.11.0 fpm
 
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built

--- a/pkg/dev/debian8/Dockerfile
+++ b/pkg/dev/debian8/Dockerfile
@@ -119,6 +119,8 @@ RUN mkdir -p "$LIBGIT2TEMP" \
  && make \
  && make install
 
+ENV LC_ALL=C.UTF-8
+
 #pyinstaller requirements start
 #must be preceded by libgit2 install
 COPY pyinstaller-requirements.txt /
@@ -134,7 +136,6 @@ RUN apt-get install -y ruby ruby-dev rubygems gcc make \
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
-ENV LC_ALL=C.UTF-8
 ENV HUBBLE_CHECKOUT=v3.0.14
 ENV HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
 ENV HUBBLE_VERSION=3.0.14

--- a/pkg/dev/debian9/Dockerfile
+++ b/pkg/dev/debian9/Dockerfile
@@ -119,6 +119,8 @@ RUN mkdir -p "$LIBGIT2TEMP" \
  && make \
  && make install
 
+ENV LC_ALL=C.UTF-8
+
 #pyinstaller requirements start
 #must be preceded by libgit2 install
 COPY pyinstaller-requirements.txt /
@@ -131,7 +133,6 @@ RUN apt-get install -y ruby ruby-dev rubygems gcc make \
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built
 #use the following variables to choose the version of hubble
-ENV LC_ALL=C.UTF-8
 ENV HUBBLE_CHECKOUT=v3.0.14
 ENV HUBBLE_GIT_URL=https://github.com/hubblestack/hubble.git
 ENV HUBBLE_VERSION=3.0.14

--- a/pkg/dev/debian9/Dockerfile
+++ b/pkg/dev/debian9/Dockerfile
@@ -126,7 +126,7 @@ RUN pip -v install -r pyinstaller-requirements.txt
 
 #deb package making requirements start
 RUN apt-get install -y ruby ruby-dev rubygems gcc make \
- && gem install --no-ri --no-rdoc fpm
+ && gem install --no-ri --no-rdoc --version 1.11.0 fpm
 
 #pyinstaller start
 #commands specified for ENTRYPOINT and CMD are executed when the container is run, not when the image is built


### PR DESCRIPTION
* the most modern fpm won't install anywhere freeze at 1.11.0
* even at 1.11.0, ruby < 2.3 gets pretty miffed about linking to ffi in fpm; upgrade ruby on some platforms
* some of the packages get really angry about ascii locales (C, and Python both); try to use C.UTF-8 where possible, or give up and use en_US.UTF-8 (in one case)