### PR TITLE
I think this will sort out The Elusive Signing Bug

### DIFF
--- a/hubblestack/fileclient.py
+++ b/hubblestack/fileclient.py
@@ -271,6 +271,7 @@ class Client(object):
             to_remove = set(scan_files(scan_target, cachedir)) - set(ret)
             for i,item in enumerate(to_remove):
                 log.debug('cache_dir(%s) to_remove[%d]: %s', path, i, item)
+                os.unlink(item)
 
         return ret
 

--- a/hubblestack/fileserver/__init__.py
+++ b/hubblestack/fileserver/__init__.py
@@ -171,7 +171,8 @@ def reap_fileserver_cache_dir(cache_base, find_func):
                 ret = find_func(filename, saltenv=saltenv)
                 # if we don't actually have the file, lets clean up the cache
                 # object
-                log.debug('REAP file_path=%s, file_rel_path=%s; ret = find_func => %s', ret)
+                log.debug('REAP file_path=%s, file_rel_path=%s; ret = find_func => %s',
+                    file_path, file_rel_path, ret)
                 if ret['path'] == '':
                     log.debug('REAP os.unlink(%s)', file_path)
                     os.unlink(file_path)

--- a/hubblestack/fileserver/__init__.py
+++ b/hubblestack/fileserver/__init__.py
@@ -171,7 +171,9 @@ def reap_fileserver_cache_dir(cache_base, find_func):
                 ret = find_func(filename, saltenv=saltenv)
                 # if we don't actually have the file, lets clean up the cache
                 # object
+                log.debug('REAP file_path=%s, file_rel_path=%s; ret = find_func => %s', ret)
                 if ret['path'] == '':
+                    log.debug('REAP os.unlink(%s)', file_path)
                     os.unlink(file_path)
 
 

--- a/hubblestack/fileserver/roots.py
+++ b/hubblestack/fileserver/roots.py
@@ -137,13 +137,13 @@ def update():
     When we are asked to update (regular interval) lets reap the cache
     """
     try:
-        hubblestack.fileserver.reap_fileserver_cache_dir(
-            os.path.join(__opts__['cachedir'], 'roots', 'hash'),
-            find_file
-        )
-    except (IOError, OSError):
+        reap_target = os.path.join(__opts__['cachedir'], 'roots', 'hash')
+        log.debug('reap_fileserver_cache_dir(%s)', reap_target)
+        hubblestack.fileserver.reap_fileserver_cache_dir(reap_target, find_file)
+    except (IOError, OSError) as e:
         # Hash file won't exist if no files have yet been served up
-        pass
+        # not really an error, but maybe worth noting if we're debugging
+        log.debug('reap_fileserver_cache_dir(%s) error: %s', reap_target, e)
 
     mtime_map_path = os.path.join(__opts__['cachedir'], 'roots', 'mtime_map')
     # data to send on event

--- a/hubblestack/modules/cp.py
+++ b/hubblestack/modules/cp.py
@@ -159,7 +159,8 @@ def cache_file(path, saltenv="base", source_hash=None):
 
 
 def cache_dir(
-    path, saltenv="base", include_empty=False, include_pat=None, exclude_pat=None
+    path, saltenv="base", include_empty=False, include_pat=None, exclude_pat=None,
+    cleanup_existing=True
 ):
     """
     Download and cache everything under a directory from the master
