### PR TITLE
add setting to allow specifying salt-padding-bits in RSA

### DIFF
--- a/hubblestack/modules/nebula_osquery.py
+++ b/hubblestack/modules/nebula_osquery.py
@@ -1148,8 +1148,8 @@ def _dict_update(dest, upd, recursive_update=True, merge_lists=False):
     This behavior is only activated when recursive_update=True. By default
     merge_lists=False.
     """
-    if (not isinstance(dest, collections.Mapping)) \
-            or (not isinstance(upd, collections.Mapping)):
+    if (not isinstance(dest, collections.abc.Mapping)) \
+            or (not isinstance(upd, collections.abc.Mapping)):
         raise TypeError('Cannot update using non-dict types in dictupdate.update()')
     updkeys = list(upd.keys())
     if not set(list(dest.keys())) & set(updkeys):
@@ -1161,8 +1161,8 @@ def _dict_update(dest, upd, recursive_update=True, merge_lists=False):
                 dest_subkey = dest.get(key, None)
             except AttributeError:
                 dest_subkey = None
-            if isinstance(dest_subkey, collections.Mapping) \
-                    and isinstance(val, collections.Mapping):
+            if isinstance(dest_subkey, collections.abc.Mapping) \
+                    and isinstance(val, collections.abc.Mapping):
                 ret = _dict_update(dest_subkey, val, merge_lists=merge_lists)
                 dest[key] = ret
             elif isinstance(dest_subkey, list) \

--- a/hubblestack/modules/pulsar.py
+++ b/hubblestack/modules/pulsar.py
@@ -972,8 +972,8 @@ def _dict_update(dest, upd, recursive_update=True, merge_lists=False):
     This behavior is only activated when recursive_update=True. By default
     merge_lists=False.
     """
-    if (not isinstance(dest, collections.Mapping)) \
-            or (not isinstance(upd, collections.Mapping)):
+    if (not isinstance(dest, collections.abc.Mapping)) \
+            or (not isinstance(upd, collections.abc.Mapping)):
         raise TypeError('Cannot update using non-dict types in dictupdate.update()')
     updkeys = list(upd.keys())
     if not set(list(dest.keys())) & set(updkeys):
@@ -985,8 +985,8 @@ def _dict_update(dest, upd, recursive_update=True, merge_lists=False):
                 dest_subkey = dest.get(key, None)
             except AttributeError:
                 dest_subkey = None
-            if isinstance(dest_subkey, collections.Mapping) \
-                    and isinstance(val, collections.Mapping):
+            if isinstance(dest_subkey, collections.abc.Mapping) \
+                    and isinstance(val, collections.abc.Mapping):
                 ret = _dict_update(dest_subkey, val, merge_lists=merge_lists)
                 dest[key] = ret
             elif isinstance(dest_subkey, list) \

--- a/hubblestack/modules/signing.py
+++ b/hubblestack/modules/signing.py
@@ -48,7 +48,7 @@ def verify(*targets, **kw):
 
     mfname = kw.get('mfname', HuS.Options.manifest_file_name)
     sfname = kw.get('sfname', HuS.Options.signature_file_name)
-    cfname = kw.get('cfname', 'CERTIFICATES')
+    cfname = kw.get('cfname', HuS.Options.certificates_file_name)
     public_crt = kw.get('public_crt', HuS.Options.public_crt)
     ca_crt = kw.get('ca_crt', HuS.Options.ca_crt)
     pwd = os.path.abspath(os.path.curdir)

--- a/hubblestack/modules/win_pulsar.py
+++ b/hubblestack/modules/win_pulsar.py
@@ -446,8 +446,8 @@ def _dict_update(dest, upd, recursive_update=True, merge_lists=False):
     This behavior is only activated when recursive_update=True. By default
     merge_lists=False.
     """
-    if (not isinstance(dest, collections.Mapping)) \
-            or (not isinstance(upd, collections.Mapping)):
+    if (not isinstance(dest, collections.abc.Mapping)) \
+            or (not isinstance(upd, collections.abc.Mapping)):
         raise TypeError('Cannot update using non-dict types in dictupdate.update()')
     updkeys = list(upd.keys())
     if not set(list(dest.keys())) & set(updkeys):
@@ -459,8 +459,8 @@ def _dict_update(dest, upd, recursive_update=True, merge_lists=False):
                 dest_subkey = dest.get(key, None)
             except AttributeError:
                 dest_subkey = None
-            if isinstance(dest_subkey, collections.Mapping) \
-                    and isinstance(val, collections.Mapping):
+            if isinstance(dest_subkey, collections.abc.Mapping) \
+                    and isinstance(val, collections.abc.Mapping):
                 ret = _dict_update(dest_subkey, val, merge_lists=merge_lists)
                 dest[key] = ret
             elif isinstance(dest_subkey, list) \

--- a/hubblestack/modules/win_pulsar_winaudit.py
+++ b/hubblestack/modules/win_pulsar_winaudit.py
@@ -603,8 +603,8 @@ def _dict_update(dest, upd, recursive_update=True, merge_lists=False):
     This behavior is only activated when recursive_update=True. By default
     merge_lists=False.
     """
