### PR TITLE
pyenv init - no longer sets PATH.

### DIFF
--- a/pkg/amazonlinux2016.09/Dockerfile
+++ b/pkg/amazonlinux2016.09/Dockerfile
@@ -106,11 +106,11 @@ RUN umask 022 \
  && curl -s -S -L "$PYENV_INSTALLER_URL" -o /usr/bin/pyenv-installer \
  && chmod 0755 /usr/bin/pyenv-installer \
  && /usr/bin/pyenv-installer \
- && eval "$(pyenv init -)" \
+ && eval "$(pyenv init --path)" \ 
  && pyenv install $PYENV_VERSION \
  && pyenv global $PYENV_VERSION
 
-RUN eval "$(pyenv init -)" \
+RUN eval "$(pyenv init --path)" \ 
  && pip -v install --upgrade pip
 
 #extract osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg

--- a/pkg/amazonlinux2016.09/entrypoint.sh
+++ b/pkg/amazonlinux2016.09/entrypoint.sh
@@ -26,8 +26,7 @@ cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixe
 
 sed -i -e "s/'.*'/'$HUBBLE_VERSION_ENV'/g" /hubble_build/hubblestack/version.py
 
-eval "$(pyenv init -)"
-
+eval "$(pyenv init --path)"
 # locate some pyenv things
 pyenv_prefix="$(pyenv prefix)"
 python_binary="$(pyenv which python)"

--- a/pkg/centos7/Dockerfile
+++ b/pkg/centos7/Dockerfile
@@ -106,11 +106,11 @@ RUN umask 022 \
  && curl -s -S -L "$PYENV_INSTALLER_URL" -o /usr/bin/pyenv-installer \
  && chmod 0755 /usr/bin/pyenv-installer \
  && /usr/bin/pyenv-installer \
- && eval "$(pyenv init -)" \
+ && eval "$(pyenv init --path)" \ 
  && pyenv install $PYENV_VERSION \
  && pyenv global $PYENV_VERSION
 
-RUN eval "$(pyenv init -)" \
+RUN eval "$(pyenv init --path)" \ 
  && pip -v install --upgrade pip
 
 #extract osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg

--- a/pkg/centos7/entrypoint.sh
+++ b/pkg/centos7/entrypoint.sh
@@ -26,7 +26,7 @@ cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixe
 
 sed -i -e "s/'.*'/'$HUBBLE_VERSION_ENV'/g" /hubble_build/hubblestack/version.py
 
-eval "$(pyenv init -)"
+eval "$(pyenv init --path)"
 
 # locate some pyenv things
 pyenv_prefix="$(pyenv prefix)"

--- a/pkg/centos8/Dockerfile
+++ b/pkg/centos8/Dockerfile
@@ -109,11 +109,11 @@ RUN umask 022 \
  && curl -s -S -L "$PYENV_INSTALLER_URL" -o /usr/bin/pyenv-installer \
  && chmod 0755 /usr/bin/pyenv-installer \
  && /usr/bin/pyenv-installer \
- && eval "$(pyenv init -)" \
+ && eval "$(pyenv init --path)" \ 
  && pyenv install $PYENV_VERSION \
  && pyenv global $PYENV_VERSION
 
-RUN eval "$(pyenv init -)" \
+RUN eval "$(pyenv init --path)" \ 
  && pip -v install --upgrade pip
 
 #extract osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg

--- a/pkg/centos8/entrypoint.sh
+++ b/pkg/centos8/entrypoint.sh
@@ -26,8 +26,7 @@ cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixe
 
 sed -i -e "s/'.*'/'$HUBBLE_VERSION_ENV'/g" /hubble_build/hubblestack/version.py
 
-eval "$(pyenv init -)"
-
+eval "$(pyenv init --path)"
 # locate some pyenv things
 pyenv_prefix="$(pyenv prefix)"
 python_binary="$(pyenv which python)"

--- a/pkg/coreos/Dockerfile
+++ b/pkg/coreos/Dockerfile
@@ -100,11 +100,11 @@ RUN umask 022 \
  && curl -s -S -L "$PYENV_INSTALLER_URL" -o /usr/bin/pyenv-installer \
  && chmod 0755 /usr/bin/pyenv-installer \
  && /usr/bin/pyenv-installer \
- && eval "$(pyenv init -)" \
+ && eval "$(pyenv init --path)" \ 
  && pyenv install $PYENV_VERSION \
  && pyenv global $PYENV_VERSION
 
-RUN eval "$(pyenv init -)" \
+RUN eval "$(pyenv init --path)" \ 
  && pip -v install --upgrade pip
 
 #extract osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg

--- a/pkg/coreos/entrypoint.sh
+++ b/pkg/coreos/entrypoint.sh
@@ -26,8 +26,7 @@ cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixe
 
 sed -i -e "s/'.*'/'$HUBBLE_VERSION_ENV'/g" /hubble_build/hubblestack/version.py
 
-eval "$(pyenv init -)"
-
+eval "$(pyenv init --path)"
 # locate some pyenv things
 pyenv_prefix="$(pyenv prefix)"
 python_binary="$(pyenv which python)"

--- a/pkg/debian10/Dockerfile
+++ b/pkg/debian10/Dockerfile
@@ -108,11 +108,11 @@ RUN umask 022 \
  && curl -s -S -L "$PYENV_INSTALLER_URL" -o /usr/bin/pyenv-installer \
  && chmod 0755 /usr/bin/pyenv-installer \
  && /usr/bin/pyenv-installer \
- && eval "$(pyenv init -)" \
+ && eval "$(pyenv init --path)" \ 
  && pyenv install $PYENV_VERSION \
  && pyenv global $PYENV_VERSION
 
-RUN eval "$(pyenv init -)" \
+RUN eval "$(pyenv init --path)" \ 
  && pip -v install --upgrade pip
 
 #extract osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg

--- a/pkg/debian10/entrypoint.sh
+++ b/pkg/debian10/entrypoint.sh
@@ -26,8 +26,7 @@ cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixe
 
 sed -i -e "s/'.*'/'$HUBBLE_VERSION_ENV'/g" /hubble_build/hubblestack/version.py
 
-eval "$(pyenv init -)"
-
+eval "$(pyenv init --path)"
 # locate some pyenv things
 pyenv_prefix="$(pyenv prefix)"
 python_binary="$(pyenv which python)"

--- a/pkg/debian8/Dockerfile
+++ b/pkg/debian8/Dockerfile
@@ -107,11 +107,11 @@ RUN umask 022 \
  && curl -s -S -L "$PYENV_INSTALLER_URL" -o /usr/bin/pyenv-installer \
  && chmod 0755 /usr/bin/pyenv-installer \
  && /usr/bin/pyenv-installer \
- && eval "$(pyenv init -)" \
+ && eval "$(pyenv init --path)" \ 
  && pyenv install $PYENV_VERSION \
  && pyenv global $PYENV_VERSION
 
-RUN eval "$(pyenv init -)" \
+RUN eval "$(pyenv init --path)" \ 
  && pip -v install --upgrade pip
 
 #extract osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg

--- a/pkg/debian8/entrypoint.sh
+++ b/pkg/debian8/entrypoint.sh
@@ -26,8 +26,7 @@ cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixe
 
 sed -i -e "s/'.*'/'$HUBBLE_VERSION_ENV'/g" /hubble_build/hubblestack/version.py
 
-eval "$(pyenv init -)"
-
+eval "$(pyenv init --path)"
 # locate some pyenv things
 pyenv_prefix="$(pyenv prefix)"
 python_binary="$(pyenv which python)"

--- a/pkg/debian9/Dockerfile
+++ b/pkg/debian9/Dockerfile
@@ -108,11 +108,11 @@ RUN umask 022 \
  && curl -s -S -L "$PYENV_INSTALLER_URL" -o /usr/bin/pyenv-installer \
  && chmod 0755 /usr/bin/pyenv-installer \
  && /usr/bin/pyenv-installer \
- && eval "$(pyenv init -)" \
+ && eval "$(pyenv init --path)" \ 
  && pyenv install $PYENV_VERSION \
  && pyenv global $PYENV_VERSION
 
-RUN eval "$(pyenv init -)" \
+RUN eval "$(pyenv init --path)" \ 
  && pip -v install --upgrade pip
 
 #extract osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg

--- a/pkg/debian9/entrypoint.sh
+++ b/pkg/debian9/entrypoint.sh
@@ -26,8 +26,7 @@ cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixe
 
 sed -i -e "s/'.*'/'$HUBBLE_VERSION_ENV'/g" /hubble_build/hubblestack/version.py
 
-eval "$(pyenv init -)"
-
+eval "$(pyenv init --path)"
 # locate some pyenv things
 pyenv_prefix="$(pyenv prefix)"
 python_binary="$(pyenv which python)"

--- a/pkg/dev/amazonlinux2016.09/Dockerfile
+++ b/pkg/dev/amazonlinux2016.09/Dockerfile
@@ -106,11 +106,11 @@ RUN umask 022 \
  && curl -s -S -L "$PYENV_INSTALLER_URL" -o /usr/bin/pyenv-installer \
  && chmod 0755 /usr/bin/pyenv-installer \
  && /usr/bin/pyenv-installer \
