### PR TITLE
patch all the returners to reject `None` in addition to `""`

### DIFF
--- a/hubblestack/returners/splunk_audit_return.py
+++ b/hubblestack/returners/splunk_audit_return.py
@@ -185,7 +185,7 @@ def _generate_event(args, cloud_details, custom_fields, check_type=None, data=No
 
     if check_type == 'Success':
         # Remove any empty fields from the event payload
-        remove_keys = [k for k in event if event[k] == ""]
+        remove_keys = [k for k,v in event.items() if v is None or v == ""]
         for k in remove_keys:
             del event[k]
 

--- a/hubblestack/returners/splunk_fdg_return.py
+++ b/hubblestack/returners/splunk_fdg_return.py
@@ -221,8 +221,8 @@ def _generate_payload(args, fdg_args, cloud_details, opts, index_extracted_field
                             cloud_details=cloud_details,
                             custom_fields=opts['custom_fields'])
     # Remove any empty fields from the event payload
-    remove_keys = [k for k in event
-                   if event[k] == "" and not k.startswith('fdg_')]
+    remove_keys = [k for k,v in event.items()
+                   if not k.startswith('fdg_') and (v == "" or v is None)]
     for k in remove_keys:
         del event[k]
 

--- a/hubblestack/returners/splunk_nebula_return.py
+++ b/hubblestack/returners/splunk_nebula_return.py
@@ -165,7 +165,7 @@ def _generate_event(host_args, query_result, query_name, custom_fields, cloud_de
             event.update({custom_field_name: custom_field_value})
 
     # Remove any empty fields from the event payload
-    remove_keys = [k for k in event if event[k] == ""]
+    remove_keys = [k for k,v in event.items() if v is None or v == ""]
     for k in remove_keys:
         del event[k]
 

--- a/hubblestack/returners/splunk_nova_return.py
+++ b/hubblestack/returners/splunk_nova_return.py
@@ -186,7 +186,7 @@ def _generate_event(args, cloud_details, custom_fields, check_type=None, data=No
 
     if check_type == 'Success':
         # Remove any empty fields from the event payload
-        remove_keys = [k for k in event if event[k] == ""]
+        remove_keys = [k for k,v in event.items() if v is None or v == ""]
         for k in remove_keys:
             del event[k]
 

--- a/hubblestack/returners/splunk_osqueryd_return.py
+++ b/hubblestack/returners/splunk_osqueryd_return.py
@@ -212,7 +212,7 @@ def _update_event(custom_fields, event):
             event.update({custom_field_name: custom_field_value})
 
     # Remove any empty fields from the event payload
-    remove_keys = [k for k in event if event[k] == ""]
+    remove_keys = [k for k,v in event.items() if v is None or v == ""]
     for k in remove_keys:
         del event[k]
 

--- a/hubblestack/returners/splunk_pulsar_return.py
+++ b/hubblestack/returners/splunk_pulsar_return.py
@@ -316,7 +316,7 @@ def _update_event(custom_fields, host_args, cloud_details, event):
         if isinstance(custom_field_value, str):
             event.update({custom_field_name: custom_field_value})
     # Remove any empty fields from the event payload
-    remove_keys = [k for k in event if event[k] == ""]
+    remove_keys = [k for k,v in event.items() if v is None or v == ""]
     for k in remove_keys:
         del event[k]
 


### PR DESCRIPTION
* a handful of returns from fim and audit where presenting `null` fields in JSON (so, `None` in python); tell the key filter in each reterner to reject `None` in addition to `""`
