### PR TITLE
Fix logging formatting

### DIFF
--- a/hubblestack/fileclient.py
+++ b/hubblestack/fileclient.py
@@ -41,7 +41,7 @@ log = logging.getLogger(__name__)
 MAX_FILENAME_LENGTH = 255
 
 
-def get_file_client(opts, pillar=False):
+def get_file_client(opts):
     '''
     Read in the ``file_client`` option and return the correct type of file
     server
@@ -257,7 +257,7 @@ class Client(object):
                         os.makedirs(minion_dir)
                     ret.append(minion_dir)
 
-        def scan_files(target, cachedir):
+        def scan_files(target):
             log.debug('cache_dir(%s) scanning %s for files that should be removed', path, target)
             for wpath, dirs, files in os.walk(target):
                 for file in files:
@@ -688,7 +688,7 @@ class Client(object):
                 hubblestack.utils.files.rename(dest_tmp, dest)
                 return dest
         except HTTPError as exc:
-            raise MinionError('HTTP error {0} reading {1}: {3}'.format(
+            raise MinionError('HTTP error {0} reading {1}: {2}'.format(
                 exc.code,
                 url,
                 BaseHTTPRequestHandler.responses[exc.code]))

--- a/hubblestack/fileclient.py
+++ b/hubblestack/fileclient.py
@@ -256,7 +256,7 @@ class Client(object):
             cachedir = self.get_cachedir(cachedir)
             scan_target = os.path.join(cachedir, "files", saltenv, path)
             log.debug("cache_dir(%s) cleanup_existing is set", path)
-            to_remove = set(scan_files(scan_target, cachedir)) - set(ret)
+            to_remove = set(scan_files(scan_target)) - set(ret)
             for i, item in enumerate(to_remove):
                 log.debug("cache_dir(%s) to_remove[%d]: %s", path, i, item)
                 os.unlink(item)

--- a/hubblestack/fileclient.py
+++ b/hubblestack/fileclient.py
@@ -476,7 +476,7 @@ class Client(object):
                     form = hubblestack.utils.files.HASHES_REVMAP[len(source_hash)]
                     if hubblestack.utils.hashutils.get_hash(dest, form) == source_hash:
                         log.debug(
-                            "Cached copy of %s (%s) matches source_hash %s, " "skipping download",
+                            "Cached copy of %s (%s) matches source_hash %s, skipping download",
                             url,
                             dest,
                             source_hash,
@@ -775,11 +775,11 @@ class RemoteClient(Client):
         if not dest2check:
             rel_path = self._check_proto(path)
 
-            log.debug("In saltenv '%s', looking at rel_path '%s' to resolve " "'%s'", saltenv, rel_path, path)
+            log.debug("In saltenv '%s', looking at rel_path '%s' to resolve '%s'", saltenv, rel_path, path)
             with self._cache_loc(rel_path, saltenv, cachedir=cachedir) as cache_dest:
                 dest2check = cache_dest
 
-        log.debug("In saltenv '%s', ** considering ** path '%s' to resolve " "'%s'", saltenv, dest2check, path)
+        log.debug("In saltenv '%s', ** considering ** path '%s' to resolve '%s'", saltenv, dest2check, path)
 
         if dest2check and os.path.isfile(dest2check):
             if not hubblestack.utils.platform.is_windows():

--- a/hubblestack/fileclient.py
+++ b/hubblestack/fileclient.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-'''
+"""
 Classes that manage file clients
-'''
+"""
 
 # Import python libs
 import contextlib
@@ -18,9 +18,7 @@ from http.server import BaseHTTPRequestHandler
 import hubblestack.utils.atomicfile
 
 # Import salt libs
-from hubblestack.exceptions import (
-    CommandExecutionError, MinionError
-)
+from hubblestack.exceptions import CommandExecutionError, MinionError
 import hubblestack.loader
 import hubblestack.payload
 import hubblestack.fileserver
@@ -42,23 +40,22 @@ MAX_FILENAME_LENGTH = 255
 
 
 def get_file_client(opts):
-    '''
+    """
     Read in the ``file_client`` option and return the correct type of file
     server
-    '''
-    client = opts.get('file_client', 'remote')
-    return {
-        'remote': RemoteClient,
-        'local': FSClient,
-    }.get(client, RemoteClient)(opts)
+    """
+    client = opts.get("file_client", "remote")
+    return {"remote": RemoteClient, "local": FSClient,}.get(
+        client, RemoteClient
+    )(opts)
 
 
 def decode_dict_keys_to_str(src):
-    '''
+    """
     Convert top level keys from bytes to strings if possible.
     This is necessary because Python 3 makes a distinction
     between these types.
-    '''
+    """
     if not isinstance(src, dict):
         return src
 
@@ -74,9 +71,10 @@ def decode_dict_keys_to_str(src):
 
 
 class Client(object):
-    '''
+    """
     Base class for Salt file interactions
-    '''
+    """
+
     def __init__(self, opts):
         self.opts = opts
         self.utils = hubblestack.loader.utils(self.opts)
@@ -90,24 +88,24 @@ class Client(object):
     def __setstate__(self, state):
         # This will polymorphically call __init__
         # in the derived class.
-        self.__init__(state['opts'])
+        self.__init__(state["opts"])
 
     def __getstate__(self):
-        return {'opts': self.opts}
+        return {"opts": self.opts}
 
     def _check_proto(self, path):
-        '''
+        """
         Make sure that this path is intended for the salt master and trim it
-        '''
-        if not path.startswith('salt://'):
-            raise MinionError('Unsupported path: {0}'.format(path))
+        """
+        if not path.startswith("salt://"):
+            raise MinionError("Unsupported path: {0}".format(path))
         file_path, saltenv = hubblestack.utils.url.parse(path)
         return file_path
 
     def _file_local_list(self, dest):
-        '''
+        """
         Helper util to return a list of files in a directory
-        '''
+        """
         if os.path.isdir(dest):
             destdir = dest
         else:
@@ -123,15 +121,12 @@ class Client(object):
         return filelist
 
     @contextlib.contextmanager
-    def _cache_loc(self, path, saltenv='base', cachedir=None):
-        '''
+    def _cache_loc(self, path, saltenv="base", cachedir=None):
+        """
         Return the local location to cache the file, cache dirs will be made
-        '''
+        """
         cachedir = self.get_cachedir(cachedir)
