### PR TITLE
check bool() not len() to avoid TypeError and for style points

### DIFF
--- a/hubblestack/grains/docker_details.py
+++ b/hubblestack/grains/docker_details.py
@@ -52,7 +52,7 @@ def _is_docker_installed(grains):
         log.debug("OS not supported")
         return False
     query_result = osquery_util(query_sql=osquery_sql)
-    if len(query_result) != 0:
+    if query_result:
         for result in query_result:
             if isinstance(result, dict):
                 package_name = result.get("name")


### PR DESCRIPTION
This is a really minor thing, but I often test hubble without osquery installed... frequently I don't really care about the output, just the process details of daemon.py and the returners and things...

We get a pretty ungraceful crash if this needlessly checks the length of None; when a simple bool context would do the job.