### PR TITLE
fixing file caching bug in windows

### DIFF
--- a/hubblestack/fileclient.py
+++ b/hubblestack/fileclient.py
@@ -218,7 +218,7 @@ class Client(object):
         # We want to make sure files start with this *directory*, use
         # '/' explicitly because the master (that's generating the
         # list of files) only runs on POSIX
-        if not path.endswith('/'):
+        if not hubblestack.utils.platform.is_windows() and not path.endswith('/'):
             path = path + '/'
 
         log.info(


### PR DESCRIPTION
The extra '/' appended at the end of the path makes that path only linux specific, creating a problem for windows paths where '\' are used in paths instead of '/'. Not adding the extra '/' at the end of windows path works fine now.