-        dest = hubblestack.utils.path.join(cachedir,
-                                    'files',
-                                    saltenv,
-                                    path)
+        dest = hubblestack.utils.path.join(cachedir, "files", saltenv, path)
         destdir = os.path.dirname(dest)
         with hubblestack.utils.files.set_umask(0o077):
             # remove destdir if it is a regular file to avoid an OSError when
@@ -150,89 +145,82 @@ class Client(object):
 
     def get_cachedir(self, cachedir=None):
         if cachedir is None:
-            cachedir = self.opts['cachedir']
+            cachedir = self.opts["cachedir"]
         elif not os.path.isabs(cachedir):
-            cachedir = os.path.join(self.opts['cachedir'], cachedir)
+            cachedir = os.path.join(self.opts["cachedir"], cachedir)
         return cachedir
 
-    def get_file(self,
-                 path,
-                 dest='',
-                 makedirs=False,
-                 saltenv='base',
-                 gzip=None,
-                 cachedir=None):
-        '''
+    def get_file(self, path, dest="", makedirs=False, saltenv="base", gzip=None, cachedir=None):
+        """
         Copies a file from the local files or master depending on
         implementation
-        '''
+        """
         raise NotImplementedError
 
-    def file_list_emptydirs(self, saltenv='base', prefix=''):
-        '''
+    def file_list_emptydirs(self, saltenv="base", prefix=""):
+        """
         List the empty dirs
-        '''
+        """
         raise NotImplementedError
 
-    def cache_file(self, path, saltenv='base', cachedir=None, source_hash=None):
-        '''
+    def cache_file(self, path, saltenv="base", cachedir=None, source_hash=None):
+        """
         Pull a file down from the file server and store it in the minion
         file cache
-        '''
-        return self.get_url(
-            path, '', True, saltenv, cachedir=cachedir, source_hash=source_hash)
+        """
+        return self.get_url(path, "", True, saltenv, cachedir=cachedir, source_hash=source_hash)
 
-    def cache_files(self, paths, saltenv='base', cachedir=None):
-        '''
+    def cache_files(self, paths, saltenv="base", cachedir=None):
+        """
         Download a list of files stored on the master and put them in the
         minion file cache
-        '''
+        """
         ret = []
         if isinstance(paths, str):
-            paths = paths.split(',')
+            paths = paths.split(",")
         for path in paths:
             ret.append(self.cache_file(path, saltenv, cachedir=cachedir))
         return ret
 
-    def cache_master(self, saltenv='base', cachedir=None):
-        '''
+    def cache_master(self, saltenv="base", cachedir=None):
+        """
         Download and cache all files on a master in a specified environment
-        '''
+        """
         ret = []
         for path in self.file_list(saltenv):
-            ret.append(
-                self.cache_file(
-                    hubblestack.utils.url.create(path), saltenv, cachedir=cachedir)
-            )
+            ret.append(self.cache_file(hubblestack.utils.url.create(path), saltenv, cachedir=cachedir))
         return ret
 
-    def cache_dir(self, path, saltenv='base', include_empty=False,
-                  include_pat=None, exclude_pat=None, cachedir=None,
-                  cleanup_existing=True):
-        '''
+    def cache_dir(
+        self,
+        path,
+        saltenv="base",
+        include_empty=False,
+        include_pat=None,
+        exclude_pat=None,
+        cachedir=None,
+        cleanup_existing=True,
+    ):
+        """
         Download all of the files in a subdir of the master
-        '''
+        """
         ret = []
 
         path = self._check_proto(hubblestack.utils.data.decode(path))
         # We want to make sure files start with this *directory*, use
         # '/' explicitly because the master (that's generating the
         # list of files) only runs on POSIX
-        if not hubblestack.utils.platform.is_windows() and not path.endswith('/'):
-            path = path + '/'
+        if not hubblestack.utils.platform.is_windows() and not path.endswith("/"):
+            path = path + "/"
 
-        log.info(
-            'Caching directory \'%s\' for environment \'%s\'', path, saltenv
-        )
+        log.info("Caching directory '%s' for environment '%s'", path, saltenv)
         # go through the list of all files finding ones that are in
         # the target directory and caching them
         for fn_ in self.file_list(saltenv):
             fn_ = hubblestack.utils.data.decode(fn_)
             if fn_.strip() and fn_.startswith(path):
-                if hubblestack.utils.stringutils.check_include_exclude(
-                        fn_, include_pat, exclude_pat):
-                    fn_ = self.cache_file(
-                        hubblestack.utils.url.create(fn_), saltenv, cachedir=cachedir)
+                if hubblestack.utils.stringutils.check_include_exclude(fn_, include_pat, exclude_pat):
+                    fn_ = self.cache_file(hubblestack.utils.url.create(fn_), saltenv, cachedir=cachedir)
                     if fn_:
                         ret.append(fn_)
 
@@ -248,39 +236,38 @@ class Client(object):
             #     prefix = separated[0]
             cachedir = self.get_cachedir(cachedir)
 
-            dest = hubblestack.utils.path.join(cachedir, 'files', saltenv)
+            dest = hubblestack.utils.path.join(cachedir, "files", saltenv)
             for fn_ in self.file_list_emptydirs(saltenv):
                 fn_ = hubblestack.utils.data.decode(fn_)
                 if fn_.startswith(path):
-                    minion_dir = '{0}/{1}'.format(dest, fn_)
+                    minion_dir = "{0}/{1}".format(dest, fn_)
                     if not os.path.isdir(minion_dir):
                         os.makedirs(minion_dir)
                     ret.append(minion_dir)
 
         def scan_files(target):
-            log.debug('cache_dir(%s) scanning %s for files that should be removed', path, target)
+            log.debug("cache_dir(%s) scanning %s for files that should be removed", path, target)
             for wpath, dirs, files in os.walk(target):
                 for file in files:
-                    log.trace('cache_dir(%s) %s/%s seems potentially to be worth removing', path, wpath, file)
-                    yield os.path.join(wpath,file)
+                    log.trace("cache_dir(%s) %s/%s seems potentially to be worth removing", path, wpath, file)
+                    yield os.path.join(wpath, file)
 
         if cleanup_existing:
             cachedir = self.get_cachedir(cachedir)
