### PR TITLE
Loader fixes

### DIFF
--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -704,10 +704,11 @@ def refresh_grains(initial=False):
     persist, old_grains = {}, {}
     if initial:
         if not os.environ.get('NO_PRESERVE_OPTS'):
-            # 'POP' is for tracking persistent opts protection
             if os.environ.get('NOISY_POP_DEBUG'):
                 log.error('POP setting __opts__ to preservable (id=%d)', id(__opts__))
             hubblestack.loader.set_preservable_opts(__opts__)
+        elif os.environ.get('NOISY_POP_DEBUG'):
+            log.error('POP we are not attemting to protect __opts__ from lazyloader reloads')
     else:
         old_grains = copy.deepcopy(__grains__)
         for grain in __opts__.get('grains_persist', []):

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -697,8 +697,16 @@ def refresh_grains(initial=False):
     global __returners__
     global __context__
 
+    # 'POP' is for tracking persistent opts protection
+    log.debug('POP refreshing grains (id=%d)', id(__opts__))
+
     persist, old_grains = {}, {}
-    if not initial:
+    if initial:
+        if not os.environ.get('NO_PRESERVE_OPTS'):
+            # 'POP' is for tracking persistent opts protection
+            log.debug('POP setting __opts__ to preservable (id=%d)', id(__opts__))
+            hubblestack.loader.set_preservable_opts(__opts__)
+    else:
         old_grains = copy.deepcopy(__grains__)
         for grain in __opts__.get('grains_persist', []):
             if grain in __grains__:

--- a/hubblestack/daemon.py
+++ b/hubblestack/daemon.py
@@ -698,13 +698,15 @@ def refresh_grains(initial=False):
     global __context__
 
     # 'POP' is for tracking persistent opts protection
-    log.debug('POP refreshing grains (id=%d)', id(__opts__))
+    if os.environ.get('NOISY_POP_DEBUG'):
+        log.error('POP refreshing grains (id=%d)', id(__opts__))
 
     persist, old_grains = {}, {}
     if initial:
         if not os.environ.get('NO_PRESERVE_OPTS'):
             # 'POP' is for tracking persistent opts protection
-            log.debug('POP setting __opts__ to preservable (id=%d)', id(__opts__))
+            if os.environ.get('NOISY_POP_DEBUG'):
+                log.error('POP setting __opts__ to preservable (id=%d)', id(__opts__))
             hubblestack.loader.set_preservable_opts(__opts__)
     else:
         old_grains = copy.deepcopy(__grains__)

--- a/hubblestack/loader.py
+++ b/hubblestack/loader.py
@@ -76,6 +76,35 @@ PY3_PRE_EXT = \
 # Will be set to pyximport module at runtime if cython is enabled in config.
 pyximport = None
 