-    if (not isinstance(dest, collections.Mapping)) \
-            or (not isinstance(upd, collections.Mapping)):
+    if (not isinstance(dest, collections.abc.Mapping)) \
+            or (not isinstance(upd, collections.abc.Mapping)):
         raise TypeError('Cannot update using non-dict types in dictupdate.update()')
     updkeys = list(upd.keys())
     if not set(list(dest.keys())) & set(updkeys):
@@ -616,8 +616,8 @@ def _dict_update(dest, upd, recursive_update=True, merge_lists=False):
                 dest_subkey = dest.get(key, None)
             except AttributeError:
                 dest_subkey = None
-            if isinstance(dest_subkey, collections.Mapping) \
-                    and isinstance(val, collections.Mapping):
+            if isinstance(dest_subkey, collections.abc.Mapping) \
+                    and isinstance(val, collections.abc.Mapping):
                 ret = _dict_update(dest_subkey, val, merge_lists=merge_lists)
                 dest[key] = ret
             elif isinstance(dest_subkey, list) \

--- a/hubblestack/utils/path.py
+++ b/hubblestack/utils/path.py
@@ -94,7 +94,7 @@ def which_bin(exes):
     '''
     Scan over some possible executables and return the first one that is found
     '''
-    if not isinstance(exes, collections.Iterable):
+    if not isinstance(exes, collections.abc.Iterable):
         return None
     for exe in exes:
         path = which(exe)