-            scan_target = os.path.join(cachedir, 'files', saltenv, path)
-            log.debug('cache_dir(%s) cleanup_existing is set', path)
+            scan_target = os.path.join(cachedir, "files", saltenv, path)
+            log.debug("cache_dir(%s) cleanup_existing is set", path)
             to_remove = set(scan_files(scan_target, cachedir)) - set(ret)
-            for i,item in enumerate(to_remove):
-                log.debug('cache_dir(%s) to_remove[%d]: %s', path, i, item)
+            for i, item in enumerate(to_remove):
+                log.debug("cache_dir(%s) to_remove[%d]: %s", path, i, item)
                 os.unlink(item)
 
         return ret
 
     def cache_local_file(self, path, **kwargs):
-        '''
+        """
         Cache a local file on the minion in the localfiles cache
-        '''
-        dest = os.path.join(self.opts['cachedir'], 'localfiles',
-                            path.lstrip('/'))
+        """
+        dest = os.path.join(self.opts["cachedir"], "localfiles", path.lstrip("/"))
         destdir = os.path.dirname(dest)
 
         if not os.path.isdir(destdir):
@@ -289,41 +276,41 @@ class Client(object):
         shutil.copyfile(path, dest)
         return dest
 
-    def file_local_list(self, saltenv='base'):
-        '''
+    def file_local_list(self, saltenv="base"):
+        """
         List files in the local minion files and localfiles caches
-        '''
-        filesdest = os.path.join(self.opts['cachedir'], 'files', saltenv)
-        localfilesdest = os.path.join(self.opts['cachedir'], 'localfiles')
+        """
+        filesdest = os.path.join(self.opts["cachedir"], "files", saltenv)
+        localfilesdest = os.path.join(self.opts["cachedir"], "localfiles")
 
         fdest = self._file_local_list(filesdest)
         ldest = self._file_local_list(localfilesdest)
         return sorted(fdest.union(ldest))
 
-    def file_list(self, saltenv='base', prefix=''):
-        '''
+    def file_list(self, saltenv="base", prefix=""):
+        """
         This function must be overwritten
-        '''
+        """
         return []
 
-    def dir_list(self, saltenv='base', prefix=''):
-        '''
+    def dir_list(self, saltenv="base", prefix=""):
+        """
         This function must be overwritten
-        '''
+        """
         return []
 
-    def symlink_list(self, saltenv='base', prefix=''):
-        '''
+    def symlink_list(self, saltenv="base", prefix=""):
+        """
         This function must be overwritten
-        '''
+        """
         return {}
 
-    def is_cached(self, path, saltenv='base', cachedir=None):
-        '''
+    def is_cached(self, path, saltenv="base", cachedir=None):
+        """
         Returns the full path to a file if it is cached locally on the minion
         otherwise returns a blank string
-        '''
-        if path.startswith('salt://'):
+        """
+        if path.startswith("salt://"):
             path, senv = hubblestack.utils.url.parse(path)
             if senv:
                 saltenv = senv
@@ -331,70 +318,65 @@ class Client(object):
         escaped = True if hubblestack.utils.url.is_escaped(path) else False
 
         # also strip escape character '|'
-        localsfilesdest = os.path.join(
-            self.opts['cachedir'], 'localfiles', path.lstrip('|/'))
-        filesdest = os.path.join(
-            self.opts['cachedir'], 'files', saltenv, path.lstrip('|/'))
+        localsfilesdest = os.path.join(self.opts["cachedir"], "localfiles", path.lstrip("|/"))
+        filesdest = os.path.join(self.opts["cachedir"], "files", saltenv, path.lstrip("|/"))
         extrndest = self._extrn_path(path, saltenv, cachedir=cachedir)
 
         if os.path.exists(filesdest):
             return hubblestack.utils.url.escape(filesdest) if escaped else filesdest
         elif os.path.exists(localsfilesdest):
-            return hubblestack.utils.url.escape(localsfilesdest) \
-                if escaped \
-                else localsfilesdest
+            return hubblestack.utils.url.escape(localsfilesdest) if escaped else localsfilesdest
         elif os.path.exists(extrndest):
             return extrndest
 
-        return ''
+        return ""
 
     def list_states(self, saltenv):
-        '''
+        """
         Return a list of all available sls modules on the master for a given
         environment
-        '''
+        """
         states = set()
         for path in self.file_list(saltenv):
             if hubblestack.utils.platform.is_windows():
-                path = path.replace('\\', '/')
-            if path.endswith('.sls'):
+                path = path.replace("\\", "/")
+            if path.endswith(".sls"):
                 # is an sls module!
-                if path.endswith('/init.sls'):
-                    states.add(path.replace('/', '.')[:-9])
+                if path.endswith("/init.sls"):
+                    states.add(path.replace("/", ".")[:-9])
                 else:
-                    states.add(path.replace('/', '.')[:-4])
+                    states.add(path.replace("/", ".")[:-4])
         return sorted(states)
 
     def get_state(self, sls, saltenv, cachedir=None):
-        '''
+        """
         Get a state file from the master and store it in the local minion
         cache; return the location of the file
-        '''
-        if '.' in sls:
-            sls = sls.replace('.', '/')
-        sls_url = hubblestack.utils.url.create(sls + '.sls')
-        init_url = hubblestack.utils.url.create(sls + '/init.sls')
+        """
+        if "." in sls:
+            sls = sls.replace(".", "/")
+        sls_url = hubblestack.utils.url.create(sls + ".sls")
+        init_url = hubblestack.utils.url.create(sls + "/init.sls")
         for path in [sls_url, init_url]:
             dest = self.cache_file(path, saltenv, cachedir=cachedir)
             if dest:
-                return {'source': path, 'dest': dest}
+                return {"source": path, "dest": dest}
         return {}
 
-    def get_dir(self, path, dest='', saltenv='base', gzip=None,
-                cachedir=None):
-        '''
+    def get_dir(self, path, dest="", saltenv="base", gzip=None, cachedir=None):
+        """
         Get a directory recursively from the salt-master
-        '''
+        """
         ret = []
         # Strip trailing slash
