### PR TITLE
Handle Unicode decode failure

### DIFF
--- a/hubblestack/fileserver/roots.py
+++ b/hubblestack/fileserver/roots.py
@@ -159,7 +159,6 @@ def update():
     if os.path.exists(mtime_map_path):
         with hubblestack.utils.files.fopen(mtime_map_path, 'rb') as fp_:
             row = 0
-            line = ''
             for line in fp_:
                 try:
                     row += 1


### PR DESCRIPTION
On rare occasion, a line in the cache file is not able to pass the unicode decode.  This skips over that line and continues with the rest, as opposed to failing to start the fileserver service.