### PR TITLE
not assuming that value is an int

### DIFF
--- a/hubblestack/comparators/dict.py
+++ b/hubblestack/comparators/dict.py
@@ -171,7 +171,7 @@ def _compare_dictionary_values(audit_id, result_to_compare, args, errors):
             _compare_dictionary_values(audit_id, value, args, errors)
         else:
             if 'type' in args:
-                ret_status, ret_val = hubblestack.module_runner.comparator.run(audit_id, args, int(value))
+                ret_status, ret_val = hubblestack.module_runner.comparator.run(audit_id, args, value)
                 if not ret_status:
                     errors.append(ret_val)
 


### PR DESCRIPTION
In case the value type is string, it would error out. Instead pass the value as is and let the comparator take action.