-        path = self._check_proto(path).rstrip('/')
+        path = self._check_proto(path).rstrip("/")
         # Break up the path into a list containing the bottom-level directory
         # (the one being recursively copied) and the directories preceding it
-        separated = path.rsplit('/', 1)
+        separated = path.rsplit("/", 1)
         if len(separated) != 2:
             # No slashes in path. (This means all files in saltenv will be
             # copied)
-            prefix = ''
+            prefix = ""
         else:
             prefix = separated[0]
 
@@ -403,19 +385,17 @@ class Client(object):
             # Prevent files in "salt://foobar/" (or salt://foo.sh) from
             # matching a path of "salt://foo"
             try:
-                if fn_[len(path)] != '/':
+                if fn_[len(path)] != "/":
                     continue
             except IndexError:
                 continue
             # Remove the leading directories from path to derive
             # the relative path on the minion.
-            minion_relpath = fn_[len(prefix):].lstrip('/')
+            minion_relpath = fn_[len(prefix) :].lstrip("/")
             ret.append(
-               self.get_file(
-                  hubblestack.utils.url.create(fn_),
-                  '{0}/{1}'.format(dest, minion_relpath),
-                  True, saltenv, gzip
-               )
+                self.get_file(
+                    hubblestack.utils.url.create(fn_), "{0}/{1}".format(dest, minion_relpath), True, saltenv, gzip
+                )
             )
         # Replicate empty dirs from master
         try:
@@ -423,14 +403,14 @@ class Client(object):
                 # Prevent an empty dir "salt://foobar/" from matching a path of
                 # "salt://foo"
                 try:
-                    if fn_[len(path)] != '/':
+                    if fn_[len(path)] != "/":
                         continue
                 except IndexError:
                     continue
                 # Remove the leading directories from path to derive
                 # the relative path on the minion.
-                minion_relpath = fn_[len(prefix):].lstrip('/')
-                minion_mkdir = '{0}/{1}'.format(dest, minion_relpath)
+                minion_relpath = fn_[len(prefix) :].lstrip("/")
+                minion_mkdir = "{0}/{1}".format(dest, minion_relpath)
                 if not os.path.isdir(minion_mkdir):
                     os.makedirs(minion_mkdir)
                 ret.append(minion_mkdir)
@@ -439,23 +419,20 @@ class Client(object):
         ret.sort()
         return ret
 
-    def get_url(self, url, dest, makedirs=False, saltenv='base',
-                no_cache=False, cachedir=None, source_hash=None):
-        '''
+    def get_url(self, url, dest, makedirs=False, saltenv="base", no_cache=False, cachedir=None, source_hash=None):
+        """
         Get a single file from a URL.
-        '''
+        """
         url_data = urlparse(url)
         url_scheme = url_data.scheme
-        url_path = os.path.join(
-                url_data.netloc, url_data.path).rstrip(os.sep)
+        url_path = os.path.join(url_data.netloc, url_data.path).rstrip(os.sep)
 
         # If dest is a directory, rewrite dest with filename
-        if dest is not None \
-                and (os.path.isdir(dest) or dest.endswith(('/', '\\'))):
-            if url_data.query or len(url_data.path) > 1 and not url_data.path.endswith('/'):
-                strpath = url.split('/')[-1]
+        if dest is not None and (os.path.isdir(dest) or dest.endswith(("/", "\\"))):
+            if url_data.query or len(url_data.path) > 1 and not url_data.path.endswith("/"):
+                strpath = url.split("/")[-1]
             else:
-                strpath = 'index.html'
+                strpath = "index.html"
 
             if hubblestack.utils.platform.is_windows():
                 strpath = hubblestack.utils.path.sanitize_win_path(strpath)
@@ -463,25 +440,23 @@ class Client(object):
             dest = os.path.join(dest, strpath)
 
         if url_scheme and url_scheme.lower() in string.ascii_lowercase:
-            url_path = ':'.join((url_scheme, url_path))
-            url_scheme = 'file'
+            url_path = ":".join((url_scheme, url_path))
+            url_scheme = "file"
 
-        if url_scheme in ('file', ''):
+        if url_scheme in ("file", ""):
             # Local filesystem
             if not os.path.isabs(url_path):
-                raise CommandExecutionError(
-                    'Path \'{0}\' is not absolute'.format(url_path)
-                )
+                raise CommandExecutionError("Path '{0}' is not absolute".format(url_path))
             if dest is None:
-                with hubblestack.utils.files.fopen(url_path, 'rb') as fp_:
+                with hubblestack.utils.files.fopen(url_path, "rb") as fp_:
                     data = fp_.read()
                 return data
             return url_path
 
-        if url_scheme == 'salt':
+        if url_scheme == "salt":
             result = self.get_file(url, dest, makedirs, saltenv, cachedir=cachedir)
             if result and dest is None:
-                with hubblestack.utils.files.fopen(result, 'rb') as fp_:
+                with hubblestack.utils.files.fopen(result, "rb") as fp_:
                     data = fp_.read()
                 return data
             return result
@@ -492,17 +467,19 @@ class Client(object):
                 if makedirs:
                     os.makedirs(destdir)
                 else:
-                    return ''
+                    return ""
         elif not no_cache:
             dest = self._extrn_path(url, saltenv, cachedir=cachedir)
             if source_hash is not None:
                 try:
-                    source_hash = source_hash.split('=')[-1]
+                    source_hash = source_hash.split("=")[-1]
                     form = hubblestack.utils.files.HASHES_REVMAP[len(source_hash)]
                     if hubblestack.utils.hashutils.get_hash(dest, form) == source_hash:
                         log.debug(
-                            'Cached copy of %s (%s) matches source_hash %s, '
-                            'skipping download', url, dest, source_hash
+                            "Cached copy of %s (%s) matches source_hash %s, " "skipping download",
+                            url,
+                            dest,
+                            source_hash,
                         )
                         return dest
                 except (AttributeError, KeyError, IOError, OSError):
@@ -511,60 +488,61 @@ class Client(object):
             if not os.path.isdir(destdir):
                 os.makedirs(destdir)
 
-        if url_data.scheme == 's3':
+        if url_data.scheme == "s3":
             try:
+
                 def s3_opt(key, default=None):
-                    '''
+                    """
                     Get value of s3.<key> from Minion config or from Pillar