- && eval "$(pyenv init -)" \
+ && eval "$(pyenv init --path)" \ 
  && pyenv install $PYENV_VERSION \
  && pyenv global $PYENV_VERSION
 
-RUN eval "$(pyenv init -)" \
+RUN eval "$(pyenv init --path)" \ 
  && pip -v install --upgrade pip
 
 #extract osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg

--- a/pkg/dev/amazonlinux2016.09/entrypoint.sh
+++ b/pkg/dev/amazonlinux2016.09/entrypoint.sh
@@ -26,8 +26,7 @@ cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixe
 
 sed -i -e "s/'.*'/'$HUBBLE_VERSION_ENV'/g" /hubble_build/hubblestack/version.py
 
-eval "$(pyenv init -)"
-
+eval "$(pyenv init --path)"
 # locate some pyenv things
 pyenv_prefix="$(pyenv prefix)"
 python_binary="$(pyenv which python)"

--- a/pkg/dev/centos7/Dockerfile
+++ b/pkg/dev/centos7/Dockerfile
@@ -106,11 +106,11 @@ RUN umask 022 \
  && curl -s -S -L "$PYENV_INSTALLER_URL" -o /usr/bin/pyenv-installer \
  && chmod 0755 /usr/bin/pyenv-installer \
  && /usr/bin/pyenv-installer \
- && eval "$(pyenv init -)" \
+ && eval "$(pyenv init --path)" \ 
  && pyenv install $PYENV_VERSION \
  && pyenv global $PYENV_VERSION
 
-RUN eval "$(pyenv init -)" \
+RUN eval "$(pyenv init --path)" \ 
  && pip -v install --upgrade pip
 
 #extract osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg

--- a/pkg/dev/centos7/entrypoint.sh
+++ b/pkg/dev/centos7/entrypoint.sh
@@ -26,8 +26,7 @@ cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixe
 
 sed -i -e "s/'.*'/'$HUBBLE_VERSION_ENV'/g" /hubble_build/hubblestack/version.py
 
-eval "$(pyenv init -)"
-
+eval "$(pyenv init --path)"
 # locate some pyenv things
 pyenv_prefix="$(pyenv prefix)"
 python_binary="$(pyenv which python)"

--- a/pkg/dev/centos8/Dockerfile
+++ b/pkg/dev/centos8/Dockerfile
@@ -109,11 +109,11 @@ RUN umask 022 \
  && curl -s -S -L "$PYENV_INSTALLER_URL" -o /usr/bin/pyenv-installer \
  && chmod 0755 /usr/bin/pyenv-installer \
  && /usr/bin/pyenv-installer \
- && eval "$(pyenv init -)" \
+ && eval "$(pyenv init --path)" \ 
  && pyenv install $PYENV_VERSION \
  && pyenv global $PYENV_VERSION
 
-RUN eval "$(pyenv init -)" \
+RUN eval "$(pyenv init --path)" \ 
  && pip -v install --upgrade pip
 
 #extract osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg

--- a/pkg/dev/centos8/entrypoint.sh
+++ b/pkg/dev/centos8/entrypoint.sh
@@ -26,8 +26,7 @@ cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixe
 
 sed -i -e "s/'.*'/'$HUBBLE_VERSION_ENV'/g" /hubble_build/hubblestack/version.py
 
-eval "$(pyenv init -)"
-
+eval "$(pyenv init --path)"
 # locate some pyenv things
 pyenv_prefix="$(pyenv prefix)"
 python_binary="$(pyenv which python)"

--- a/pkg/dev/coreos/Dockerfile
+++ b/pkg/dev/coreos/Dockerfile
@@ -100,11 +100,11 @@ RUN umask 022 \
  && curl -s -S -L "$PYENV_INSTALLER_URL" -o /usr/bin/pyenv-installer \
  && chmod 0755 /usr/bin/pyenv-installer \
  && /usr/bin/pyenv-installer \
- && eval "$(pyenv init -)" \
+ && eval "$(pyenv init --path)" \ 
  && pyenv install $PYENV_VERSION \
  && pyenv global $PYENV_VERSION
 
-RUN eval "$(pyenv init -)" \
+RUN eval "$(pyenv init --path)" \ 
  && pip -v install --upgrade pip
 
 #extract osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg

--- a/pkg/dev/coreos/entrypoint.sh
+++ b/pkg/dev/coreos/entrypoint.sh
@@ -26,8 +26,7 @@ cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixe
 
 sed -i -e "s/'.*'/'$HUBBLE_VERSION_ENV'/g" /hubble_build/hubblestack/version.py
 
-eval "$(pyenv init -)"
-
+eval "$(pyenv init --path)"
 # locate some pyenv things
 pyenv_prefix="$(pyenv prefix)"
 python_binary="$(pyenv which python)"

--- a/pkg/dev/debian10/Dockerfile
+++ b/pkg/dev/debian10/Dockerfile
@@ -108,11 +108,11 @@ RUN umask 022 \
  && curl -s -S -L "$PYENV_INSTALLER_URL" -o /usr/bin/pyenv-installer \
  && chmod 0755 /usr/bin/pyenv-installer \
  && /usr/bin/pyenv-installer \
- && eval "$(pyenv init -)" \
+ && eval "$(pyenv init --path)" \ 
  && pyenv install $PYENV_VERSION \
  && pyenv global $PYENV_VERSION
 
-RUN eval "$(pyenv init -)" \
+RUN eval "$(pyenv init --path)" \ 
  && pip -v install --upgrade pip
 
 #extract osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg

--- a/pkg/dev/debian10/entrypoint.sh
+++ b/pkg/dev/debian10/entrypoint.sh
@@ -26,8 +26,7 @@ cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixe
 
 sed -i -e "s/'.*'/'$HUBBLE_VERSION_ENV'/g" /hubble_build/hubblestack/version.py
 
-eval "$(pyenv init -)"
-
+eval "$(pyenv init --path)"
 # locate some pyenv things
 pyenv_prefix="$(pyenv prefix)"
 python_binary="$(pyenv which python)"

--- a/pkg/dev/debian8/Dockerfile
+++ b/pkg/dev/debian8/Dockerfile
@@ -107,11 +107,11 @@ RUN umask 022 \
  && curl -s -S -L "$PYENV_INSTALLER_URL" -o /usr/bin/pyenv-installer \
  && chmod 0755 /usr/bin/pyenv-installer \
  && /usr/bin/pyenv-installer \
- && eval "$(pyenv init -)" \
+ && eval "$(pyenv init --path)" \ 
  && pyenv install $PYENV_VERSION \
  && pyenv global $PYENV_VERSION
 
-RUN eval "$(pyenv init -)" \
+RUN eval "$(pyenv init --path)" \ 
  && pip -v install --upgrade pip
 
 #extract osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg

--- a/pkg/dev/debian8/entrypoint.sh
+++ b/pkg/dev/debian8/entrypoint.sh
@@ -26,8 +26,7 @@ cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixe
 
 sed -i -e "s/'.*'/'$HUBBLE_VERSION_ENV'/g" /hubble_build/hubblestack/version.py
 
-eval "$(pyenv init -)"
-
+eval "$(pyenv init --path)"
 # locate some pyenv things
 pyenv_prefix="$(pyenv prefix)"
 python_binary="$(pyenv which python)"

--- a/pkg/dev/debian9/Dockerfile
+++ b/pkg/dev/debian9/Dockerfile
@@ -108,11 +108,11 @@ RUN umask 022 \
  && curl -s -S -L "$PYENV_INSTALLER_URL" -o /usr/bin/pyenv-installer \
  && chmod 0755 /usr/bin/pyenv-installer \
  && /usr/bin/pyenv-installer \
- && eval "$(pyenv init -)" \
+ && eval "$(pyenv init --path)" \ 
  && pyenv install $PYENV_VERSION \
  && pyenv global $PYENV_VERSION
 
-RUN eval "$(pyenv init -)" \
+RUN eval "$(pyenv init --path)" \ 
  && pip -v install --upgrade pip
 
 #extract osquery files. optionally pass in osquery filename with OSQUERY_TAR_FILENAME build-arg

--- a/pkg/dev/debian9/entrypoint.sh
+++ b/pkg/dev/debian9/entrypoint.sh
@@ -26,8 +26,7 @@ cp /hubble_build/hubblestack/__init__.py /hubble_build/hubblestack/__init__.fixe
 
 sed -i -e "s/'.*'/'$HUBBLE_VERSION_ENV'/g" /hubble_build/hubblestack/version.py
 
-eval "$(pyenv init -)"
-
+eval "$(pyenv init --path)"
 # locate some pyenv things
 pyenv_prefix="$(pyenv prefix)"
 python_binary="$(pyenv which python)"


### PR DESCRIPTION
While building hubble pip throws error **pyenv init -` no longer sets PATH.** and is not installed. 