### PR TITLE
Manifest and signature filenames can be provided in config

### DIFF
--- a/hubblestack/modules/signing.py
+++ b/hubblestack/modules/signing.py
@@ -22,8 +22,8 @@ def msign(*targets, **kw):
         private_key :- the private key to use for the signature (default
             /etc/hubble/sign/private.key)
     """
-    mfname = kw.get('mfname', 'MANIFEST')
-    sfname = kw.get('sfname', 'SIGNATURE')
+    mfname = kw.get('mfname', HuS.Options.manifest_file_name)
+    sfname = kw.get('sfname', HuS.Options.signature_file_name)
     private_key = kw.get('private_key', HuS.Options.private_key)
 
     HuS.manifest(targets, mfname=mfname)
@@ -46,8 +46,8 @@ def verify(*targets, **kw):
                   found.
     """
 
-    mfname = kw.get('mfname', 'MANIFEST')
-    sfname = kw.get('sfname', 'SIGNATURE')
+    mfname = kw.get('mfname', HuS.Options.manifest_file_name)
+    sfname = kw.get('sfname', HuS.Options.signature_file_name)
     cfname = kw.get('cfname', 'CERTIFICATES')
     public_crt = kw.get('public_crt', HuS.Options.public_crt)
     ca_crt = kw.get('ca_crt', HuS.Options.ca_crt)

--- a/hubblestack/utils/signing.py
+++ b/hubblestack/utils/signing.py
@@ -144,6 +144,8 @@ class Options(object):
         ca_crt = '/etc/hubble/sign/ca-root.crt'
         public_crt = '/etc/hubble/sign/public.crt'
         private_key = '/etc/hubble/sign/private.key'
+        manifest_file_name = 'MANIFEST'
+        signature_file_name = 'SIGNATURE'
 
     def __getattribute__(self, name):
         """ If the option exists in the default pseudo meta class
@@ -705,8 +707,10 @@ def find_wrapf(not_found={'path': '', 'rel': ''}, real_path='path'):
             return fnd.get(real_path, fnd.get('path', ''))
 
         def inner(path, saltenv, *a, **kwargs):
-            f_mani = find_file_f('MANIFEST', saltenv, *a, **kwargs )
-            f_sign = find_file_f('SIGNATURE', saltenv, *a, **kwargs )
+            manifest_file_name = Options.manifest_file_name
+            signature_file_name = Options.signature_file_name
+            f_mani = find_file_f(manifest_file_name, saltenv, *a, **kwargs )
+            f_sign = find_file_f(signature_file_name, saltenv, *a, **kwargs )
             f_pub_cert = find_file_f('CERTIFICATES', saltenv, *a, **kwargs)
             f_path = find_file_f(path, saltenv, *a, **kwargs)
             real_path = _p(f_path)


### PR DESCRIPTION
Example 
```
repo_signing:
  require_verify: true
  manifest_file_name: 'MANIFEST_v2'
  signature_file_name: 'SIGNATURE_v2'
```