-                    '''
-                    if 's3.' + key in self.opts:
-                        return self.opts['s3.' + key]
+                    """
+                    if "s3." + key in self.opts:
+                        return self.opts["s3." + key]
                     try:
-                        return self.opts['pillar']['s3'][key]
+                        return self.opts["pillar"]["s3"][key]
                     except (KeyError, TypeError):
                         return default
-                self.utils['s3.query'](method='GET',
-                                       bucket=url_data.netloc,
-                                       path=url_data.path[1:],
-                                       return_bin=False,
-                                       local_file=dest,
-                                       action=None,
-                                       key=s3_opt('key'),
-                                       keyid=s3_opt('keyid'),
-                                       service_url=s3_opt('service_url'),
-                                       verify_ssl=s3_opt('verify_ssl', True),
-                                       location=s3_opt('location'),
-                                       path_style=s3_opt('path_style', False),
-                                       https_enable=s3_opt('https_enable', True))
+
+                self.utils["s3.query"](
+                    method="GET",
+                    bucket=url_data.netloc,
+                    path=url_data.path[1:],
+                    return_bin=False,
+                    local_file=dest,
+                    action=None,
+                    key=s3_opt("key"),
+                    keyid=s3_opt("keyid"),
+                    service_url=s3_opt("service_url"),
+                    verify_ssl=s3_opt("verify_ssl", True),
+                    location=s3_opt("location"),
+                    path_style=s3_opt("path_style", False),
+                    https_enable=s3_opt("https_enable", True),
+                )
                 return dest
             except Exception as exc:
-                raise MinionError(
-                    'Could not fetch from {0}. Exception: {1}'.format(url, exc)
-                )
-        if url_data.scheme == 'ftp':
+                raise MinionError("Could not fetch from {0}. Exception: {1}".format(url, exc))
+        if url_data.scheme == "ftp":
             try:
                 ftp = ftplib.FTP()
                 ftp.connect(url_data.hostname, url_data.port)
                 ftp.login(url_data.username, url_data.password)
-                remote_file_path = url_data.path.lstrip('/')
-                with hubblestack.utils.files.fopen(dest, 'wb') as fp_:
-                    ftp.retrbinary('RETR {0}'.format(remote_file_path), fp_.write)
+                remote_file_path = url_data.path.lstrip("/")
+                with hubblestack.utils.files.fopen(dest, "wb") as fp_:
+                    ftp.retrbinary("RETR {0}".format(remote_file_path), fp_.write)
                 ftp.quit()
                 return dest
             except Exception as exc:
-                raise MinionError('Could not retrieve {0} from FTP server. Exception: {1}'.format(url, exc))
+                raise MinionError("Could not retrieve {0} from FTP server. Exception: {1}".format(url, exc))
 
         get_kwargs = {}
-        if url_data.username is not None \
-                and url_data.scheme in ('http', 'https'):
+        if url_data.username is not None and url_data.scheme in ("http", "https"):
             netloc = url_data.netloc
-            at_sign_pos = netloc.rfind('@')
+            at_sign_pos = netloc.rfind("@")
             if at_sign_pos != -1:
-                netloc = netloc[at_sign_pos + 1:]
+                netloc = netloc[at_sign_pos + 1 :]
             fixed_url = urlunparse(
-                (url_data.scheme, netloc, url_data.path,
-                 url_data.params, url_data.query, url_data.fragment))
-            get_kwargs['auth'] = (url_data.username, url_data.password)
+                (url_data.scheme, netloc, url_data.path, url_data.params, url_data.query, url_data.fragment)
+            )
+            get_kwargs["auth"] = (url_data.username, url_data.password)
         else:
             fixed_url = url
 
@@ -600,7 +578,7 @@ class Client(object):
 
             def on_header(hdr):
                 if write_body[1] is not False and write_body[2] is None:
-                    if not hdr.strip() and 'Content-Type' not in write_body[1]:
+                    if not hdr.strip() and "Content-Type" not in write_body[1]:
                         # If write_body[0] is True, then we are not following a
                         # redirect (initial response was a 200 OK). So there is
                         # no need to reset write_body[0].
@@ -614,16 +592,16 @@ class Client(object):
                     # Try to find out what content type encoding is used if
                     # this is a text file
                     write_body[1].parse_line(hdr)  # pylint: disable=no-member
-                    if 'Content-Type' in write_body[1]:
-                        content_type = write_body[1].get('Content-Type')  # pylint: disable=no-member
-                        if not content_type.startswith('text'):
+                    if "Content-Type" in write_body[1]:
+                        content_type = write_body[1].get("Content-Type")  # pylint: disable=no-member
+                        if not content_type.startswith("text"):
                             write_body[1] = write_body[2] = False
                         else:
-                            encoding = 'utf-8'
-                            fields = content_type.split(';')
+                            encoding = "utf-8"
+                            fields = content_type.split(";")
                             for field in fields:
-                                if 'encoding' in field:
-                                    encoding = field.split('encoding=')[-1]
+                                if "encoding" in field:
+                                    encoding = field.split("encoding=")[-1]
                             write_body[2] = encoding
                             # We have found our encoding. Stop processing headers.
                             write_body[1] = False
@@ -656,11 +634,12 @@ class Client(object):
                         if write_body[2]:
                             chunk = chunk.decode(write_body[2])
                         result.append(chunk)
+
             else:
-                dest_tmp = u"{0}.part".format(dest)
+                dest_tmp = "{0}.part".format(dest)
                 # We need an open filehandle to use in the on_chunk callback,
                 # that's why we're not using a with clause here.
-                destfp = hubblestack.utils.files.fopen(dest_tmp, 'wb')  # pylint: disable=resource-leakage
+                destfp = hubblestack.utils.files.fopen(dest_tmp, "wb")  # pylint: disable=resource-leakage
 
                 def on_chunk(chunk):
                     if write_body[0]:
@@ -676,32 +655,31 @@ class Client(object):
                 opts=self.opts,
                 **get_kwargs
             )
-            if 'handle' not in query:
-                raise MinionError('Error: {0} reading {1}'.format(query['error'], url))
+            if "handle" not in query:
+                raise MinionError("Error: {0} reading {1}".format(query["error"], url))
             if no_cache:
                 if write_body[2]:
-                    return ''.join(result)
-                return b''.join(result)
+                    return "".join(result)
+                return b"".join(result)
             else:
                 destfp.close()
                 destfp = None
                 hubblestack.utils.files.rename(dest_tmp, dest)
                 return dest
         except HTTPError as exc:
-            raise MinionError('HTTP error {0} reading {1}: {2}'.format(
-                exc.code,
-                url,
-                BaseHTTPRequestHandler.responses[exc.code]))
+            raise MinionError(
+                "HTTP error {0} reading {1}: {2}".format(exc.code, url, BaseHTTPRequestHandler.responses[exc.code])
+            )
         except URLError as exc:
-            raise MinionError('Error reading {0}: {1}'.format(url, exc.reason))
+            raise MinionError("Error reading {0}: {1}".format(url, exc.reason))
         finally:
             if destfp is not None:
                 destfp.close()
 
     def _extrn_path(self, url, saltenv, cachedir=None):
-        '''
+        """
         Return the extrn_filepath for a given url
-        '''
+        """
         url_data = urlparse(url)
         if hubblestack.utils.platform.is_windows():
             netloc = hubblestack.utils.path.sanitize_win_path(url_data.netloc)
