### PR TITLE
not installing vcredist anymore, and updated osquery version in windows

### DIFF
--- a/pkg/windows/Dockerfile
+++ b/pkg/windows/Dockerfile
@@ -86,7 +86,7 @@ RUN Set-ExecutionPolicy Bypass -Scope Process -Force; \
  [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]'Tls,Tls11,Tls12'; \
  iex ((New-Object System.Net.WebClient).DownloadString("$env:CHOCO_URL"));
 RUN choco install git nssm -y;
-RUN choco install osquery --version 3.4.0 -y;
+RUN choco install osquery --version 4.6.0.2 -y;
 
 #All the variables used for hubble
 ARG HUBBLE_CHECKOUT=v4.0.0

--- a/pkg/windows/Dockerfile
+++ b/pkg/windows/Dockerfile
@@ -114,10 +114,6 @@ RUN Push-Location C:/temp/hubble; \
   -r package-requirements.txt; \
   Pop-Location;
 
-#Get vcredist prereq for hubble
-RUN $ProgressPreference = 'SilentlyContinue'; \
-  Invoke-WebRequest -Uri 'http://repo.saltstack.com/windows/dependencies/64/vcredist_x64_2008_mfc.exe' -OutFile "C:/temp/hubble/pkg/windows/vcredist.exe"
-
 COPY entrypoint.ps1 C:/temp/
 ENV HUBBLE_CHECKOUT_ENV=$HUBBLE_CHECKOUT
 ENTRYPOINT ["powershell.exe", "C:/temp/entrypoint.ps1"]


### PR DESCRIPTION
* Not installing vcredist because it is only required in windows server 2008/ windows 7 and below. Also,
1. Reduces the build size by 6MBs, which is a 16.66% gain.
2. Greatly improves build time.

* updated osquery version from 3.4.0 to 4.6.0.2