### PR TITLE
dict comparator's match_any_if_keyvalue_matches bug

### DIFF
--- a/hubblestack/comparators/dict.py
+++ b/hubblestack/comparators/dict.py
@@ -308,7 +308,9 @@ def match_any_if_keyvalue_matches(audit_id, result_to_compare, args):
             if not errors:
                 # found a match
                 return True, "Dictionary comparison passed"
-
+        else:
+            error_msg = "required key value '{0}' does not match with found value '{1}'".format(to_compare_val2, to_compare_val1)
+            return False, error_msg
     if key_found_once:
         error_message = 'dict::match_any_if_keyvalue_matches failed, errors={0}'.format(str(errors))
         return False, error_message


### PR DESCRIPTION
The function never checked if the required key's value is same as found value! Fixing that.