@@ -709,42 +687,37 @@ class Client(object):
             netloc = url_data.netloc
 
         # Strip user:pass from URLs
-        netloc = netloc.split('@')[-1]
+        netloc = netloc.split("@")[-1]
 
         if cachedir is None:
-            cachedir = self.opts['cachedir']
+            cachedir = self.opts["cachedir"]
         elif not os.path.isabs(cachedir):
-            cachedir = os.path.join(self.opts['cachedir'], cachedir)
+            cachedir = os.path.join(self.opts["cachedir"], cachedir)
 
         if url_data.query:
-            file_name = '-'.join([url_data.path, url_data.query])
+            file_name = "-".join([url_data.path, url_data.query])
         else:
             file_name = url_data.path
 
         if len(file_name) > MAX_FILENAME_LENGTH:
             file_name = hubblestack.utils.hashutils.sha256_digest(file_name)
 
-        return hubblestack.utils.path.join(
-            cachedir,
-            'extrn_files',
-            saltenv,
-            netloc,
-            file_name
-        )
+        return hubblestack.utils.path.join(cachedir, "extrn_files", saltenv, netloc, file_name)
 
 
 class RemoteClient(Client):
-    '''
+    """
     Interact with the salt master file server.
-    '''
+    """
+
     def __init__(self, opts):
         Client.__init__(self, opts)
         self._closing = False
-        self.channel = '' # Dummy channel for remote client
-        if hasattr(self.channel, 'auth'):
+        self.channel = ""  # Dummy channel for remote client
+        if hasattr(self.channel, "auth"):
             self.auth = self.channel.auth
         else:
-            self.auth = ''
+            self.auth = ""
 
     def __del__(self):
         self.destroy()
@@ -762,19 +735,13 @@ class RemoteClient(Client):
         if channel is not None:
             channel.close()
 
-    def get_file(self,
-                 path,
-                 dest='',
-                 makedirs=False,
-                 saltenv='base',
-                 gzip=None,
-                 cachedir=None):
-        '''
+    def get_file(self, path, dest="", makedirs=False, saltenv="base", gzip=None, cachedir=None):
+        """
         Get a single file from the salt-master
         path must be a salt server location, aka, salt://path/to/file, if
         dest is omitted, then the downloaded file will be placed in the minion
         cache
