### PR TITLE
adding a method for fetching failure reason from module

### DIFF
--- a/hubblestack/audit/bexpr.py
+++ b/hubblestack/audit/bexpr.py
@@ -359,7 +359,7 @@ def _evaluate_expression(expr_list, keyword_list, referred_checks_result):
 
 def get_failure_reason(block_id, block_dict, extra_args=None):
     """
-
+    The function is used to find the action that was performed during the audit check
     :param block_id:
         id of the block
     :param block_dict:
@@ -373,8 +373,7 @@ def get_failure_reason(block_id, block_dict, extra_args=None):
     :return:
     """
     expression = runner_utils.get_param_for_module(block_id, block_dict, 'expr')
-    failure_reason = "Executing expression {0}".format(expression)
-    return failure_reason
+    return "Executing expression {0}".format(expression)
 
 class BoolOperand:
     def __init__(self, t):

--- a/hubblestack/audit/bexpr.py
+++ b/hubblestack/audit/bexpr.py
@@ -357,6 +357,25 @@ def _evaluate_expression(expr_list, keyword_list, referred_checks_result):
     return boolExpr.parseString(parsed_expr)[0]
 
 
+def get_failure_reason(block_id, block_dict, extra_args=None):
+    """
+
+    :param block_id:
+        id of the block
+    :param block_dict:
+        parameter for this module
+    :param extra_args:
+        Extra argument dictionary, (If any)
+        Example: {'chaining_args': {'result': "True", 'status': True},
+                  'extra_args': [{'check_id': 'ADOBE-01',
+                                  'check_status': 'Success'}]
+                  'caller': 'Audit'}
+    :return:
+    """
+    expression = runner_utils.get_param_for_module(block_id, block_dict, 'expr')
+    failure_reason = "Executing expression {0}".format(expression)
+    return failure_reason
+
 class BoolOperand:
     def __init__(self, t):
         self.label = t[0]

--- a/hubblestack/audit/command_line_parser.py
+++ b/hubblestack/audit/command_line_parser.py
@@ -457,3 +457,22 @@ def get_filtered_params_to_log(block_id, block_dict, extra_args=None):
         'key_aliases': key_aliases,
         'delimiter': delimiter
     }
+
+
+def get_failure_reason(block_id, block_dict, extra_args=None):
+    """
+
+    :param block_id:
+        id of the block
+    :param block_dict:
+        parameter for this module
+    :param extra_args:
+        Extra argument dictionary, (If any)
+        Example: {'chaining_args': {'result': {'cmdline': 'app --config-file=test test'}, 'status': True},
+                  'caller': 'Audit'}
+    :return:
+    """
+    key_aliases = runner_utils.get_param_for_module(block_id, block_dict, 'key_aliases')
+    command_line = runner_utils.get_param_for_module(block_id, block_dict, 'cmdline')
+    failure_reason = "Fetching value of {0} in {1}".format(key_aliases, command_line)
+    return failure_reason

--- a/hubblestack/audit/command_line_parser.py
+++ b/hubblestack/audit/command_line_parser.py
@@ -461,7 +461,7 @@ def get_filtered_params_to_log(block_id, block_dict, extra_args=None):
 
 def get_failure_reason(block_id, block_dict, extra_args=None):
     """
-
+    The function is used to find the action that was performed during the audit check
     :param block_id:
         id of the block
     :param block_dict:
@@ -474,5 +474,4 @@ def get_failure_reason(block_id, block_dict, extra_args=None):
     """
     key_aliases = runner_utils.get_param_for_module(block_id, block_dict, 'key_aliases')
     command_line = runner_utils.get_param_for_module(block_id, block_dict, 'cmdline')
-    failure_reason = "Fetching value of {0} in {1}".format(key_aliases, command_line)
-    return failure_reason
+    return "Fetching value of {0} in {1}".format(key_aliases, command_line)

--- a/hubblestack/audit/curl.py
+++ b/hubblestack/audit/curl.py
@@ -401,7 +401,7 @@ def get_filtered_params_to_log(block_id, block_dict, extra_args=None):
 
 def get_failure_reason(block_id, block_dict, extra_args=None):
     """
-
+    The function is used to find the action that was performed during the audit check
     :param block_id:
         id of the block
     :param block_dict:
@@ -413,5 +413,4 @@ def get_failure_reason(block_id, block_dict, extra_args=None):
     """
     function_name = runner_utils.get_param_for_module(block_id, block_dict, 'function')
     url = runner_utils.get_param_for_module(block_id, block_dict, 'url')
