### PR TITLE
spooky unnecessary error message (on info channel)

### DIFF
--- a/hubblestack/fileserver/gitfs.py
+++ b/hubblestack/fileserver/gitfs.py
@@ -86,7 +86,6 @@ def __virtual__():
     properly in the master config file.
     """
     if __virtualname__ not in __opts__['fileserver_backend']:
-        log.info("no fileserver_backend configs, skipping gitfs")
         return False
     try:
         _gitfs(init_remotes=False)


### PR DESCRIPTION
This error looks spooky when you're looking for possibly related problems:

```
hubble.loaded.int.fi  INFO: no fileserver_backend configs, skipping gitfs                                              
```

It's also pretty misleading even if it were useful to spam it.