-        '''
+        """
         path, senv = hubblestack.utils.url.split_env(path)
         if senv:
             saltenv = senv
@@ -791,20 +758,15 @@ class RemoteClient(Client):
 
         # Check if file exists on server, before creating files and
         # directories
-        if hash_server == '':
-            log.debug(
-                'Could not find file \'%s\' in saltenv \'%s\'',
-                path, saltenv
-            )
+        if hash_server == "":
+            log.debug("Could not find file '%s' in saltenv '%s'", path, saltenv)
             return False
 
         # If dest is a directory, rewrite dest with filename
-        if dest is not None \
-                and (os.path.isdir(dest) or dest.endswith(('/', '\\'))):
+        if dest is not None and (os.path.isdir(dest) or dest.endswith(("/", "\\"))):
             dest = os.path.join(dest, os.path.basename(path))
             log.debug(
-                'In saltenv \'%s\', \'%s\' is a directory. Changing dest to '
-                '\'%s\'', saltenv, os.path.dirname(dest), dest
+                "In saltenv '%s', '%s' is a directory. Changing dest to " "'%s'", saltenv, os.path.dirname(dest), dest
             )
 
         # Hash compare local copy with master and skip download
@@ -813,23 +775,15 @@ class RemoteClient(Client):
         if not dest2check:
             rel_path = self._check_proto(path)
 
-            log.debug(
-                'In saltenv \'%s\', looking at rel_path \'%s\' to resolve '
-                '\'%s\'', saltenv, rel_path, path
-            )
-            with self._cache_loc(
-                    rel_path, saltenv, cachedir=cachedir) as cache_dest:
+            log.debug("In saltenv '%s', looking at rel_path '%s' to resolve " "'%s'", saltenv, rel_path, path)
+            with self._cache_loc(rel_path, saltenv, cachedir=cachedir) as cache_dest:
                 dest2check = cache_dest
 
-        log.debug(
-            'In saltenv \'%s\', ** considering ** path \'%s\' to resolve '
-            '\'%s\'', saltenv, dest2check, path
-        )
+        log.debug("In saltenv '%s', ** considering ** path '%s' to resolve " "'%s'", saltenv, dest2check, path)
 
         if dest2check and os.path.isfile(dest2check):
             if not hubblestack.utils.platform.is_windows():
-                hash_local, stat_local = \
-                    self.hash_and_stat_file(dest2check, saltenv)
+                hash_local, stat_local = self.hash_and_stat_file(dest2check, saltenv)
                 try:
                     mode_local = stat_local[0]
                 except (IndexError, TypeError):
@@ -841,19 +795,14 @@ class RemoteClient(Client):
             if hash_local == hash_server:
                 return dest2check
 
-        log.debug(
-            'Fetching file from saltenv \'%s\', ** attempting ** \'%s\'',
-            saltenv, path
-        )
+        log.debug("Fetching file from saltenv '%s', ** attempting ** '%s'", saltenv, path)
         d_tries = 0
         transport_tries = 0
         path = self._check_proto(path)
-        load = {'path': path,
-                'saltenv': saltenv,
-                'cmd': '_serve_file'}
+        load = {"path": path, "saltenv": saltenv, "cmd": "_serve_file"}
         if gzip:
             gzip = int(gzip)
-            load['gzip'] = gzip
+            load["gzip"] = gzip
 
         fn_ = None
         if dest:
@@ -869,15 +818,15 @@ class RemoteClient(Client):
                     return False
             # We need an open filehandle here, that's why we're not using a
             # with clause:
-            fn_ = hubblestack.utils.files.fopen(dest, 'wb+')  # pylint: disable=resource-leakage
+            fn_ = hubblestack.utils.files.fopen(dest, "wb+")  # pylint: disable=resource-leakage
         else:
-            log.debug('No dest file found')
+            log.debug("No dest file found")
 
         while True:
             if not fn_:
-                load['loc'] = 0
+                load["loc"] = 0
             else:
-                load['loc'] = fn_.tell()
+                load["loc"] = fn_.tell()
             data = self.channel.send(load, raw=True)
             # Sometimes the source is local (eg when using
             # 'salt.fileserver.FSChan'), in which case the keys are
@@ -886,43 +835,36 @@ class RemoteClient(Client):
             # strings for the top-level keys to simplify things.
             data = decode_dict_keys_to_str(data)
             try:
-                if not data['data']:
-                    if not fn_ and data['dest']:
+                if not data["data"]:
+                    if not fn_ and data["dest"]:
                         # This is a 0 byte file on the master
-                        with self._cache_loc(
-                                data['dest'],
-                                saltenv,
-                                cachedir=cachedir) as cache_dest:
+                        with self._cache_loc(data["dest"], saltenv, cachedir=cachedir) as cache_dest:
                             dest = cache_dest
-                            with hubblestack.utils.files.fopen(cache_dest, 'wb+') as ofile:
-                                ofile.write(data['data'])
-                    if 'hsum' in data and d_tries < 3:
+                            with hubblestack.utils.files.fopen(cache_dest, "wb+") as ofile:
+                                ofile.write(data["data"])
+                    if "hsum" in data and d_tries < 3:
                         # Master has prompted a file verification, if the
                         # verification fails, re-download the file. Try 3 times
                         d_tries += 1
-                        hsum = hubblestack.utils.hashutils.get_hash(dest, hubblestack.utils.stringutils.to_str(data.get('hash_type', b'md5')))
-                        if hsum != data['hsum']:
-                            log.warning(
-                                'Bad download of file %s, attempt %d of 3',
-                                path, d_tries
-                            )
+                        hsum = hubblestack.utils.hashutils.get_hash(
+                            dest, hubblestack.utils.stringutils.to_str(data.get("hash_type", b"md5"))
+                        )
+                        if hsum != data["hsum"]:
+                            log.warning("Bad download of file %s, attempt %d of 3", path, d_tries)
                             continue
                     break
                 if not fn_:
-                    with self._cache_loc(
-                            data['dest'],
-                            saltenv,
-                            cachedir=cachedir) as cache_dest:
+                    with self._cache_loc(data["dest"], saltenv, cachedir=cachedir) as cache_dest:
                         dest = cache_dest
                         # If a directory was formerly cached at this path, then
                         # remove it to avoid a traceback trying to write the file
                         if os.path.isdir(dest):
                             hubblestack.utils.files.rm_rf(dest)
-                        fn_ = hubblestack.utils.atomicfile.atomic_open(dest, 'wb+')
-                if data.get('gzip', None):
-                    data = hubblestack.utils.gzip_util.uncompress(data['data'])
+                        fn_ = hubblestack.utils.atomicfile.atomic_open(dest, "wb+")
+                if data.get("gzip", None):
+                    data = hubblestack.utils.gzip_util.uncompress(data["data"])
                 else:
-                    data = data['data']
+                    data = data["data"]
                 if isinstance(data, str):
                     data = data.encode()
                 fn_.write(data)
@@ -934,105 +876,89 @@ class RemoteClient(Client):
                     data_type = str(type(data))
                 transport_tries += 1
                 log.warning(
-                    'Data transport is broken, got: %s, type: %s, '
-                    'exception: %s, attempt %d of 3',
-                    data, data_type, exc, transport_tries
+                    "Data transport is broken, got: %s, type: %s, " "exception: %s, attempt %d of 3",
+                    data,
+                    data_type,
+                    exc,
+                    transport_tries,
                 )
                 if transport_tries > 3:
                     log.error(
-                        'Data transport is broken, got: %s, type: %s, '
-                        'exception: %s, retry attempts exhausted',
-                        data, data_type, exc
+                        "Data transport is broken, got: %s, type: %s, " "exception: %s, retry attempts exhausted",
+                        data,
+                        data_type,
+                        exc,
                     )
                     break
 
         if fn_:
             fn_.close()
-            log.info(
-                'Fetching file from saltenv \'%s\', ** done ** \'%s\'',
-                saltenv, path
-            )
+            log.info("Fetching file from saltenv '%s', ** done ** '%s'", saltenv, path)
         else:
-            log.debug(
-                'In saltenv \'%s\', we are ** missing ** the file \'%s\'',
-                saltenv, path
-            )
+            log.debug("In saltenv '%s', we are ** missing ** the file '%s'", saltenv, path)
 
         return dest
 
-    def file_list(self, saltenv='base', prefix=''):
-        '''
+    def file_list(self, saltenv="base", prefix=""):
+        """
         List the files on the master
-        '''
-        load = {'saltenv': saltenv,
-                'prefix': prefix,
-                'cmd': '_file_list'}
+        """
+        load = {"saltenv": saltenv, "prefix": prefix, "cmd": "_file_list"}
         return self.channel.send(load)
 