-    failure_reason = "Making {0} request on {1}".format(function_name, url)
-    return failure_reason
+    return "Making {0} request on {1}".format(function_name, url)

--- a/hubblestack/audit/curl.py
+++ b/hubblestack/audit/curl.py
@@ -397,3 +397,21 @@ def get_filtered_params_to_log(block_id, block_dict, extra_args=None):
     url = runner_utils.get_param_for_module(block_id, block_dict, 'url')
 
     return {'url': url}
+
+
+def get_failure_reason(block_id, block_dict, extra_args=None):
+    """
+
+    :param block_id:
+        id of the block
+    :param block_dict:
+        parameter for this module
+    :param extra_args:
+        Extra argument dictionary, (If any)
+
+    :return:
+    """
+    function_name = runner_utils.get_param_for_module(block_id, block_dict, 'function')
+    url = runner_utils.get_param_for_module(block_id, block_dict, 'url')
+    failure_reason = "Making {0} request on {1}".format(function_name, url)
+    return failure_reason

--- a/hubblestack/audit/fdg.py
+++ b/hubblestack/audit/fdg.py
@@ -325,3 +325,21 @@ def _get_consolidated_result(fdg_run, consolidation_operator):
         else:
             overall_result = overall_result or fdg_status
     return fdg_run, overall_result
+
+
+def get_failure_reason(block_id, block_dict, extra_args=None):
+    """
+
+    :param block_id:
+        id of the block
+    :param block_dict:
+        parameter for this module
+    :param extra_args:
+        Extra argument dictionary, (If any)
+        Example: {'chaining_args': {'result': "/some/path/file.txt", 'status': True},
+                  'caller': 'Audit'}
+    :return:
+    """
+    fdg_file = runner_utils.get_param_for_module(block_id, block_dict, 'fdg_file')
+    failure_reason = "Executing fdg_file {0}".format(fdg_file)
+    return failure_reason

--- a/hubblestack/audit/fdg.py
+++ b/hubblestack/audit/fdg.py
@@ -329,7 +329,7 @@ def _get_consolidated_result(fdg_run, consolidation_operator):
 
 def get_failure_reason(block_id, block_dict, extra_args=None):
     """
-
+    The function is used to find the action that was performed during the audit check
     :param block_id:
         id of the block
     :param block_dict:
@@ -341,5 +341,4 @@ def get_failure_reason(block_id, block_dict, extra_args=None):
     :return:
     """
     fdg_file = runner_utils.get_param_for_module(block_id, block_dict, 'fdg_file')
-    failure_reason = "Executing fdg_file {0}".format(fdg_file)
-    return failure_reason
+    return "Executing fdg_file {0}".format(fdg_file)