@@ -184,6 +185,10 @@ def cache_dir(
 
         .. versionadded:: 2014.7.0
 
+    cleanup_existing : True
+        Files that don't exist int he source location will be automatically
+        removed from the destination
+
 
     CLI Examples:
 
@@ -192,4 +197,5 @@ def cache_dir(
         salt '*' cp.cache_dir salt://path/to/dir
         salt '*' cp.cache_dir salt://path/to/dir include_pat='E@*.py$'
     """
-    return _client().cache_dir(path, saltenv, include_empty, include_pat, exclude_pat)
+    return _client().cache_dir(path, saltenv, include_empty, include_pat, exclude_pat,
+        cleanup_existing=cleanup_existing)

--- a/hubblestack/modules/hubble.py
+++ b/hubblestack/modules/hubble.py
@@ -743,7 +743,7 @@ def _get_top_data(topfile):
         return list()
 
     except Exception as exc:
-        raise CommandExecutionError('Could not load topfile: {0}'.format(exc))
+        raise CommandExecutionError('Could not load topfile') from exc
 
     if not isinstance(topdata, dict) or 'nova' not in topdata or \
             (not isinstance(topdata['nova'], dict)):

--- a/hubblestack/modules/hubble.py
+++ b/hubblestack/modules/hubble.py
@@ -730,7 +730,10 @@ def _get_top_data(topfile):
     """
     Helper method to retrieve and parse the nova topfile
     """
+    orig_topfile = topfile
     topfile = os.path.join(_hubble_dir()[1], topfile)
+
+    log.debug('reading nova topfile=%s (%s)', topfile, orig_topfile)
 
     try:
         with open(topfile) as handle:

--- a/hubblestack/modules/hubble.py
+++ b/hubblestack/modules/hubble.py
@@ -738,6 +738,10 @@ def _get_top_data(topfile):
     try:
         with open(topfile) as handle:
             topdata = yaml.safe_load(handle)
+    except FileNotFoundError:
+        log.error('could not find any nova topfile')
+        return list()
+
     except Exception as exc:
         raise CommandExecutionError('Could not load topfile: {0}'.format(exc))
 

--- a/hubblestack/modules/hubble.py
+++ b/hubblestack/modules/hubble.py
@@ -740,7 +740,7 @@ def _get_top_data(topfile):
             topdata = yaml.safe_load(handle)
 
     except Exception as exc:
-        log.error('error loading nova topfile: %s', e)
+        log.error('error loading nova topfile: %s', exc)
         return list()
 
     if not isinstance(topdata, dict) or 'nova' not in topdata or \

--- a/hubblestack/modules/hubble.py
+++ b/hubblestack/modules/hubble.py
@@ -738,12 +738,10 @@ def _get_top_data(topfile):
     try:
         with open(topfile) as handle:
             topdata = yaml.safe_load(handle)
-    except FileNotFoundError:
-        log.error('could not find any nova topfile')
-        return list()
 
     except Exception as exc:
-        raise CommandExecutionError('Could not load topfile') from exc
+        log.error('error loading nova topfile: %s', e)
+        return list()
 
     if not isinstance(topdata, dict) or 'nova' not in topdata or \
             (not isinstance(topdata['nova'], dict)):

--- a/hubblestack/modules/hubble.py
+++ b/hubblestack/modules/hubble.py
@@ -588,7 +588,7 @@ def _clean_up_results(results, show_success):
         results.pop('Success')
 
 
-def sync(clean=False):
+def sync(clean=True):
     """
     Sync the nova audit modules and profiles from the saltstack fileserver.
 
@@ -606,9 +606,13 @@ def sync(clean=False):
 
     Returns a boolean representing success
 
-    NOTE: This function will optionally clean out existing files at the cached
-    location, as cp.cache_dir doesn't clean out old files. Pass ``clean=True``
-    to enable this behavior
+    NOTE: This function will optionally clean out files that are already
+    cached, but do not exist in the source location. Historically, this was
+    done with file.remove followed by a fresh copy, but that's unacceptably
+    slow for large repositories, so it was usually disabled. That is now fixed
+    such that cp.cache_dir knows how to clean up files that aren't found in the
+    source repo. The default is to clean up these files; pass ``clean=False``
+    to disable this behavior.
 
     CLI Examples:
 
@@ -623,10 +627,6 @@ def sync(clean=False):
     _nova_module_dir, cached_profile_dir = _hubble_dir()
     saltenv = __mods__['config.get']('hubblestack:nova:saltenv', 'base')
 
-    # Clean previously synced files
-    if clean:
-        __mods__['file.remove'](cached_profile_dir)
-
     synced = []
     # Support optional salt:// in config
     if 'salt://' in nova_profile_dir:
@@ -636,7 +636,7 @@ def sync(clean=False):
         path = 'salt://{0}'.format(nova_profile_dir)
 
     # Sync the files
-    cached = __mods__['cp.cache_dir'](path, saltenv=saltenv)
+    cached = __mods__['cp.cache_dir'](path, saltenv=saltenv, cleanup_existing=True)
 
     if cached and isinstance(cached, list):
         # Success! Trim the paths

--- a/hubblestack/utils/signing.py
+++ b/hubblestack/utils/signing.py
@@ -43,7 +43,6 @@ import re
 import json
 import io as cStringIO
 import hubblestack.utils.platform
-import inspect
 
 from time import time
 from collections import OrderedDict, namedtuple
@@ -848,10 +847,12 @@ def find_wrapf(not_found={'path': '', 'rel': ''}, real_path='path'):
                 return f_path
             if vrg == STATUS.UNKNOWN and not Options.require_verify:
                 return f_path
-            log.debug('claiming %s (%s) not found', path, f_path)
-            for idx,frame in enumerate(inspect.stack()[1:11]):
-                if 'hubblestack' in frame.filename:
-                    log.debug('find caller[%d] %s %s() %s', idx, frame.filename, frame.function, frame.lineno)
+            log.debug('claiming not found: %s (%s)', path, f_path)
+            if os.environ.get('HUBBLE_SIGNING_STACK_DEBUG'):
+                import inspect
+                for idx,frame in enumerate(inspect.stack()[1:60]):
+                    if 'hubblestack' in frame.filename:
+                        log.debug('find caller[%d] %s %s() %s', idx, frame.filename, frame.function, frame.lineno)
             return dict(**not_found)
         return inner
     return wrapper

--- a/hubblestack/utils/signing.py
+++ b/hubblestack/utils/signing.py
@@ -832,7 +832,8 @@ def find_wrapf(not_found={'path': '', 'rel': ''}, real_path='path'):
             sign_path = _p( find_file_f(Options.signature_file_name, saltenv, *a, **kwargs ) )
             cert_path = _p( find_file_f(Options.certificates_file_name, saltenv, *a, **kwargs) )
 
-            log.debug('path: %s | manifest: "%s" | signature: "%s"', path, mani_path, sign_path)
+            log.debug('path: %s | f_path: %s | p_path: %s | manifest: "%s" | signature: "%s"',
+                path, f_path: p_path: mani_path, sign_path)
 
             verify_res = verify_files([p_path],
                                         mfname=mani_path, sfname=sign_path,

--- a/hubblestack/utils/signing.py
+++ b/hubblestack/utils/signing.py
@@ -43,6 +43,7 @@ import re
 import json
 import io as cStringIO
 import hubblestack.utils.platform
+import inspect
 
 from time import time
 from collections import OrderedDict, namedtuple
@@ -833,7 +834,7 @@ def find_wrapf(not_found={'path': '', 'rel': ''}, real_path='path'):
             cert_path = _p( find_file_f(Options.certificates_file_name, saltenv, *a, **kwargs) )
 
             log.debug('path: %s | f_path: %s | p_path: %s | manifest: "%s" | signature: "%s"',
-                path, f_path: p_path: mani_path, sign_path)
+                path, f_path, p_path, mani_path, sign_path)
 
             verify_res = verify_files([p_path],
                                         mfname=mani_path, sfname=sign_path,
@@ -847,7 +848,10 @@ def find_wrapf(not_found={'path': '', 'rel': ''}, real_path='path'):
                 return f_path
             if vrg == STATUS.UNKNOWN and not Options.require_verify:
                 return f_path
-            log.debug('claiming not found')
+            log.debug('claiming %s (%s) not found', path, f_path)
+            for idx,frame in enumerate(inspect.stack()[1:11]):
+                if 'hubblestack' in frame.filename:
+                    log.debug('find caller[%d] %s %s() %s', idx, frame.filename, frame.function, frame.lineno)
             return dict(**not_found)
         return inner
     return wrapper

--- a/hubblestack/utils/signing.py
+++ b/hubblestack/utils/signing.py
@@ -848,7 +848,7 @@ def find_wrapf(not_found={'path': '', 'rel': ''}, real_path='path'):
             if vrg == STATUS.UNKNOWN and not Options.require_verify:
                 return f_path
             log.debug('claiming not found: %s (%s)', path, f_path)
-            if os.environ.get('HUBBLE_SIGNING_STACK_DEBUG'):
+            if log.isEnabledFor(logging.DEBUG):
                 import inspect
                 for idx,frame in enumerate(inspect.stack()[1:60]):
                     if 'hubblestack' in frame.filename:


### PR DESCRIPTION
For the record, the Elusive Signing Bug is a subtle bug where when a file fails the repo signing checks, it's still sometimes served to the code that was looking for it. It was extremely difficult to reproduce for some reason (even though some people could reproduce it every time).

I spent a horrific amount of time tracking this down. I finally determined that `cp.cache_dir` was never meant to be a proper sync. The original authors of hubble.audit.sync provided a `clean` argument that would `file.remove` the cache dir to prevent objects deleted from the repo sticking around after being elided.

The problem is that removing the whole cache and re-downloading it on every schedule loop is expensive, so someone disabled it later. It was probably thought that the regular `file_client.channel.fs.update()` (which invokes the `fileserver.reap_fileserver_cache_dir()`) would properly handle these cases; but it definitely does not appear to do so. 

Essentially the problem is the double cache copy situation:

1. we first copy from the fileserver (roots, or gitfs or whatever) into `roots` (i.e. `/var/cache/hubble/roots`)
2. `cp.cache_dir` then copies from `roots` to `files` (i.e. `/var/cache/hubble/files`)
3. the daemon `file_client.channel.fs.update()` updates the `roots` (but never attempts to clean up the `files` copy).
4. signing needs these files to not be found, which is handled in `roots` but not `files`

It's worth noting that the unwelcome leftover files were at least downloaded in good faith. To get downloaded at all, they either had to be downloaded before signing was a thing or at some point when signing verified they were OK...

But they should definitely get cleaned up when they fail the signing pass.

The fix: I taught `cp.cache_dir` how to notice these files missing in `roots` that exist in `files`. It can now remove them automatically during what should have been a proper sync. Note that the old behavior can be restored by setting `cleanup_existing=False` but I can't think of a scenario where this would be desirable.


There's still the remaining question: 
Why did this affect `hubble.audit` but not `audit.run`?

Answer:
`hubble.audit` uses `cp.cache_dir` to copy the whole thing all at once; but `audit.run` uses `cp.cache_file` and checks the result. Specifically checking one file, will indeed reveal the file is missing in `roots` even if it exists in `files` as a spurious older file. (`module_runner.runner.make_file_available` also uses `cp.cache_file`, so the `hubble.audit` issue is entirely avoided in the successor).

my old (wrong) analysis:
~~Basically the problem is that various parts of the hubble code base read from the fileserver cache directly (rather than using the intended interfaces for such tasks). The repo signing checks are injected into the fileserver `find_file()` mechanisms, which normally trigger a `fileserver.reap_cache_dir()` hit, causing the file to be deleted from the cache.~~

~~But in some cases, apparently, a cache refresh isn't even part of the invocation of the execution module(s) in question. So the "reaping" never happens (at least not during the execution) and the failing file is serv^H^H^H^H read from the cache as if it was OK.~~

~~All this means, that it feels like a race condition to me. Eventually there would have been a cache refresh that would have cleared the failing file (via the reaping mechanism). This patch simply forces the reaping of files that fail the signing check so there's no need to wait for the reaping and no question about when it happens in the case of a signature check failure.~~