### PR TITLE
signing verification caching

### DIFF
--- a/hubblestack/utils/signing.py
+++ b/hubblestack/utils/signing.py
@@ -591,7 +591,7 @@ def verify_signature(fname, sfname, public_crt=None, ca_crt=None, extra_crt=None
     if not isinstance(salt_padding_bits_list, (list,tuple)):
         salt_padding_bits_list = [ salt_padding_bits_list ]
 
-    sha256sum = hash_target(fname)
+    sha256sum = ''.join(f'{x:02x}' for x in digest)
 
     for crt,txt,status in x509.public_crt:
         args = { 'signature': sig, 'data': digest }

--- a/hubblestack/utils/signing.py
+++ b/hubblestack/utils/signing.py
@@ -565,7 +565,9 @@ def _cache_key(*files):
 
 VERIFY_CACHE = dict()
 
-def _clean_verify_cache(old=Options.verify_cache_age):
+def _clean_verify_cache(old=None):
+    if old is None:
+        old = Options.verify_cache_age
     if old < 1:
         return
     old = time() - old
@@ -579,7 +581,7 @@ def _clean_verify_cache(old=Options.verify_cache_age):
     for k in to_remove:
         del VERIFY_CACHE[k]
 
-def _get_verify_cache(key, auto_clean=Options.verify_cache_age):
+def _get_verify_cache(key, auto_clean=None):
     _clean_verify_cache(old=auto_clean)
     log.debug('verify_signature()_get_verify_cache(%s) -> %s', key, VERIFY_CACHE.get(key))
     try:

--- a/hubblestack/utils/signing.py
+++ b/hubblestack/utils/signing.py
@@ -558,7 +558,7 @@ def _stat_file(fname):
             return (os.path.abspath(fname), st.st_mtime, st.st_ctime)
         except FileNotFoundError:
             pass
-    return (0,0)
+    return tuple()
 
 def _cache_key(*files):
     return sum((_stat_file(x) for x in files), tuple())


### PR DESCRIPTION
This is meant as a speedup to the verification checking.

I don't think this was ever the source of very much slowdown, but it certainly does seem silly to verify signatures over and over and over for every file in the profile.