--- a/hubblestack/audit/grep.py
+++ b/hubblestack/audit/grep.py
@@ -404,7 +404,7 @@ def _grep(path,
 
 def get_failure_reason(block_id, block_dict, extra_args=None):
     """
-
+    The function is used to find the action that was performed during the audit check
     :param block_id:
         id of the block
     :param block_dict:
@@ -417,5 +417,4 @@ def get_failure_reason(block_id, block_dict, extra_args=None):
     """
     pattern_val = runner_utils.get_param_for_module(block_id, block_dict, 'pattern')
     filepath = runner_utils.get_param_for_module(block_id, block_dict, 'path')
-    failure_reason = "Finding pattern {0} in filepath {1}".format(pattern_val, filepath)
-    return failure_reason
+    return "Finding pattern {0} in filepath {1}".format(pattern_val, filepath)

--- a/hubblestack/audit/grep.py
+++ b/hubblestack/audit/grep.py
@@ -400,3 +400,22 @@ def _grep(path,
         raise CommandExecutionError(exc.strerror)
 
     return ret
+
+
+def get_failure_reason(block_id, block_dict, extra_args=None):
+    """
+
+    :param block_id:
+        id of the block
+    :param block_dict:
+        parameter for this module
+    :param extra_args:
+        Extra argument dictionary, (If any)
+        Example: {'chaining_args': {'result': "/some/path/file.txt", 'status': True},
+                  'caller': 'Audit'}
+    :return:
+    """
+    pattern_val = runner_utils.get_param_for_module(block_id, block_dict, 'pattern')
+    filepath = runner_utils.get_param_for_module(block_id, block_dict, 'path')
+    failure_reason = "Finding pattern {0} in filepath {1}".format(pattern_val, filepath)
+    return failure_reason

--- a/hubblestack/audit/misc.py
+++ b/hubblestack/audit/misc.py
@@ -382,6 +382,25 @@ def execute(block_id, block_dict, extra_args=None):
         return runner_utils.prepare_positive_result_for_module(block_id, True)
     return runner_utils.prepare_negative_result_for_module(block_id, result)
 
+
+def get_failure_reason(block_id, block_dict, extra_args=None):
+    """
+
+    :param block_id:
+        id of the block
+    :param block_dict:
+        parameter for this module
+    :param extra_args:
+        Extra argument dictionary, (If any)
+        Example: {'chaining_args': {'result': "/some/path/file.txt", 'status': True},
+                  'caller': 'Audit'}
+    :return:
+    """
+    function_name = runner_utils.get_param_for_module(block_id, block_dict, 'function')
+    failure_reason = "Executing function {0}".format(function_name)
+    return failure_reason
+
+
 def _check_all_ports_firewall_rules(block_id, block_dict, extra_args):
     """
     Ensure firewall rule for all open ports

--- a/hubblestack/audit/misc.py
+++ b/hubblestack/audit/misc.py
@@ -385,7 +385,7 @@ def execute(block_id, block_dict, extra_args=None):
 
 def get_failure_reason(block_id, block_dict, extra_args=None):
     """
-
+    The function is used to find the action that was performed during the audit check
     :param block_id:
         id of the block
     :param block_dict:
@@ -397,8 +397,7 @@ def get_failure_reason(block_id, block_dict, extra_args=None):
     :return:
     """
     function_name = runner_utils.get_param_for_module(block_id, block_dict, 'function')
-    failure_reason = "Executing function {0}".format(function_name)
-    return failure_reason
+    return "Executing function {0}".format(function_name)
 
 
 def _check_all_ports_firewall_rules(block_id, block_dict, extra_args):

--- a/hubblestack/audit/osquery.py
+++ b/hubblestack/audit/osquery.py
@@ -351,7 +351,7 @@ def _convert_to_str(data):
 
 def get_failure_reason(block_id, block_dict, extra_args=None):
     """
-
+    The function is used to find the action that was performed during the audit check
     :param block_id:
         id of the block
     :param block_dict:
@@ -363,5 +363,4 @@ def get_failure_reason(block_id, block_dict, extra_args=None):
     :return:
     """
     query = runner_utils.get_param_for_module(block_id, block_dict, 'query')
-    failure_reason = "Executing query '{0}'".format(query)
-    return failure_reason
+    return "Executing query '{0}'".format(query)

--- a/hubblestack/audit/osquery.py
+++ b/hubblestack/audit/osquery.py
@@ -347,3 +347,21 @@ def _convert_to_str(data):
         return None
 
     return ret
+
+
+def get_failure_reason(block_id, block_dict, extra_args=None):
+    """
+
+    :param block_id:
+        id of the block
+    :param block_dict:
+        parameter for this module
+    :param extra_args:
+        Extra argument dictionary, (If any)
+        Example: {'chaining_args': {'result': [{'name': 'CentOS Linux', 'platform': 'rhel', 'version': 'CentOS Linux release 7.8.2003 (Core)'}], 'status': True},
+                  'caller': 'FDG'}
+    :return:
+    """
+    query = runner_utils.get_param_for_module(block_id, block_dict, 'query')
+    failure_reason = "Executing query '{0}'".format(query)
+    return failure_reason

--- a/hubblestack/audit/pkg.py
+++ b/hubblestack/audit/pkg.py
@@ -273,7 +273,7 @@ def get_filtered_params_to_log(block_id, block_dict, extra_args=None):
 
 def get_failure_reason(block_id, block_dict, extra_args=None):
     """
-
+    The function is used to find the action that was performed during the audit check
     :param block_id:
         id of the block
     :param block_dict:
@@ -285,5 +285,4 @@ def get_failure_reason(block_id, block_dict, extra_args=None):
     :return:
     """
     name = runner_utils.get_param_for_module(block_id, block_dict, 'name')
-    failure_reason = "Fetching package information for package {0}".format(name)
-    return failure_reason
+    return "Fetching package information for package {0}".format(name)

--- a/hubblestack/audit/pkg.py
+++ b/hubblestack/audit/pkg.py
@@ -269,3 +269,21 @@ def get_filtered_params_to_log(block_id, block_dict, extra_args=None):
         name = runner_utils.get_param_for_module(block_id, block_dict, 'name')
 
     return {'name': name}
+
+
+def get_failure_reason(block_id, block_dict, extra_args=None):
+    """
+
+    :param block_id:
+        id of the block
+    :param block_dict:
+        parameter for this module
+    :param extra_args:
+        Extra argument dictionary, (If any)
+        Example: {'chaining_args': {'result': "/some/path/file.txt", 'status': True},
+                  'caller': 'Audit'}
+    :return:
+    """
+    name = runner_utils.get_param_for_module(block_id, block_dict, 'name')
+    failure_reason = "Fetching package information for package {0}".format(name)
+    return failure_reason

--- a/hubblestack/audit/readfile.py
+++ b/hubblestack/audit/readfile.py
@@ -666,3 +666,22 @@ def get_filtered_params_to_log(block_id, block_dict, extra_args=None):
     # fetch required param
     filepath = runner_utils.get_param_for_module(block_id, block_dict, 'path')
     return {'path': filepath}
+
+
+def get_failure_reason(block_id, block_dict, extra_args=None):
+    """
+
+    :param block_id:
+        id of the block
+    :param block_dict:
+        parameter for this module
+    :param extra_args:
+        Extra argument dictionary, (If any)
+        Example: {'chaining_args': {'result': '/some/path', 'status': True},
+                  'caller': 'Audit'}
+    :return:
+    """
+    subkey = runner_utils.get_param_for_module(block_id, block_dict, 'subkey')
+    path = runner_utils.get_param_for_module(block_id, block_dict, 'path')
+    failure_reason = "Fetching subkey '{0}' in file {1}".format(subkey, path)
+    return failure_reason

--- a/hubblestack/audit/readfile.py
+++ b/hubblestack/audit/readfile.py
@@ -670,7 +670,7 @@ def get_filtered_params_to_log(block_id, block_dict, extra_args=None):
 
 def get_failure_reason(block_id, block_dict, extra_args=None):
     """
-
+    The function is used to find the action that was performed during the audit check
     :param block_id:
         id of the block
     :param block_dict:
@@ -683,5 +683,4 @@ def get_failure_reason(block_id, block_dict, extra_args=None):
     """
     subkey = runner_utils.get_param_for_module(block_id, block_dict, 'subkey')
     path = runner_utils.get_param_for_module(block_id, block_dict, 'path')
-    failure_reason = "Fetching subkey '{0}' in file {1}".format(subkey, path)
-    return failure_reason
+    return "Fetching subkey '{0}' in file {1}".format(subkey, path)

--- a/hubblestack/audit/service.py
+++ b/hubblestack/audit/service.py
@@ -278,3 +278,21 @@ def get_filtered_params_to_log(block_id, block_dict, extra_args=None):
     if not name:
         name = runner_utils.get_param_for_module(block_id, block_dict, 'name')
     return {'name': name}
+
+
+def get_failure_reason(block_id, block_dict, extra_args=None):
+    """
+
+    :param block_id:
+        id of the block
+    :param block_dict:
+        parameter for this module
+    :param extra_args:
+        Extra argument dictionary, (If any)
+        Example: {'chaining_args': {'result': "/some/path/file.txt", 'status': True},
+                  'caller': 'Audit'}
+    :return:
+    """
+    name = runner_utils.get_param_for_module(block_id, block_dict, 'name')
+    failure_reason = "Fetching service information for '{0}'".format(name)
+    return failure_reason

--- a/hubblestack/audit/service.py
+++ b/hubblestack/audit/service.py
@@ -282,7 +282,7 @@ def get_filtered_params_to_log(block_id, block_dict, extra_args=None):
 
 def get_failure_reason(block_id, block_dict, extra_args=None):
     """
-
+    The function is used to find the action that was performed during the audit check
     :param block_id:
         id of the block
     :param block_dict:
@@ -294,5 +294,4 @@ def get_failure_reason(block_id, block_dict, extra_args=None):
     :return:
     """
     name = runner_utils.get_param_for_module(block_id, block_dict, 'name')
-    failure_reason = "Fetching service information for '{0}'".format(name)
-    return failure_reason
+    return "Fetching service information for '{0}'".format(name)

--- a/hubblestack/audit/ssl_certificate.py
+++ b/hubblestack/audit/ssl_certificate.py
@@ -449,7 +449,7 @@ def _get_certificate_san(x509cert):
 
 def get_failure_reason(block_id, block_dict, extra_args=None):
     """
-
+    The function is used to find the action that was performed during the audit check
     :param block_id:
         id of the block
     :param block_dict:
@@ -464,5 +464,4 @@ def get_failure_reason(block_id, block_dict, extra_args=None):
     """
     host_ip = runner_utils.get_param_for_module(block_id, block_dict, 'host_ip')
     host_port = runner_utils.get_param_for_module(block_id, block_dict, 'host_port')
-    failure_reason = "Fetching certificate information for {0}:{1}".format(host_ip, host_port)
-    return failure_reason
+    return "Fetching certificate information for {0}:{1}".format(host_ip, host_port)

--- a/hubblestack/audit/ssl_certificate.py
+++ b/hubblestack/audit/ssl_certificate.py
@@ -191,7 +191,7 @@ ssl_cert_check:
             path: /path/to/pem/file
           comparator:
             type: certificate
-            compare:
+            match:
                 not_before: 30 # maximum number of days until the certificate becomes valid (Optional)
                                # the check is failed if the certificate becomes valid in more than 30 days
                 not_after: 45  # minimum number of days until certificate expires (Optional)
@@ -445,3 +445,24 @@ def _get_certificate_san(x509cert):
         message = "ssl_certificate couldn't fetch SANs: {0}".format(e)
         log.error(message)
     return trimmed_san_list
+
+
+def get_failure_reason(block_id, block_dict, extra_args=None):
+    """
+
+    :param block_id:
+        id of the block
+    :param block_dict:
+        parameter for this module
+    :param extra_args:
+        Extra argument dictionary, (If any)
+        Example: {'chaining_args': {'result': {'host_ip': '127.0.0.1',
+                                                'host_port': 443},
+                                    'status': True},
+                  'caller': 'Audit'}
+    :return:
+    """
+    host_ip = runner_utils.get_param_for_module(block_id, block_dict, 'host_ip')
+    host_port = runner_utils.get_param_for_module(block_id, block_dict, 'host_port')
+    failure_reason = "Fetching certificate information for {0}:{1}".format(host_ip, host_port)
+    return failure_reason

--- a/hubblestack/audit/stat.py
+++ b/hubblestack/audit/stat.py
@@ -300,5 +300,5 @@ def get_failure_reason(block_id, block_dict, extra_args=None):
     :return:
     """
     path = runner_utils.get_param_for_module(block_id, block_dict, 'path')
-    failure_reason = "fetching file stats for file {0}".format(path)
+    failure_reason = "Fetching file stats for file {0}".format(path)
     return failure_reason

--- a/hubblestack/audit/stat.py
+++ b/hubblestack/audit/stat.py
@@ -284,3 +284,21 @@ def get_filtered_params_to_log(block_id, block_dict, extra_args=None):
     if not filepath:
         filepath = runner_utils.get_param_for_module(block_id, block_dict, 'path')
     return {'path': filepath}
+
+
+def get_failure_reason(block_id, block_dict, extra_args=None):
+    """
+
+    :param block_id:
+        id of the block
+    :param block_dict:
+        parameter for this module
+    :param extra_args:
+        Extra argument dictionary, (If any)
+        Example: {'chaining_args': {'result': "/some/path/file.txt", 'status': True},
+                  'caller': 'Audit'}
+    :return:
+    """
+    path = runner_utils.get_param_for_module(block_id, block_dict, 'path')
+    failure_reason = "fetching file stats for file {0}".format(path)
+    return failure_reason

--- a/hubblestack/audit/stat.py
+++ b/hubblestack/audit/stat.py
@@ -288,7 +288,7 @@ def get_filtered_params_to_log(block_id, block_dict, extra_args=None):
 
 def get_failure_reason(block_id, block_dict, extra_args=None):
     """
-
+    The function is used to find the action that was performed during the audit check
     :param block_id:
         id of the block
     :param block_dict:
@@ -300,5 +300,4 @@ def get_failure_reason(block_id, block_dict, extra_args=None):
     :return:
     """
     path = runner_utils.get_param_for_module(block_id, block_dict, 'path')
-    failure_reason = "Fetching file stats for file {0}".format(path)
-    return failure_reason
+    return "Fetching file stats for file {0}".format(path)

--- a/hubblestack/audit/sysctl.py
+++ b/hubblestack/audit/sysctl.py
@@ -264,7 +264,7 @@ def get_filtered_params_to_log(block_id, block_dict, extra_args=None):
 
 def get_failure_reason(block_id, block_dict, extra_args=None):
     """
-
+    The function is used to find the action that was performed during the audit check
     :param block_id:
         id of the block
     :param block_dict:
@@ -276,5 +276,4 @@ def get_failure_reason(block_id, block_dict, extra_args=None):
     :return:
     """
     name = runner_utils.get_param_for_module(block_id, block_dict, 'name')
-    failure_reason = "Fetching information for kernel param '{0}'".format(name)
-    return failure_reason
+    return "Fetching information for kernel param '{0}'".format(name)

--- a/hubblestack/audit/sysctl.py
+++ b/hubblestack/audit/sysctl.py
@@ -260,3 +260,21 @@ def get_filtered_params_to_log(block_id, block_dict, extra_args=None):
     if not name:
         name = runner_utils.get_param_for_module(block_id, block_dict, 'name')
     return {'name': name}
+
+
+def get_failure_reason(block_id, block_dict, extra_args=None):
+    """
+
+    :param block_id:
+        id of the block
+    :param block_dict:
+        parameter for this module
+    :param extra_args:
+        Extra argument dictionary, (If any)
+        Example: {'chaining_args': {'result': "vm.zone_reclaim_mode", 'status': True},
+                  'caller': 'Audit'}
+    :return:
+    """
+    name = runner_utils.get_param_for_module(block_id, block_dict, 'name')
+    failure_reason = "Fetching information for kernel param '{0}'".format(name)
+    return failure_reason

--- a/hubblestack/audit/time_sync.py
+++ b/hubblestack/audit/time_sync.py
@@ -344,3 +344,21 @@ def _query_ntp_server(ntp_server):
         log.error("Unexpected error occured while querying the server.", exc_info=True)
 
     return ret
+
+
+def get_failure_reason(block_id, block_dict, extra_args=None):
+    """
+
+    :param block_id:
+        id of the block
+    :param block_dict:
+        parameter for this module
+    :param extra_args:
+        Extra argument dictionary, (If any)
+        Example: {'chaining_args': {'result': ['server1', 'server2'], 'status': True},
+                  'caller': 'Audit'}
+    :return:
+    """
+    ntp_servers = _get_ntp_servers(block_id, block_dict, extra_args)
+    failure_reason = "Fetching information about following NTP servers {0}".format(ntp_servers)
+    return failure_reason

--- a/hubblestack/audit/time_sync.py
+++ b/hubblestack/audit/time_sync.py
@@ -348,7 +348,7 @@ def _query_ntp_server(ntp_server):
 
 def get_failure_reason(block_id, block_dict, extra_args=None):
     """
-
+    The function is used to find the action that was performed during the audit check
     :param block_id:
         id of the block
     :param block_dict:
@@ -360,5 +360,4 @@ def get_failure_reason(block_id, block_dict, extra_args=None):
     :return:
     """
     ntp_servers = _get_ntp_servers(block_id, block_dict, extra_args)
-    failure_reason = "Fetching information about following NTP servers {0}".format(ntp_servers)
-    return failure_reason
+    return "Fetching information about following NTP servers {0}".format(ntp_servers)

--- a/hubblestack/audit/util.py
+++ b/hubblestack/audit/util.py
@@ -1208,7 +1208,7 @@ def get_filtered_params_to_log(block_id, block_dict, extra_args=None):
 
 def get_failure_reason(block_id, block_dict, extra_args=None):
     """
-
+    The function is used to find the action that was performed during the audit check
     :param block_id:
         id of the block
     :param block_dict:
@@ -1222,5 +1222,4 @@ def get_failure_reason(block_id, block_dict, extra_args=None):
     :return:
     """
     function_param = runner_utils.get_param_for_module(block_id, block_dict, 'function')
-    failure_reason = "Executing function {0}".format(function_param)
-    return failure_reason
+    return "Executing function {0}".format(function_param)

--- a/hubblestack/audit/util.py
+++ b/hubblestack/audit/util.py
@@ -1204,3 +1204,23 @@ def get_filtered_params_to_log(block_id, block_dict, extra_args=None):
     function_param = runner_utils.get_param_for_module(block_id, block_dict, 'function')
 
     return {'function': function_param}
+
+
+def get_failure_reason(block_id, block_dict, extra_args=None):
+    """
+
+    :param block_id:
+        id of the block
+    :param block_dict:
+        parameter for this module
+    :param extra_args:
+        Extra argument dictionary, (If any)
+        Example: {'chaining_args': {'result': "string/dict", 'status': True},
+                  'extra_args': [{'check_id': 'ADOBE-01',
+                                  'check_status': 'Success'}]
+                  'caller': 'FDG'}
+    :return:
+    """
+    function_param = runner_utils.get_param_for_module(block_id, block_dict, 'function')
+    failure_reason = "Executing function {0}".format(function_param)
+    return failure_reason

--- a/hubblestack/audit/win_auditpol.py
+++ b/hubblestack/audit/win_auditpol.py
@@ -293,7 +293,7 @@ def _auditpol_export():
 
 def get_failure_reason(block_id, block_dict, extra_args=None):
     """
-
+    The function is used to find the action that was performed during the audit check
     :param block_id:
         id of the block
     :param block_dict:
@@ -305,5 +305,4 @@ def get_failure_reason(block_id, block_dict, extra_args=None):
     :return:
     """
     name = runner_utils.get_param_for_module(block_id, block_dict, 'name')
-    failure_reason = "Fetching audit policy {0}".format(name)
-    return failure_reason
+    return "Fetching audit policy {0}".format(name)

--- a/hubblestack/audit/win_auditpol.py
+++ b/hubblestack/audit/win_auditpol.py
@@ -289,3 +289,21 @@ def _auditpol_export():
             log.error('Nothing was returned from the auditpol command.')
     except Exception:
         log.error('An error occurred running the auditpol command.')
+
+
+def get_failure_reason(block_id, block_dict, extra_args=None):
+    """
+
+    :param block_id:
+        id of the block
+    :param block_dict:
+        parameter for this module
+    :param extra_args:
+        Extra argument dictionary, (If any)
+        Example: {'chaining_args': {'result': 'Distribution Group Management', 'status': True},
+                  'caller': 'Audit'}
+    :return:
+    """
+    name = runner_utils.get_param_for_module(block_id, block_dict, 'name')
+    failure_reason = "Fetching audit policy {0}".format(name)
+    return failure_reason

--- a/hubblestack/audit/win_firewall.py
+++ b/hubblestack/audit/win_firewall.py
@@ -328,3 +328,21 @@ def _import_firewall():
                 temp_values[value_list[0].strip()] = value_list[1].strip()
         dict_return[temp_values['Name']] = temp_values
     return dict_return
+
+
+def get_failure_reason(block_id, block_dict, extra_args=None):
+    """
+
+    :param block_id:
+        id of the block
+    :param block_dict:
+        parameter for this module
+    :param extra_args:
+        Extra argument dictionary, (If any)
+        Example: {'chaining_args': {'result': {"name": "LogFileName", "value_type": "public"}, 'status': True},
+                  'caller': 'Audit'}
+    :return:
+    """
+    name = runner_utils.get_param_for_module(block_id, block_dict, 'name')
+    failure_reason = "Fetching firewall rule {0}".format(name)
+    return failure_reason

--- a/hubblestack/audit/win_firewall.py
+++ b/hubblestack/audit/win_firewall.py
@@ -332,7 +332,7 @@ def _import_firewall():
 
 def get_failure_reason(block_id, block_dict, extra_args=None):
     """
-
+    The function is used to find the action that was performed during the audit check
     :param block_id:
         id of the block
     :param block_dict:
@@ -344,5 +344,4 @@ def get_failure_reason(block_id, block_dict, extra_args=None):
     :return:
     """
     name = runner_utils.get_param_for_module(block_id, block_dict, 'name')
-    failure_reason = "Fetching firewall rule {0}".format(name)
-    return failure_reason
+    return "Fetching firewall rule {0}".format(name)

--- a/hubblestack/audit/win_pkg.py
+++ b/hubblestack/audit/win_pkg.py
@@ -290,3 +290,21 @@ def get_filtered_params_to_log(block_id, block_dict, extra_args=None):
         pkg_name = runner_utils.get_param_for_module(block_id, block_dict, 'name')
 
     return {'name': pkg_name}
+
+
+def get_failure_reason(block_id, block_dict, extra_args=None):
+    """
+
+    :param block_id:
+        id of the block
+    :param block_dict:
+        parameter for this module
+    :param extra_args:
+        Extra argument dictionary, (If any)
+        Example: {'chaining_args': {'result': "Local Administrator Password Solution", 'status': True},
+                  'caller': 'Audit'}
+    :return:
+    """
+    name = runner_utils.get_param_for_module(block_id, block_dict, 'name')
+    failure_reason = "Fetching package information for {0}".format(name)
+    return failure_reason

--- a/hubblestack/audit/win_pkg.py
+++ b/hubblestack/audit/win_pkg.py
@@ -294,7 +294,7 @@ def get_filtered_params_to_log(block_id, block_dict, extra_args=None):
 
 def get_failure_reason(block_id, block_dict, extra_args=None):
     """
-
+    The function is used to find the action that was performed during the audit check
     :param block_id:
         id of the block
     :param block_dict:
@@ -306,5 +306,4 @@ def get_failure_reason(block_id, block_dict, extra_args=None):
     :return:
     """
     name = runner_utils.get_param_for_module(block_id, block_dict, 'name')
-    failure_reason = "Fetching package information for {0}".format(name)
-    return failure_reason
+    return "Fetching package information for {0}".format(name)

--- a/hubblestack/audit/win_reg.py
+++ b/hubblestack/audit/win_reg.py
@@ -353,7 +353,7 @@ def _read_reg_value(reg_hive, reg_key, reg_value):
 
 def get_failure_reason(block_id, block_dict, extra_args=None):
     """
-
+    The function is used to find the action that was performed during the audit check
     :param block_id:
         id of the block
     :param block_dict:
@@ -365,5 +365,4 @@ def get_failure_reason(block_id, block_dict, extra_args=None):
     :return:
     """
     reg_name = runner_utils.get_param_for_module(block_id, block_dict, 'name')
-    failure_reason = "Fetching registry information for {0}".format(reg_name)
-    return failure_reason
+    return "Fetching registry information for {0}".format(reg_name)

--- a/hubblestack/audit/win_reg.py
+++ b/hubblestack/audit/win_reg.py
@@ -349,3 +349,21 @@ def _read_reg_value(reg_hive, reg_key, reg_value):
             return reg_result.get('vdata')
     else:
         return False
+
+
+def get_failure_reason(block_id, block_dict, extra_args=None):
+    """
+
+    :param block_id:
+        id of the block
+    :param block_dict:
+        parameter for this module
+    :param extra_args:
+        Extra argument dictionary, (If any)
+        Example: {'chaining_args': {'result': "HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\EventLog\Application\MaxSize", 'status': True},
+                  'caller': 'Audit'}
+    :return:
+    """
+    reg_name = runner_utils.get_param_for_module(block_id, block_dict, 'name')
+    failure_reason = "Fetching registry information for {0}".format(reg_name)
+    return failure_reason

--- a/hubblestack/audit/win_secedit.py
+++ b/hubblestack/audit/win_secedit.py
@@ -463,7 +463,7 @@ def _get_account_name(account_id):
 
 def get_failure_reason(block_id, block_dict, extra_args=None):
     """
-
+    The function is used to find the action that was performed during the audit check
     :param block_id:
         id of the block
     :param block_dict:
@@ -475,5 +475,4 @@ def get_failure_reason(block_id, block_dict, extra_args=None):
     :return:
     """
     sec_name = runner_utils.get_param_for_module(block_id, block_dict, 'name')
-    failure_reason = "Fetching security configuration  for {0}".format(sec_name)
-    return failure_reason
+    return "Fetching security configuration  for {0}".format(sec_name)

--- a/hubblestack/audit/win_secedit.py
+++ b/hubblestack/audit/win_secedit.py
@@ -459,3 +459,21 @@ def _get_account_name(account_id):
             if sec_value[1:].lower() == value.lower():
                 ret_list.append(key)
     return ret_list
+
+
+def get_failure_reason(block_id, block_dict, extra_args=None):
+    """
+
+    :param block_id:
+        id of the block
+    :param block_dict:
+        parameter for this module
+    :param extra_args:
+        Extra argument dictionary, (If any)
+        Example: {'chaining_args': {'result': "SeRemoteInteractiveLogonRight", 'status': True},
+                  'caller': 'Audit'}
+    :return:
+    """
+    sec_name = runner_utils.get_param_for_module(block_id, block_dict, 'name')
+    failure_reason = "Fetching security configuration  for {0}".format(sec_name)
+    return failure_reason

--- a/hubblestack/module_runner/audit_runner.py
+++ b/hubblestack/module_runner/audit_runner.py
@@ -218,7 +218,9 @@ class AuditRunner(hubblestack.module_runner.runner.Runner):
                 audit_result_local['check_result'] = CHECK_STATUS['Failure']
                 audit_result_local['failure_reason'] = comparator_result if comparator_result else module_result_local[
                     'error']
+                module_failure_reason = self._get_module_failure_reason(audit_impl['module'], audit_id, audit_check)
                 failure_reasons.append(audit_result_local['failure_reason'])
+                failure_reasons.append(module_failure_reason)
             module_logs = {}
             if not verbose:
                 log.debug('Non verbose mode')

--- a/hubblestack/module_runner/runner.py
+++ b/hubblestack/module_runner/runner.py
@@ -150,6 +150,13 @@ class Runner(ABC):
                                                                    'extra_args': extra_args,
                                                                    'caller': self._caller})
 
+    def _get_module_failure_reason(self, module_name, profile_id, module_args):
+        """
+        Helper method to execute a Module's get_failure_reason() method.
+        """
+        failure_reason_method = '{0}.get_failure_reason'.format(module_name)
+        return __hmods__[failure_reason_method](profile_id, module_args, {'caller': self._caller})
+
     def _make_file_available(self, file):
         """
         Cache file if path is salt://...


### PR DESCRIPTION
Adding a method in modules that can tell the audit runner what it was doing. This message can be then clubbed with failure reason from comparator to tell the user what actually failed on the system.