### PR TITLE
various log spam fixes

### DIFF
--- a/hubblestack/files/hubblestack_nova/service.py
+++ b/hubblestack/files/hubblestack_nova/service.py
@@ -112,6 +112,11 @@ def audit(data_list, tags, labels, debug=False, **kwargs):
                 name = tag_data['name']
                 audittype = tag_data['type']
 
+                if 'service.status' not in __mods__ or 'service.available' not in __mods__:
+                    tag_data['failure_reason'] = f"unable to look for service '{name}' since host seems to lack init system"
+                    ret['Failure'].append(tag_data)
+                    continue
+
                 # Blacklisted packages (must not be installed)
                 if audittype == 'blacklist':
                     if __mods__['service.available'](name) and __mods__['service.status'](name):

--- a/hubblestack/files/hubblestack_nova/systemctl.py
+++ b/hubblestack/files/hubblestack_nova/systemctl.py
@@ -80,6 +80,7 @@ def audit(data_list, tags, labels, debug=False, **kwargs):
         log.debug(__tags__)
 
     ret = {'Success': [], 'Failure': [], 'Controlled': []}
+
     for tag in __tags__:
         if fnmatch.fnmatch(tag, tags):
             for tag_data in __tags__[tag]:
@@ -88,6 +89,11 @@ def audit(data_list, tags, labels, debug=False, **kwargs):
                     continue
                 name = tag_data['name']
                 audittype = tag_data['type']
+
+                if 'service.enabled' not in __mods__:
+                    tag_data['failure_reason'] = f"unable to look for service '{name}' since host seems to lack init system"
+                    ret['Failure'].append(tag_data)
+                    continue
 
                 enabled = __mods__['service.enabled'](name)
                 # Blacklisted service (must not be running or not found)

--- a/hubblestack/grains/cloud_details.py
+++ b/hubblestack/grains/cloud_details.py
@@ -14,17 +14,17 @@ def get_cloud_details():
     grains = {}
 
     aws = _get_aws_details()
-    if not aws['cloud_details']: # Unable to fetch details from AWS. Let's try from Azure
+    if not aws.get('cloud_details'):
         log.debug("Unable to fetch AWS details. Now trying to fetch Azure details")
         azure = _get_azure_details()
-        if not azure['cloud_details']: # Unable to fetch details from Azure. Let's try from GCP
+        if azure.get('cloud_details'):
             log.debug("Unable to fetch Azure details. Now trying to fetch GCP details")
             gcp = _get_gcp_details()
             if gcp['cloud_details']:
                 log.debug("Fetched instance metadata from GCP")
                 grains.update(gcp)
             else:
-                log.error("Unable to fetch details from AWS/Azure/GCP. Please verify the instance settings.")
+                log.debug("Unable to fetch details from AWS/Azure/GCP. Please verify the instance settings.")
         else:
             log.debug("Fetched instance metadata from Azure")
             grains.update(azure)
@@ -76,8 +76,7 @@ def _get_aws_details():
         else:
             aws = None
     except (requests.exceptions.RequestException, ValueError) as e:
-        log.error(e)
-        # Not on an AWS box
+        log.debug(e)
         aws = None
     if aws:
         try:
@@ -133,7 +132,7 @@ def _get_azure_details():
         else:
             raise ValueError("Error while fetching Azure instance metadata. Got status code: %s " % (response.status_code))
     except (requests.exceptions.RequestException, ValueError) as e:
-        log.error(e)
+        log.debug(e)
         # Not on an Azure box
         azure = None
 
@@ -171,11 +170,13 @@ def _get_azure_details():
             else:
                 raise ValueError("Error while fetching metadata for Azure instance: %s. Got status code: %s" % (azure['cloud_instance_id'], response.status_code))
         except (requests.exceptions.RequestException, ValueError) as e:
-            log.error(e)
+            log.debug(e)
             azure_extra = None
 
-    ret['cloud_details'] = azure
-    ret['cloud_details_extra'] = azure_extra
+    if azure:
+        ret['cloud_details'] = azure
+    if azure_extra:
+        ret['cloud_details_extra'] = azure_extra
     return ret
 
 
@@ -200,7 +201,7 @@ def _get_gcp_details():
             raise ValueError("Error while fetching GCP instance metadata. Got status code: %s" % (response.status_code))
 
     except (requests.exceptions.RequestException, KeyError, ValueError) as e:
-        log.error(e)
+        log.debug(e)
         # Not on gcp box
         gcp = None
     if gcp:
@@ -211,11 +212,13 @@ def _get_gcp_details():
                 if not gcp_extra[key]:
                     gcp_extra.pop(key)
         except (requests.exceptions.RequestException, KeyError, ValueError) as e:
-            log.error(e)
+            log.debug(e)
             gcp_extra = None
 
-    ret['cloud_details'] = gcp
-    ret['cloud_details_extra'] = gcp_extra
+    if gcp:
+        ret['cloud_details'] = gcp
+    if gcp_extra:
+        ret['cloud_details_extra'] = gcp_extra
     return ret
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ chardet
 croniter
 cryptography
 daemon
+distro
 futures
 gitdb2
 gitpython


### PR DESCRIPTION
* grains should not generate log errors -- all hosts are missing something, we usually don't mention things we can't detect
* semi-unrelated logspam fix for minor nova processes: service.* is missing from `__mods__` on Docker processes. This shouldn't generate KeyError exceptions in the logs.