-    def file_list_emptydirs(self, saltenv='base', prefix=''):
-        '''
+    def file_list_emptydirs(self, saltenv="base", prefix=""):
+        """
         List the empty dirs on the master
-        '''
-        load = {'saltenv': saltenv,
-                'prefix': prefix,
-                'cmd': '_file_list_emptydirs'}
+        """
+        load = {"saltenv": saltenv, "prefix": prefix, "cmd": "_file_list_emptydirs"}
         return self.channel.send(load)
 
-    def dir_list(self, saltenv='base', prefix=''):
-        '''
+    def dir_list(self, saltenv="base", prefix=""):
+        """
         List the dirs on the master
-        '''
-        load = {'saltenv': saltenv,
-                'prefix': prefix,
-                'cmd': '_dir_list'}
+        """
+        load = {"saltenv": saltenv, "prefix": prefix, "cmd": "_dir_list"}
         return self.channel.send(load)
 
-    def symlink_list(self, saltenv='base', prefix=''):
-        '''
+    def symlink_list(self, saltenv="base", prefix=""):
+        """
         List symlinked files and dirs on the master
-        '''
-        load = {'saltenv': saltenv,
-                'prefix': prefix,
-                'cmd': '_symlink_list'}
+        """
+        load = {"saltenv": saltenv, "prefix": prefix, "cmd": "_symlink_list"}
         return self.channel.send(load)
 
-    def __hash_and_stat_file(self, path, saltenv='base'):
-        '''
+    def __hash_and_stat_file(self, path, saltenv="base"):
+        """
         Common code for hashing and stating files
-        '''
+        """
         try:
             path = self._check_proto(path)
         except MinionError as err:
             if not os.path.isfile(path):
-                log.warning(
-                    'specified file %s is not present to generate hash: %s',
-                    path, err
-                )
+                log.warning("specified file %s is not present to generate hash: %s", path, err)
                 return {}, None
             else:
                 ret = {}
-                hash_type = self.opts.get('hash_type', 'md5')
-                ret['hsum'] = hubblestack.utils.hashutils.get_hash(path, form=hash_type)
-                ret['hash_type'] = hash_type
+                hash_type = self.opts.get("hash_type", "md5")
+                ret["hsum"] = hubblestack.utils.hashutils.get_hash(path, form=hash_type)
+                ret["hash_type"] = hash_type
                 return ret
-        load = {'path': path,
-                'saltenv': saltenv,
-                'cmd': '_file_hash'}
+        load = {"path": path, "saltenv": saltenv, "cmd": "_file_hash"}
         return self.channel.send(load)
 
-    def hash_file(self, path, saltenv='base'):
-        '''
+    def hash_file(self, path, saltenv="base"):
+        """
         Return the hash of a file, to get the hash of a file on the salt
         master file server prepend the path with salt://<file on server>
         otherwise, prepend the file with / for a local file.
-        '''
+        """
         return self.__hash_and_stat_file(path, saltenv)
 
-    def hash_and_stat_file(self, path, saltenv='base'):
-        '''
+    def hash_and_stat_file(self, path, saltenv="base"):
+        """
         The same as hash_file, but also return the file's mode, or None if no
         mode data is present.
-        '''
+        """
         hash_result = self.hash_file(path, saltenv)
         try:
             path = self._check_proto(path)
@@ -1044,63 +970,59 @@ class RemoteClient(Client):
                     return hash_result, list(os.stat(path))
                 except Exception:
                     return hash_result, None
-        load = {'path': path,
-                'saltenv': saltenv,
-                'cmd': '_file_find'}
+        load = {"path": path, "saltenv": saltenv, "cmd": "_file_find"}
         fnd = self.channel.send(load)
         try:
-            stat_result = fnd.get('stat')
+            stat_result = fnd.get("stat")
         except AttributeError:
             stat_result = None
         return hash_result, stat_result
 
-    def list_env(self, saltenv='base'):
-        '''
+    def list_env(self, saltenv="base"):
+        """
         Return a list of the files in the file server's specified environment
-        '''
-        load = {'saltenv': saltenv,
-                'cmd': '_file_list'}
+        """
+        load = {"saltenv": saltenv, "cmd": "_file_list"}
         return self.channel.send(load)
 
     def envs(self):
-        '''
+        """
         Return a list of available environments
-        '''
-        load = {'cmd': '_file_envs'}
+        """
+        load = {"cmd": "_file_envs"}
         return self.channel.send(load)
 
     def master_opts(self):
-        '''
+        """
         Return the master opts data
-        '''
-        load = {'cmd': '_master_opts'}
+        """
+        load = {"cmd": "_master_opts"}
         return self.channel.send(load)
 
     def master_tops(self):
-        '''
+        """
         Return the metadata derived from the master_tops system
-        '''
+        """
         log.debug(
-            'The _ext_nodes master function has been renamed to _master_tops. '
-            'To ensure compatibility when using older Salt masters we will '
-            'continue to invoke the function as _ext_nodes until the '
-            'Magnesium release.'
+            "The _ext_nodes master function has been renamed to _master_tops. "
+            "To ensure compatibility when using older Salt masters we will "
+            "continue to invoke the function as _ext_nodes until the "
+            "Magnesium release."
         )
         # TODO: Change back to _master_tops
         # for Magnesium release
-        load = {'cmd': '_ext_nodes',
-                'id': self.opts['id'],
-                'opts': self.opts}
+        load = {"cmd": "_ext_nodes", "id": self.opts["id"], "opts": self.opts}
         if self.auth:
-            load['tok'] = self.auth.gen_token(b'salt')
+            load["tok"] = self.auth.gen_token(b"salt")
         return self.channel.send(load)
 
 
 class FSClient(RemoteClient):
-    '''
+    """
     A local client that uses the RemoteClient but substitutes the channel for
     the FSChan object
-    '''
+    """
+
     def __init__(self, opts):  # pylint: disable=W0231
         Client.__init__(self, opts)  # pylint: disable=W0233
         self._closing = False
@@ -1114,9 +1036,10 @@ LocalClient = FSClient
 
 
 class DumbAuth(object):
-    '''
+    """
     The dumbauth class is used to stub out auth calls fired from the FSClient
     subsystem
-    '''
+    """
+
     def gen_token(self, clear_tok):
         return clear_tok


### PR DESCRIPTION
Formatting in MinionError references a a field 3, which should be a field 2.  May cause an exception if executed.

Note: the change-set is quite big due to linter requirements. The actual change is on line 691. Additionally, I've removed unused arguments on lines 44 and 260, respectively.