### PR TITLE
fixing windows build issue and adding check_unique_id key

### DIFF
--- a/hubblestack/module_runner/audit_runner.py
+++ b/hubblestack/module_runner/audit_runner.py
@@ -59,7 +59,7 @@ class AuditRunner(hubblestack.module_runner.runner.Runner):
                     # Gather boolean expressions in separate list and evaluate after evaluating all other checks.
                     log.debug('Boolean expression found. Gathering it to evaluate later.')
                     boolean_expr_check_list.append({
-                        'check_id': audit_id,
+                        'check_unique_id': audit_id,
                         'audit_impl': audit_impl,
                         'audit_data': audit_data
                     })
@@ -70,8 +70,9 @@ class AuditRunner(hubblestack.module_runner.runner.Runner):
             except (HubbleCheckValidationError, HubbleCheckVersionIncompatibleError) as herror:
                 # add into error/skipped section
                 result_list.append({
-                    'check_id': audit_id,
+                    'check_unique_id': audit_id,
                     'tag': audit_data['tag'],
+                    'check_id': audit_data['tag'],
                     'description': audit_data['description'],
                     'sub_check': audit_data.get('sub_check', False),
                     'check_result': CHECK_STATUS['Error'] if isinstance(herror, HubbleCheckValidationError) else
@@ -146,11 +147,12 @@ class AuditRunner(hubblestack.module_runner.runner.Runner):
         :return:
         """
         audit_result = {
-            "check_id": audit_id,
+            "check_unique_id": audit_id,
             "description": audit_data['description'],
             "audit_profile": audit_profile,
             "sub_check": audit_data.get('sub_check', False),
             "tag": audit_data['tag'],
+            "check_id": audit_data['tag'],
             "module": audit_impl['module'],
             "run_config": {
                 "filter": audit_impl['filter'],
@@ -270,8 +272,9 @@ class AuditRunner(hubblestack.module_runner.runner.Runner):
                 except (HubbleCheckValidationError, HubbleCheckVersionIncompatibleError) as herror:
                     # add into error section
                     boolean_expr_result_list.append({
-                        'check_id': boolean_expr['check_id'],
+                        'check_unique_id': boolean_expr['check_id'],
                         'tag': boolean_expr['audit_data']['tag'],
+                        'check_id': boolean_expr['audit_data']['tag'],
                         'sub_check': boolean_expr['audit_data'].get('sub_check', False),
                         'description': boolean_expr['audit_data']['description'],
                         'check_result': CHECK_STATUS['Error'] if isinstance(herror, HubbleCheckValidationError) else

--- a/pkg/windows/Dockerfile
+++ b/pkg/windows/Dockerfile
@@ -8,7 +8,8 @@
 #                    3. Copy over any other items you want to include with hubble and place them in <host folder>/opt
 #                    4. docker run -it --rm -v <host folder>:c:\data <image_name>
 #build docker image from windowscore
-FROM microsoft/windowsservercore:ltsc2016_old
+#the sha is used here to pin the image that has been working correctly before
+FROM microsoft/windowsservercore@sha256:10e43e24be6eb5f3e19e705a88adb9794b569028f0e0d715d40f25e53e04c3fc
 #Needed to just work
 ENV PYTHONIOENCODING='UTF-8'
 ENV _HOOK_DIR='./pkg/'

--- a/pkg/windows/Dockerfile
+++ b/pkg/windows/Dockerfile
@@ -8,7 +8,7 @@
 #                    3. Copy over any other items you want to include with hubble and place them in <host folder>/opt
 #                    4. docker run -it --rm -v <host folder>:c:\data <image_name>
 #build docker image from windowscore
-FROM microsoft/windowsservercore:ltsc2016
+FROM microsoft/windowsservercore:ltsc2016_old
 #Needed to just work
 ENV PYTHONIOENCODING='UTF-8'
 ENV _HOOK_DIR='./pkg/'


### PR DESCRIPTION
* The newer image of windows server is giving problem while building. Therefore using an old image that has been tested to be working.
Also, renamed the old check_id to check_unique_id and created a new key check_id that has the same value as old version of hubble