### PR TITLE
Spurious utils.signing errors

### DIFF
--- a/hubblestack/modules/audit.py
+++ b/hubblestack/modules/audit.py
@@ -374,13 +374,13 @@ def _get_top_data(topfile):
         return None
     if not isinstance(topdata, dict) or 'audit' not in topdata or \
             (not isinstance(topdata['audit'], dict)):
-        log.exception('Audit topfile not formatted correctly')
+        log.error('Audit topfile not formatted correctly')
         return None
     topdata = topdata['audit']
     ret = []
     for match, data in topdata.items():
         if data is None:
-            log.exception('No profiles found for one or more filters in topfile %s', topfile)
+            log.error('No profiles found for one or more filters in topfile %s', topfile)
             return None
         if __mods__['match.compound'](match):
             ret.extend(data)

--- a/hubblestack/modules/fdg.py
+++ b/hubblestack/modules/fdg.py
@@ -276,7 +276,7 @@ def top(fdg_topfile='top.fdg', fdg_version='fdg'):
         call_function = run
 
     if not fdg_routines:
-        log.exception("No fdg_routines found for one or more filters in topfile %s", fdg_topfile)
+        log.error("No fdg_routines found for one or more filters in topfile %s", fdg_topfile)
         return ret
     for fdg_file in fdg_routines:
         if isinstance(fdg_file, dict):
@@ -318,7 +318,7 @@ def _get_top_data(topfile, fdg_version):
 
     for match, data in topdata.items():
         if data is None:
-            log.exception('No profiles found for one or more filters in topfile %s', topfile)
+            log.error('No profiles found for one or more filters in topfile %s', topfile)
             return None
         if __mods__['match.compound'](match):
             ret.extend(data)

--- a/hubblestack/utils/signing.py
+++ b/hubblestack/utils/signing.py
@@ -762,13 +762,16 @@ def find_wrapf(not_found={'path': '', 'rel': ''}, real_path='path'):
     """
     def wrapper(find_file_f):
         def _p(fnd):
+            # real_path is poorly named. it should contain the name of the key
+            # where we'll find the real path of the file we're finding with
+            # find_file_f()
             return fnd.get(real_path, fnd.get('path', ''))
 
         def inner(path, saltenv, *a, **kwargs):
             f_path = find_file_f(path, saltenv, *a, **kwargs)
-            real_path = _p( f_path )
+            p_path = _p( f_path )
 
-            if not real_path:
+            if not p_path:
                 # if the file doesn't exist anyway, there's no reason to continue
                 return f_path
 
@@ -776,16 +779,16 @@ def find_wrapf(not_found={'path': '', 'rel': ''}, real_path='path'):
             sign_path = _p( find_file_f(Options.signature_file_name, saltenv, *a, **kwargs ) )
             cert_path = _p( find_file_f(Options.certificates_file_name, saltenv, *a, **kwargs) )
 
-            log.debug('path: %s | manifest: "%s" | signature: "%s"', path,  mani_path, sign_path)
+            log.debug('path: %s | manifest: "%s" | signature: "%s"', path, mani_path, sign_path)
 
-            verify_res = verify_files([real_path],
+            verify_res = verify_files([p_path],
                                         mfname=mani_path, sfname=sign_path,
                                         public_crt=Options.public_crt,
                                         ca_crt=Options.ca_crt, extra_crt=cert_path)
 
             log.debug('verify: %s', dict(**verify_res))
 
-            vrg = verify_res.get(real_path, STATUS.UNKNOWN)
+            vrg = verify_res.get(p_path, STATUS.UNKNOWN)
             if vrg == STATUS.VERIFIED:
                 return f_path
             if vrg == STATUS.UNKNOWN and not Options.require_verify:

--- a/hubblestack/utils/signing.py
+++ b/hubblestack/utils/signing.py
@@ -765,12 +765,9 @@ def find_wrapf(not_found={'path': '', 'rel': ''}, real_path='path'):
             return fnd.get(real_path, fnd.get('path', ''))
 
         def inner(path, saltenv, *a, **kwargs):
-            manifest_file_name = Options.manifest_file_name
-            signature_file_name = Options.signature_file_name
-            certificates_file_name = Options.certificates_file_name
-            f_mani = find_file_f(manifest_file_name, saltenv, *a, **kwargs )
-            f_sign = find_file_f(signature_file_name, saltenv, *a, **kwargs )
-            f_pub_cert = find_file_f(certificates_file_name, saltenv, *a, **kwargs)
+            f_mani = find_file_f(Options.manifest_file_name, saltenv, *a, **kwargs )
+            f_sign = find_file_f(Options.signature_file_name, saltenv, *a, **kwargs )
+            f_pub_cert = find_file_f(Options.certificates_file_name, saltenv, *a, **kwargs)
             f_path = find_file_f(path, saltenv, *a, **kwargs)
             real_path = _p(f_path)
             mani_path = _p(f_mani)

--- a/hubblestack/utils/signing.py
+++ b/hubblestack/utils/signing.py
@@ -566,9 +566,9 @@ def verify_signature(fname, sfname, public_crt=None, ca_crt=None, extra_crt=None
         ca_crt = Options.ca_crt
 
     log_level = log.debug
-    if fname is None or sfname is None:
+    if not (fname and sfname):
         status = STATUS.UNKNOWN
-        log_level('fname=%s or sfname=%s is None => status=%s', fname, sfname, status)
+        log_level('!(fname=%s and sfname=%s) => status=%s', fname, sfname, status)
         return status
     short_fname = fname.split('/')[-1]
 

--- a/hubblestack/utils/signing.py
+++ b/hubblestack/utils/signing.py
@@ -765,23 +765,26 @@ def find_wrapf(not_found={'path': '', 'rel': ''}, real_path='path'):
             return fnd.get(real_path, fnd.get('path', ''))
 
         def inner(path, saltenv, *a, **kwargs):
-            f_mani = find_file_f(Options.manifest_file_name, saltenv, *a, **kwargs )
-            f_sign = find_file_f(Options.signature_file_name, saltenv, *a, **kwargs )
-            f_pub_cert = find_file_f(Options.certificates_file_name, saltenv, *a, **kwargs)
             f_path = find_file_f(path, saltenv, *a, **kwargs)
-            real_path = _p(f_path)
-            mani_path = _p(f_mani)
-            sign_path = _p(f_sign)
-            cert_path = _p(f_pub_cert)
-            log.debug('path: %s | manifest: "%s" | signature: "%s"',
-                    path,  mani_path, sign_path)
+            real_path = _p( f_path )
+
             if not real_path:
+                # if the file doesn't exist anyway, there's no reason to continue
                 return f_path
+
+            mani_path = _p( find_file_f(Options.manifest_file_name, saltenv, *a, **kwargs ) )
+            sign_path = _p( find_file_f(Options.signature_file_name, saltenv, *a, **kwargs ) )
+            cert_path = _p( find_file_f(Options.certificates_file_name, saltenv, *a, **kwargs) )
+
+            log.debug('path: %s | manifest: "%s" | signature: "%s"', path,  mani_path, sign_path)
+
             verify_res = verify_files([real_path],
                                         mfname=mani_path, sfname=sign_path,
                                         public_crt=Options.public_crt,
                                         ca_crt=Options.ca_crt, extra_crt=cert_path)
+
             log.debug('verify: %s', dict(**verify_res))
+
             vrg = verify_res.get(real_path, STATUS.UNKNOWN)
             if vrg == STATUS.VERIFIED:
                 return f_path


### PR DESCRIPTION
fix some minor logging issues and avoid checking manifest/signature if they don't exist