--- a/hubblestack/utils/signing.py
+++ b/hubblestack/utils/signing.py
@@ -559,9 +559,10 @@ def verify_signature(fname, sfname, public_crt=None, ca_crt=None, extra_crt=None
     log_level = log.debug
     if fname is None or sfname is None:
         status = STATUS.UNKNOWN
-        log_level('fname=%s or sfname=%s is Nones => status=%s', fname, sfname, status)
+        log_level('fname=%s or sfname=%s is None => status=%s', fname, sfname, status)
         return status
     short_fname = fname.split('/')[-1]
+
     try:
         with open(sfname, 'r') as fh:
             sig,_,_ = PEM.decode(fh.read()) # also returns header and decrypted-status

--- a/hubblestack/utils/signing.py
+++ b/hubblestack/utils/signing.py
@@ -89,7 +89,7 @@ def _format_padding_bits(x):
 
 def _format_padding_bits_txt(x):
     if isinstance(x, (tuple,list)):
-        return "/".join([ _format_padding_bits(y) for y in x ])
+        return "/".join([ _format_padding_bits_txt(y) for y in x ])
     if x is padding.PSS.MAX_LENGTH:
         return "max"
     return str(x)
@@ -590,10 +590,11 @@ def verify_signature(fname, sfname, public_crt=None, ca_crt=None, extra_crt=None
     if not isinstance(salt_padding_bits_list, (list,tuple)):
         salt_padding_bits_list = [ salt_padding_bits_list ]
 
+    sha256sum = hash_target(fname)
+
     for crt,txt,status in x509.public_crt:
         args = { 'signature': sig, 'data': digest }
         log_level = log.debug
-        sha256sum = hash_target(fname)
         pubkey = crt.get_pubkey().to_cryptography_key()
         for salt_padding_bits in salt_padding_bits_list:
             salt_padding_bits = _format_padding_bits(salt_padding_bits)
@@ -615,8 +616,8 @@ def verify_signature(fname, sfname, public_crt=None, ca_crt=None, extra_crt=None
                     log_level = log.critical
                 log_level('verify_signature(%s, %s) | sbp: %s | status: %s | sha256sum: "%s" | (2) public cert fingerprint and requester: "%s"',
                         fname, sfname, _format_padding_bits_txt(salt_padding_bits), status, sha256sum, txt)
-    log_level('verify_signature(%s, %s) | sbp: %s | status: FAIL | sha256sum: "%s" | (3) public cert fingerprint and requester: "%s"',
-            fname, sfname, _format_padding_bits_txt(salt_padding_bits), STATUS.FAIL, sha256sum, txt)
+    log_level('verify_signature(%s, %s) | sbp: %s | status: %s | sha256sum: "%s" | (3)',
+            fname, sfname, _format_padding_bits_txt(salt_padding_bits_list), STATUS.FAIL, sha256sum)
     return STATUS.FAIL
 
 

--- a/hubblestack/utils/signing.py
+++ b/hubblestack/utils/signing.py
@@ -197,13 +197,13 @@ def split_certs(fh):
             ret += line
             if line.startswith('----'):
                 ret = ret.encode()
+                log_level = log.debug
                 try:
-                    log_level = log.debug
                     yield ossl.load_certificate(ossl.FILETYPE_PEM, ret)
                 except Exception as exception_object:
                     status = STATUS.UNKNOWN
                     if check_verif_timestamp(fh):
-                        log_level = log.error
+                        log_level = log.warning
                     log_level('%s: | file: "%s" | cert decoding status: %s | attempting as PEM encoded private key',
                             short_fname, fh.name, status)
                     yield load_pem_private_key(ret, password=None, backend=default_backend())

--- a/hubblestack/utils/timed_subprocess.py
+++ b/hubblestack/utils/timed_subprocess.py
@@ -90,12 +90,12 @@ class TimedProc(object):
             rt = threading.Thread(target=receive)
             rt.start()
             rt.join(self.timeout)
-            if rt.isAlive():
+            if rt.is_alive():
                 # Subprocess cleanup (best effort)
                 self.process.kill()
 
                 def terminate():
-                    if rt.isAlive():
+                    if rt.is_alive():
                         self.process.terminate()
                 threading.Timer(10, terminate).start()
                 raise hubblestack.exceptions.TimedProcTimeoutError(

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ chardet
 croniter
 cryptography
 daemon
+distro
 futures
 gitdb2
 gitpython

--- a/tests/unittests/test_repo_signing.py
+++ b/tests/unittests/test_repo_signing.py
@@ -378,6 +378,27 @@ def test_msign_and_verify_signature(__mods__, targets, no_ppc, cdbt):
 
     assert res == sig.STATUS.FAIL
 
+def test_various_padding_bits(__mods__, targets, no_ppc, cdbt):
+    sig.Options.ca_crt = (cdb('ca-root.crt', cdbt, 1), cdb('bundle.pem', cdbt, 1))
+
+    sig.Options.public_crt  = cdb('public-1.crt', cdbt, 1)
+    sig.Options.private_key = cdb('private-1.key', cdbt, 1)
+
+    sig.Options.salt_padding_bits = 32
+    __mods__['signing.msign'](*targets)
+    res = sig.verify_signature('MANIFEST', 'SIGNATURE',
+        public_crt=sig.Options.public_crt, ca_crt=sig.Options.ca_crt)
+
+    assert res == sig.STATUS.VERIFIED
+
+    sig.Options.salt_padding_bits = 'max'
+    __mods__['signing.msign'](*targets)
+    res = sig.verify_signature('MANIFEST', 'SIGNATURE',
+        public_crt=sig.Options.public_crt, ca_crt=sig.Options.ca_crt)
+
+    assert res == sig.STATUS.VERIFIED
+
+
 
 def test_like_a_daemon_with_bundle(__mods__, no_ppc, cdbt):
     sig.Options.ca_crt = (cdb('ca-root.crt', cdbt, 1), cdb('bundle.pem', cdbt, 1))

--- a/tests/unittests/test_repo_signing.py
+++ b/tests/unittests/test_repo_signing.py
@@ -408,11 +408,18 @@ def test_various_padding_bits(__mods__, targets, no_ppc, cdbt):
         public_crt=sig.Options.public_crt, ca_crt=sig.Options.ca_crt)
     assert res == sig.STATUS.VERIFIED
 
-    # stick with the 'max'-salt-padding-bits and re-check, should fail
+    # The padding thing really only applies to RSA.
+    # So, for the below expected failures, it's only when cdbt is 'rsa'.
+    expected = sig.STATUS.FAIL if cdbt == 'rsa' else sig.STATUS.VERIFIED
+
+    # sign with max-bit-salt-padding
+    sig.Options.salt_padding_bits = 'max'
+    __mods__['signing.msign'](*targets)
+    # check with 32bit only
     sig.Options.salt_padding_bits = 32
     res = sig.verify_signature('MANIFEST', 'SIGNATURE',
         public_crt=sig.Options.public_crt, ca_crt=sig.Options.ca_crt)
-    assert res == sig.STATUS.FAIL
+    assert res == expected
 
     # re-sign with 32 bit salt padding bits
     sig.Options.salt_padding_bits = 32
@@ -421,8 +428,7 @@ def test_various_padding_bits(__mods__, targets, no_ppc, cdbt):
     sig.Options.salt_padding_bits = 'max'
     res = sig.verify_signature('MANIFEST', 'SIGNATURE',
         public_crt=sig.Options.public_crt, ca_crt=sig.Options.ca_crt)
-    assert res == sig.STATUS.FAIL
-
+    assert res == expected
 
 
 def test_like_a_daemon_with_bundle(__mods__, no_ppc, cdbt):


### PR DESCRIPTION
* finish the thought in [#1029] and allow mfname and sfname to be fully configurable
* add an option allowing RSA salt-padding-bits to be configurable. The default is ('max', 32); meaning try 'max' (aka padding.PSS.MAX_LENGTH) first, and 32 bits as a fallback. Specifying `repo_signing: { salt_padding_bits: 'max' }` will disable the fallback
* add appropriate tests to make sure signing with 32 under (max, 32) and (32, max) works, that signing with 'max' under (max, 32) and (32, max) work; 
* and that 32-sign/check-max doesn't work and finally that signing max and checking 32 doesn't work.
* oh, and one final note that: this is only applicable under RSA. ECC doesn't have this padding issue as it's specified as part of the ECC protocol for the curve.