+PRESERVABLE_OPTS = dict()
+
+def set_preservable_opts(opts):
+    '''
+    This is a scope hack designed to make sure any __opts__ we pass to the
+    modules can survive recycling of the lazy loaders.
+
+    To be sure, this is to protect an anti-pattern where the modules sometimes
+    store data for reporting in __opts__ (why did we start doing this?).
+
+    We call this from hubblestack.daemon.refresh_grains.
+    '''
+
+    oid = id(opts)
+    if oid not in PRESERVABLE_OPTS:
+        log.debug('setting %d to be preservable opts', oid)
+        PRESERVABLE_OPTS[oid] = opts.copy()
+
+def get_preserved_opts(opts):
+    ''' part of a scope hack, see: set_preservable_opts
+        we call this from __prep_mod_opts to invoke the scope hack
+    '''
+
+    oid = id(opts)
+    ret = PRESERVABLE_OPTS.get(oid)
+    if ret:
+        log.debug('preserved opts found (%d)', oid)
+    return ret
+
 def _module_dirs(
         opts,
         ext_type,
@@ -468,7 +497,7 @@ class LazyLoader(hubblestack.utils.lazy.LazyDict):
     mod_dict_class = hubblestack.utils.odict.OrderedDict
 
     def __del__(self):
-        # clear any possible circular refs
+        log.debug('clearing possible memory leaks by emptying pack, missing_modules and loaded_modules dicts')
         self.pack.clear()
         self.missing_modules.clear()
         self.loaded_modules.clear()
@@ -789,7 +818,15 @@ class LazyLoader(hubblestack.utils.lazy.LazyDict):
             self.context_dict['pillar'] = opts.get('pillar', {})
             self.pack['__pillar__'] = hubblestack.utils.context.NamespacedDictWrapper(self.context_dict, 'pillar')
 
-        return { k,v for k,v in opts.items() if k not in ('logger',) }
+        ret = opts.copy()
+        for item in ('logger',):
+            if item in ret:
+                del ret[item]
+        po = get_preserved_opts(opts)
+        if po is not None:
+            po.update(ret)
+            return po
+        return ret
 
     def _iter_files(self, mod_name):
         '''

--- a/hubblestack/loader.py
+++ b/hubblestack/loader.py
@@ -221,7 +221,9 @@ def modules(
         static_modules=static_modules,
     )
 
-    # XXX: this is the very definition of a circular ref
+    # this is the very definition of a circular ref...  we added a destructor
+    # to deal with this, although the newest pythons periodically detect
+    # detached circular ref items during garbage collection.
     ret.pack['__mods__'] = ret
 
     return ret

--- a/hubblestack/loader.py
+++ b/hubblestack/loader.py
@@ -773,6 +773,7 @@ class LazyLoader(hubblestack.utils.lazy.LazyDict):
         '''
         Strip out of the opts any logger instance
         '''
+
         if '__grains__' not in self.pack:
             self.context_dict['grains'] = opts.get('grains', {})
             self.pack['__grains__'] = hubblestack.utils.context.NamespacedDictWrapper(self.context_dict, 'grains')
@@ -781,12 +782,7 @@ class LazyLoader(hubblestack.utils.lazy.LazyDict):
             self.context_dict['pillar'] = opts.get('pillar', {})
             self.pack['__pillar__'] = hubblestack.utils.context.NamespacedDictWrapper(self.context_dict, 'pillar')
 
-        mod_opts = {}
-        for key, val in list(opts.items()):
-            if key == 'logger':
-                continue
-            mod_opts[key] = val
-        return mod_opts
+        return { k,v for k,v in opts.items() if k not in ('logger',) }
 
     def _iter_files(self, mod_name):
         '''

--- a/hubblestack/loader.py
+++ b/hubblestack/loader.py
@@ -467,6 +467,12 @@ class LazyLoader(hubblestack.utils.lazy.LazyDict):
 
     mod_dict_class = hubblestack.utils.odict.OrderedDict
 
+    def __del__(self):
+        # clear any possible circular refs
+        self.pack.clear()
+        self.missing_modules.clear()
+        self.loaded_modules.clear()
+
     def __init__(self,
                  module_dirs,
                  opts=None,

--- a/hubblestack/loader.py
+++ b/hubblestack/loader.py
@@ -192,6 +192,7 @@ def modules(
         static_modules=static_modules,
     )
 
+    # XXX: this is the very definition of a circular ref
     ret.pack['__mods__'] = ret
 
     return ret

--- a/hubblestack/modules/conf_publisher.py
+++ b/hubblestack/modules/conf_publisher.py
@@ -2,6 +2,7 @@
 """
 Module to send config options to splunk
 """
+import os
 import logging
 import copy
 import hubblestack.log

--- a/hubblestack/modules/conf_publisher.py
+++ b/hubblestack/modules/conf_publisher.py
@@ -49,7 +49,8 @@ def publish(report_directly_to_splunk=True, remove_dots=True, *args):
                 opts_to_log[arg] = __opts__[arg]
 
     # 'POP' is for tracking persistent opts protection
-    log.debug('POP config_publish (id=%d)', id(__opts__))
+    if os.environ.get('NOISY_POP_DEBUG'):
+        log.error('POP config_publish (id=%d)', id(__opts__))
 
     filtered_conf = hubblestack.log.filter_logs(opts_to_log, remove_dots=remove_dots)
 

--- a/hubblestack/modules/conf_publisher.py
+++ b/hubblestack/modules/conf_publisher.py
@@ -48,6 +48,9 @@ def publish(report_directly_to_splunk=True, remove_dots=True, *args):
             if arg in __opts__:
                 opts_to_log[arg] = __opts__[arg]
 
+    # 'POP' is for tracking persistent opts protection
+    log.debug('POP config_publish (id=%d)', id(__opts__))
+
     filtered_conf = hubblestack.log.filter_logs(opts_to_log, remove_dots=remove_dots)
 
     if report_directly_to_splunk:

--- a/hubblestack/modules/nebula_osquery.py
+++ b/hubblestack/modules/nebula_osquery.py
@@ -107,6 +107,9 @@ def queries(query_group,
     if not isinstance(query_file, list):
         query_file = [query_file]
 
+    # 'POP' is for tracking persistent opts protection
+    log.debug('POP adding nebula_queries to __opts__ (id=%d)', id(__opts__))
+
     query_data = _get_query_data(query_file)
     __opts__['nebula_queries'] = query_data
 

--- a/hubblestack/modules/nebula_osquery.py
+++ b/hubblestack/modules/nebula_osquery.py
@@ -108,7 +108,8 @@ def queries(query_group,
         query_file = [query_file]
 
     # 'POP' is for tracking persistent opts protection
-    log.debug('POP adding nebula_queries to __opts__ (id=%d)', id(__opts__))
+    if os.environ.get('NOISY_POP_DEBUG'):
+        log.error('POP adding nebula_queries to __opts__ (id=%d)', id(__opts__))
 
     query_data = _get_query_data(query_file)
     __opts__['nebula_queries'] = query_data

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ build_dependencies = [
     'pyopenssl',
     'requests>=2.13.0',
     'daemon',
+    'defusedxml',
     'pygit2',
     'gitpython',
     'pyinotify',


### PR DESCRIPTION
There's a few things here... not the least of which is a pretty obvious memory leak that we've had for as long as we've had grains-refresh...

The primary purpose of this PR is the 'POP' though. The persistent `__opts__` protection mechanism. It's definitely an anti-pattern that we're logging data by dropping it in config and publishing config... man, I wish we didn't do that, but we do it in a huge number of places. 

Recently, for some reason, the lazy loader refreshes have been resetting some of the `__opts__` return data. I can't see why it hadn't been doing it before now, but it's doing it now... so the solution -- until we address the anti-pattern -- is to trick the lazy loader into preserving __opts__.

Lastly, you may wonder: why is there no unit test to make sure this works?

This was a "Heisenbug." Recreating the bug is difficult. You have to trick the garbage collection into firing at the right time to trigger the bug and hope your config pulisher publishes the broken state. It's probably not possible to recreate in a unit test. Or at least, if you could do it, you couldn't do it reliably.
