### PR TITLE
Replace pycrypto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,7 @@ var/
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
+*.create_manifest
 
 # Installer logs
 pip-log.txt

--- a/hubblestack/fileserver/azurefs.py
+++ b/hubblestack/fileserver/azurefs.py
@@ -57,7 +57,7 @@ import hubblestack.fileserver
 import hubblestack.utils.files
 import hubblestack.utils.gzip_util
 import hubblestack.utils.hashutils
-from hubblestack.utils.signing import find_wrapf
+from hubblestack.utils.signing_utils import find_file_func_wrapper
 
 try:
     from azure.storage.blob import BlobServiceClient
@@ -95,7 +95,7 @@ def __virtual__():
     return True
 
 
-@find_wrapf(not_found={"path": "", "rel": ""})
+@find_file_func_wrapper(not_found={"path": "", "rel": ""})
 def find_file(path, saltenv="base", **kwargs):  # pylint: disable=unused-argument
     """
     Search the environment for the relative path

--- a/hubblestack/fileserver/azurefs.py
+++ b/hubblestack/fileserver/azurefs.py
@@ -57,7 +57,7 @@ import hubblestack.fileserver
 import hubblestack.utils.files
 import hubblestack.utils.gzip_util
 import hubblestack.utils.hashutils
-from hubblestack.utils.signing_utils import find_file_func_wrapper
+from hubblestack.utils.signing_helpers import find_file_func_wrapper
 
 try:
     from azure.storage.blob import BlobServiceClient

--- a/hubblestack/fileserver/gitfs.py
+++ b/hubblestack/fileserver/gitfs.py
@@ -51,33 +51,43 @@ Walkthrough <tutorial-gitfs>`.
 import logging
 
 PER_REMOTE_OVERRIDES = (
-    'base', 'mountpoint', 'root', 'ssl_verify',
-    'saltenv_whitelist', 'saltenv_blacklist',
-    'env_whitelist', 'env_blacklist', 'refspecs',
-    'disable_saltenv_mapping', 'ref_types', 'update_interval',
+    "base",
+    "mountpoint",
+    "root",
+    "ssl_verify",
+    "saltenv_whitelist",
+    "saltenv_blacklist",
+    "env_whitelist",
+    "env_blacklist",
+    "refspecs",
+    "disable_saltenv_mapping",
+    "ref_types",
+    "update_interval",
 )
-PER_REMOTE_ONLY = ('all_saltenvs', 'name', 'saltenv')
+PER_REMOTE_ONLY = ("all_saltenvs", "name", "saltenv")
 
 # Auth support (auth params can be global or per-remote, too)
-AUTH_PROVIDERS = ('pygit2',)
-AUTH_PARAMS = ('user', 'password', 'pubkey', 'privkey', 'passphrase',
-               'insecure_auth')
+AUTH_PROVIDERS = ("pygit2",)
+AUTH_PARAMS = ("user", "password", "pubkey", "privkey", "passphrase", "insecure_auth")
 
-from hubblestack.utils.signing import find_wrapf
+from hubblestack.utils.signing_utils import find_file_func_wrapper
 from hubblestack.utils.gitfs import GitFS
 from hubblestack.exceptions import FileserverConfigError
 
 log = logging.getLogger(__name__)
 
 # Define the module's virtual name
-__virtualname__ = 'gitfs'
+__virtualname__ = "gitfs"
 
 
 def _gitfs(init_remotes=True):
-    return GitFS(__opts__, __opts__['gitfs_remotes'],
-                 per_remote_overrides=PER_REMOTE_OVERRIDES,
-                 per_remote_only=PER_REMOTE_ONLY,
-                 init_remotes=init_remotes)
+    return GitFS(
+        __opts__,
+        __opts__["gitfs_remotes"],
+        per_remote_overrides=PER_REMOTE_OVERRIDES,
+        per_remote_only=PER_REMOTE_ONLY,
+        init_remotes=init_remotes,
+    )
 
 
 def __virtual__():
@@ -85,7 +95,7 @@ def __virtual__():
     Only load if the desired provider module is present and gitfs is enabled
     properly in the master config file.
     """
-    if __virtualname__ not in __opts__['fileserver_backend']:
+    if __virtualname__ not in __opts__["fileserver_backend"]:
         return False
     try:
         _gitfs(init_remotes=False)
@@ -106,7 +116,7 @@ def clear_cache():
     return _gitfs(init_remotes=False).clear_cache()
 
 
-def clear_lock(remote=None, lock_type='update'):
+def clear_lock(remote=None, lock_type="update"):
     """
     Clear update.lk
     """
@@ -145,8 +155,8 @@ def envs(ignore_cache=False):
     return _gitfs().envs(ignore_cache=ignore_cache)
 
 
-@find_wrapf(not_found={'rel': '', 'path': ''}, real_path='path')
-def find_file(path, tgt_env='base', **kwargs):  # pylint: disable=W0613
+@find_file_func_wrapper(not_found={"rel": "", "path": ""}, real_path="path")
+def find_file(path, tgt_env="base", **kwargs):  # pylint: disable=W0613
     """
     Find the first file to match the path and ref, read the file out of git
     and send the path to the newly cached file

--- a/hubblestack/fileserver/gitfs.py
+++ b/hubblestack/fileserver/gitfs.py
@@ -70,7 +70,7 @@ PER_REMOTE_ONLY = ("all_saltenvs", "name", "saltenv")
 AUTH_PROVIDERS = ("pygit2",)
 AUTH_PARAMS = ("user", "password", "pubkey", "privkey", "passphrase", "insecure_auth")
 
-from hubblestack.utils.signing_utils import find_file_func_wrapper
+from hubblestack.utils.signing_helpers import find_file_func_wrapper
 from hubblestack.utils.gitfs import GitFS
 from hubblestack.exceptions import FileserverConfigError
 

--- a/hubblestack/fileserver/roots.py
+++ b/hubblestack/fileserver/roots.py
@@ -28,7 +28,7 @@ import hubblestack.utils.path
 import hubblestack.utils.platform
 import hubblestack.utils.stringutils
 
-from hubblestack.utils.signing_utils import find_file_func_wrapper
+from hubblestack.utils.signing_helpers import find_file_func_wrapper
 
 log = logging.getLogger(__name__)
 

--- a/hubblestack/fileserver/roots.py
+++ b/hubblestack/fileserver/roots.py
@@ -28,25 +28,25 @@ import hubblestack.utils.path
 import hubblestack.utils.platform
 import hubblestack.utils.stringutils
 
-from hubblestack.utils.signing import find_wrapf
+from hubblestack.utils.signing_utils import find_file_func_wrapper
 
 log = logging.getLogger(__name__)
 
-@find_wrapf(not_found={'path': '', 'rel': ''})
-def find_file(path, saltenv='base', **kwargs):
+
+@find_file_func_wrapper(not_found={"path": "", "rel": ""})
+def find_file(path, saltenv="base", **kwargs):
     """
     Search the environment for the relative path.
     """
-    if 'env' in kwargs:
+    if "env" in kwargs:
         # "env" is not supported; Use "saltenv".
-        kwargs.pop('env')
+        kwargs.pop("env")
 
     path = os.path.normpath(path)
-    fnd = {'path': '',
-           'rel': ''}
+    fnd = {"path": "", "rel": ""}
     if os.path.isabs(path):
         return fnd
-    if saltenv not in __opts__['file_roots']:
+    if saltenv not in __opts__["file_roots"]:
         return fnd
 
     def _add_file_stat(fnd):
@@ -69,14 +69,14 @@ def find_file(path, saltenv='base', **kwargs):
         9 => st_ctime=1456338235
         """
         try:
-            fnd['stat'] = list(os.stat(fnd['path']))
+            fnd["stat"] = list(os.stat(fnd["path"]))
         except Exception:
             pass
         return fnd
 
-    if 'index' in kwargs:
+    if "index" in kwargs:
         try:
-            root = __opts__['file_roots'][saltenv][int(kwargs['index'])]
+            root = __opts__["file_roots"][saltenv][int(kwargs["index"])]
         except IndexError:
             # An invalid index was passed
             return fnd
@@ -85,15 +85,15 @@ def find_file(path, saltenv='base', **kwargs):
             return fnd
         full = os.path.join(root, path)
         if os.path.isfile(full) and not hubblestack.fileserver.is_file_ignored(__opts__, full):
-            fnd['path'] = full
-            fnd['rel'] = path
+            fnd["path"] = full
+            fnd["rel"] = path
             return _add_file_stat(fnd)
         return fnd
-    for root in __opts__['file_roots'][saltenv]:
+    for root in __opts__["file_roots"][saltenv]:
         full = os.path.join(root, path)
         if os.path.isfile(full) and not hubblestack.fileserver.is_file_ignored(__opts__, full):
-            fnd['path'] = full
-            fnd['rel'] = path
+            fnd["path"] = full
+            fnd["rel"] = path
             return _add_file_stat(fnd)
     return fnd
 
@@ -102,33 +102,32 @@ def envs():
     """
     Return the file server environments
     """
-    return sorted(__opts__['file_roots'])
+    return sorted(__opts__["file_roots"])
 
 
 def serve_file(load, fnd):
     """
     Return a chunk from a file based on the data received
     """
-    if 'env' in load:
+    if "env" in load:
         # "env" is not supported; Use "saltenv".
-        load.pop('env')
+        load.pop("env")
 
-    ret = {'data': '',
-           'dest': ''}
-    if 'path' not in load or 'loc' not in load or 'saltenv' not in load:
+    ret = {"data": "", "dest": ""}
+    if "path" not in load or "loc" not in load or "saltenv" not in load:
         return ret
-    if not fnd['path']:
+    if not fnd["path"]:
         return ret
-    ret['dest'] = fnd['rel']
-    gzip = load.get('gzip', None)
-    fpath = os.path.normpath(fnd['path'])
-    with hubblestack.utils.files.fopen(fpath, 'rb') as fp_:
-        fp_.seek(load['loc'])
-        data = fp_.read(__opts__['file_buffer_size'])
+    ret["dest"] = fnd["rel"]
+    gzip = load.get("gzip", None)
+    fpath = os.path.normpath(fnd["path"])
+    with hubblestack.utils.files.fopen(fpath, "rb") as fp_:
+        fp_.seek(load["loc"])
+        data = fp_.read(__opts__["file_buffer_size"])
         if gzip and data:
             data = hubblestack.utils.gzip_util.compress(data, gzip)
-            ret['gzip'] = gzip
-        ret['data'] = data
+            ret["gzip"] = gzip
+        ret["data"] = data
     return ret
 
 
@@ -137,74 +136,65 @@ def update():
     When we are asked to update (regular interval) lets reap the cache
     """
     try:
-        reap_target = os.path.join(__opts__['cachedir'], 'roots', 'hash')
-        log.debug('reap_fileserver_cache_dir(%s)', reap_target)
+        reap_target = os.path.join(__opts__["cachedir"], "roots", "hash")
+        log.debug("reap_fileserver_cache_dir(%s)", reap_target)
         hubblestack.fileserver.reap_fileserver_cache_dir(reap_target, find_file)
     except (IOError, OSError) as e:
         # Hash file won't exist if no files have yet been served up
         # not really an error, but maybe worth noting if we're debugging
-        log.debug('reap_fileserver_cache_dir(%s) error: %s', reap_target, e)
+        log.debug("reap_fileserver_cache_dir(%s) error: %s", reap_target, e)
 
-    mtime_map_path = os.path.join(__opts__['cachedir'], 'roots', 'mtime_map')
+    mtime_map_path = os.path.join(__opts__["cachedir"], "roots", "mtime_map")
     # data to send on event
-    data = {'changed': False,
-            'files': {'changed': []},
-            'backend': 'roots'}
+    data = {"changed": False, "files": {"changed": []}, "backend": "roots"}
 
     # generate the new map
-    new_mtime_map = hubblestack.fileserver.generate_mtime_map(__opts__, __opts__['file_roots'])
+    new_mtime_map = hubblestack.fileserver.generate_mtime_map(__opts__, __opts__["file_roots"])
 
     old_mtime_map = {}
     # if you have an old map, load that
     if os.path.exists(mtime_map_path):
-        with hubblestack.utils.files.fopen(mtime_map_path, 'rb') as fp_:
+        with hubblestack.utils.files.fopen(mtime_map_path, "rb") as fp_:
             for line in fp_:
                 line = hubblestack.utils.stringutils.to_unicode(line)
                 try:
-                    file_path, mtime = line.replace('\n', '').split(':', 1)
+                    file_path, mtime = line.replace("\n", "").split(":", 1)
                     old_mtime_map[file_path] = mtime
                     if mtime != new_mtime_map.get(file_path, mtime):
-                        data['files']['changed'].append(file_path)
+                        data["files"]["changed"].append(file_path)
                 except ValueError:
                     # Document the invalid entry in the log
-                    log.warning(
-                        'Skipped invalid cache mtime entry in %s: %s',
-                        mtime_map_path, line
-                    )
+                    log.warning("Skipped invalid cache mtime entry in %s: %s", mtime_map_path, line)
 
     # compare the maps, set changed to the return value
-    data['changed'] = hubblestack.fileserver.diff_mtime_map(old_mtime_map, new_mtime_map)
+    data["changed"] = hubblestack.fileserver.diff_mtime_map(old_mtime_map, new_mtime_map)
 
     # compute files that were removed and added
     old_files = set(old_mtime_map.keys())
     new_files = set(new_mtime_map.keys())
-    data['files']['removed'] = list(old_files - new_files)
-    data['files']['added'] = list(new_files - old_files)
+    data["files"]["removed"] = list(old_files - new_files)
+    data["files"]["added"] = list(new_files - old_files)
 
     # write out the new map
     mtime_map_path_dir = os.path.dirname(mtime_map_path)
     if not os.path.exists(mtime_map_path_dir):
         os.makedirs(mtime_map_path_dir)
-    with hubblestack.utils.files.fopen(mtime_map_path, 'wb') as fp_:
+    with hubblestack.utils.files.fopen(mtime_map_path, "wb") as fp_:
         for file_path, mtime in new_mtime_map.items():
-            fp_.write(
-                hubblestack.utils.stringutils.to_bytes(
-                    '{0}:{1}\n'.format(file_path, mtime)
-                )
-            )
+            fp_.write(hubblestack.utils.stringutils.to_bytes("{0}:{1}\n".format(file_path, mtime)))
 
 
 def file_hash(load, fnd):
     """
     Return a file hash, the hash type is set in the master config file
     """
-    if 'env' in load:
+    if "env" in load:
         # "env" is not supported; Use "saltenv".
-        load.pop('env')
+        load.pop("env")
 
-    if 'path' not in load or 'saltenv' not in load:
-        return ''
-    path = fnd['path']
+    if "path" not in load or "saltenv" not in load:
+        return ""
+    path = fnd["path"]
     ret = {}
 
     # if the file doesn't exist, we can't get a hash
@@ -212,24 +202,25 @@ def file_hash(load, fnd):
         return ret
 
     # set the hash_type as it is determined by config-- so mechanism won't change that
-    ret['hash_type'] = __opts__['hash_type']
+    ret["hash_type"] = __opts__["hash_type"]
 
     # check if the hash is cached
     # cache file's contents should be "hash:mtime"
-    cache_path = os.path.join(__opts__['cachedir'],
-                              'roots',
-                              'hash',
-                              load['saltenv'],
-                              '{0}.hash.{1}'.format(fnd['rel'],
-                              __opts__['hash_type']))
+    cache_path = os.path.join(
+        __opts__["cachedir"],
+        "roots",
+        "hash",
+        load["saltenv"],
+        "{0}.hash.{1}".format(fnd["rel"], __opts__["hash_type"]),
+    )
     # if we have a cache, serve that if the mtime hasn't changed
     if os.path.exists(cache_path):
         try:
-            with hubblestack.utils.files.fopen(cache_path, 'rb') as fp_:
+            with hubblestack.utils.files.fopen(cache_path, "rb") as fp_:
                 try:
-                    hsum, mtime = hubblestack.utils.stringutils.to_unicode(fp_.read()).split(':')
+                    hsum, mtime = hubblestack.utils.stringutils.to_unicode(fp_.read()).split(":")
                 except ValueError:
-                    log.debug('Fileserver attempted to read incomplete cache file. Retrying.')
+                    log.debug("Fileserver attempted to read incomplete cache file. Retrying.")
                     # Delete the file since its incomplete (either corrupted or incomplete)
                     try:
                         os.unlink(cache_path)
@@ -238,7 +229,7 @@ def file_hash(load, fnd):
                     return file_hash(load, fnd)
                 if str(os.path.getmtime(path)) == mtime:
                     # check if mtime changed
-                    ret['hsum'] = hsum
+                    ret["hsum"] = hsum
                     return ret
         except (os.error, IOError):  # Can't use Python select() because we need Windows support
             log.debug("Fileserver encountered lock when reading cache file. Retrying.")
@@ -250,7 +241,7 @@ def file_hash(load, fnd):
             return file_hash(load, fnd)
 
     # if we don't have a cache entry-- lets make one
-    ret['hsum'] = hubblestack.utils.hashutils.get_hash(path, __opts__['hash_type'])
+    ret["hsum"] = hubblestack.utils.hashutils.get_hash(path, __opts__["hash_type"])
     cache_dir = os.path.dirname(cache_path)
     # make cache directory if it doesn't exist
     if not os.path.exists(cache_dir):
@@ -264,8 +255,8 @@ def file_hash(load, fnd):
             else:
                 raise
     # save the cache object "hash:mtime"
-    cache_object = '{0}:{1}'.format(ret['hsum'], os.path.getmtime(path))
-    with hubblestack.utils.files.flopen(cache_path, 'w') as fp_:
+    cache_object = "{0}:{1}".format(ret["hsum"], os.path.getmtime(path))
+    with hubblestack.utils.files.flopen(cache_path, "w") as fp_:
         fp_.write(cache_object)
     return ret
 
@@ -274,64 +265,56 @@ def _file_lists(load, form):
     """
     Return a dict containing the file lists for files, dirs, emtydirs and symlinks
     """
-    if 'env' in load:
+    if "env" in load:
         # "env" is not supported; Use "saltenv".
-        load.pop('env')
+        load.pop("env")
 
-    if load['saltenv'] not in __opts__['file_roots']:
+    if load["saltenv"] not in __opts__["file_roots"]:
         return []
 
-    list_cachedir = os.path.join(__opts__['cachedir'], 'file_lists', 'roots')
+    list_cachedir = os.path.join(__opts__["cachedir"], "file_lists", "roots")
     if not os.path.isdir(list_cachedir):
         try:
             os.makedirs(list_cachedir)
         except os.error:
-            log.critical('Unable to make cachedir %s', list_cachedir)
+            log.critical("Unable to make cachedir %s", list_cachedir)
             return []
-    list_cache = os.path.join(list_cachedir, '{0}.p'.format(load['saltenv']))
-    w_lock = os.path.join(list_cachedir, '.{0}.w'.format(load['saltenv']))
-    cache_match, refresh_cache, save_cache = \
-        hubblestack.fileserver.check_file_list_cache(
-            __opts__, form, list_cache, w_lock
-        )
+    list_cache = os.path.join(list_cachedir, "{0}.p".format(load["saltenv"]))
+    w_lock = os.path.join(list_cachedir, ".{0}.w".format(load["saltenv"]))
+    cache_match, refresh_cache, save_cache = hubblestack.fileserver.check_file_list_cache(
+        __opts__, form, list_cache, w_lock
+    )
     if cache_match is not None:
         return cache_match
     if refresh_cache:
-        ret = {
-            'files': set(),
-            'dirs': set(),
-            'empty_dirs': set(),
-            'links': {}
-        }
+        ret = {"files": set(), "dirs": set(), "empty_dirs": set(), "links": {}}
 
         def _add_to(tgt, fs_root, parent_dir, items):
             """
             Add the files to the target set
             """
+
             def _translate_sep(path):
                 """
                 Translate path separators for Windows masterless minions
                 """
-                return path.replace('\\', '/') if os.path.sep == '\\' else path
+                return path.replace("\\", "/") if os.path.sep == "\\" else path
 
             for item in items:
                 abs_path = os.path.join(parent_dir, item)
-                log.trace('roots: Processing %s', abs_path)
+                log.trace("roots: Processing %s", abs_path)
                 is_link = hubblestack.utils.path.islink(abs_path)
-                log.trace(
-                    'roots: %s is %sa link',
-                    abs_path, 'not ' if not is_link else ''
-                )
-                if is_link and __opts__['fileserver_ignoresymlinks']:
+                log.trace("roots: %s is %sa link", abs_path, "not " if not is_link else "")
+                if is_link and __opts__["fileserver_ignoresymlinks"]:
                     continue
                 rel_path = _translate_sep(os.path.relpath(abs_path, fs_root))
-                log.trace('roots: %s relative path is %s', abs_path, rel_path)
+                log.trace("roots: %s relative path is %s", abs_path, rel_path)
                 if hubblestack.fileserver.is_file_ignored(__opts__, rel_path):
                     continue
                 tgt.add(rel_path)
                 try:
                     if not os.listdir(abs_path):
-                        ret['empty_dirs'].add(rel_path)
+                        ret["empty_dirs"].add(rel_path)
                 except Exception:
                     # Generic exception because running os.listdir() on a
                     # non-directory path raises an OSError on *NIX and a
@@ -339,58 +322,39 @@ def _file_lists(load, form):
                     pass
                 if is_link:
                     link_dest = hubblestack.utils.path.readlink(abs_path)
-                    log.trace(
-                        'roots: %s symlink destination is %s',
-                        abs_path, link_dest
-                    )
-                    if hubblestack.utils.platform.is_windows() \
-                            and link_dest.startswith('\\\\'):
+                    log.trace("roots: %s symlink destination is %s", abs_path, link_dest)
+                    if hubblestack.utils.platform.is_windows() and link_dest.startswith("\\\\"):
                         # Symlink points to a network path. Since you can't
                         # join UNC and non-UNC paths, just assume the original
                         # path.
-                        log.trace(
-                            'roots: %s is a UNC path, using %s instead',
-                            link_dest, abs_path
-                        )
+                        log.trace("roots: %s is a UNC path, using %s instead", link_dest, abs_path)
                         link_dest = abs_path
-                    if link_dest.startswith('..'):
+                    if link_dest.startswith(".."):
                         joined = os.path.join(abs_path, link_dest)
                     else:
-                        joined = os.path.join(
-                            os.path.dirname(abs_path), link_dest
-                        )
-                    rel_dest = _translate_sep(
-                        os.path.relpath(
-                            os.path.realpath(os.path.normpath(joined)),
-                            fs_root
-                        )
-                    )
-                    log.trace(
-                        'roots: %s relative path is %s',
-                        abs_path, rel_dest
-                    )
-                    if not rel_dest.startswith('..'):
+                        joined = os.path.join(os.path.dirname(abs_path), link_dest)
+                    rel_dest = _translate_sep(os.path.relpath(os.path.realpath(os.path.normpath(joined)), fs_root))
+                    log.trace("roots: %s relative path is %s", abs_path, rel_dest)
+                    if not rel_dest.startswith(".."):
                         # Only count the link if it does not point
                         # outside of the root dir of the fileserver
                         # (i.e. the "path" variable)
-                        ret['links'][rel_path] = link_dest
+                        ret["links"][rel_path] = link_dest
 
-        for path in __opts__['file_roots'][load['saltenv']]:
+        for path in __opts__["file_roots"][load["saltenv"]]:
             for root, dirs, files in hubblestack.utils.path.os_walk(
-                    path,
-                    followlinks=__opts__['fileserver_followsymlinks']):
-                _add_to(ret['dirs'], path, root, dirs)
-                _add_to(ret['files'], path, root, files)
+                path, followlinks=__opts__["fileserver_followsymlinks"]
+            ):
+                _add_to(ret["dirs"], path, root, dirs)
+                _add_to(ret["files"], path, root, files)
 
-        ret['files'] = sorted(ret['files'])
-        ret['dirs'] = sorted(ret['dirs'])
-        ret['empty_dirs'] = sorted(ret['empty_dirs'])
+        ret["files"] = sorted(ret["files"])
+        ret["dirs"] = sorted(ret["dirs"])
+        ret["empty_dirs"] = sorted(ret["empty_dirs"])
 
         if save_cache:
             try:
-                hubblestack.fileserver.write_file_list_cache(
-                    __opts__, ret, list_cache, w_lock
-                )
+                hubblestack.fileserver.write_file_list_cache(__opts__, ret, list_cache, w_lock)
             except NameError:
                 # Catch msgpack error in salt-ssh
                 pass
@@ -404,41 +368,39 @@ def file_list(load):
     Return a list of all files on the file server in a specified
     environment
     """
-    return _file_lists(load, 'files')
+    return _file_lists(load, "files")
 
 
 def file_list_emptydirs(load):
     """
     Return a list of all empty directories on the master
     """
-    return _file_lists(load, 'empty_dirs')
+    return _file_lists(load, "empty_dirs")
 
 
 def dir_list(load):
     """
     Return a list of all directories on the master
     """
-    return _file_lists(load, 'dirs')
+    return _file_lists(load, "dirs")
 
 
 def symlink_list(load):
     """
     Return a dict of all symlinks based on a given path on the Master
     """
-    if 'env' in load:
+    if "env" in load:
         # "env" is not supported; Use "saltenv".
-        load.pop('env')
+        load.pop("env")
 
     ret = {}
-    if load['saltenv'] not in __opts__['file_roots']:
+    if load["saltenv"] not in __opts__["file_roots"]:
         return ret
 
-    if 'prefix' in load:
-        prefix = load['prefix'].strip('/')
+    if "prefix" in load:
+        prefix = load["prefix"].strip("/")
     else:
-        prefix = ''
+        prefix = ""
 
-    symlinks = _file_lists(load, 'links')
-    return dict([(key, val)
-                 for key, val in symlinks.items()
-                 if key.startswith(prefix)])
+    symlinks = _file_lists(load, "links")
+    return dict([(key, val) for key, val in symlinks.items() if key.startswith(prefix)])

--- a/hubblestack/fileserver/s3fs.py
+++ b/hubblestack/fileserver/s3fs.py
@@ -94,7 +94,7 @@ from urllib.parse import quote as _quote
 
 # pylint: enable=import-error,no-name-in-module,redefined-builtin
 
-from hubblestack.utils.signing_utils import find_file_func_wrapper
+from hubblestack.utils.signing_helpers import find_file_func_wrapper
 
 log = logging.getLogger(__name__)
 

--- a/hubblestack/fileserver/s3fs.py
+++ b/hubblestack/fileserver/s3fs.py
@@ -91,9 +91,10 @@ import hubblestack.utils.hashutils
 
 # pylint: disable=import-error,no-name-in-module,redefined-builtin
 from urllib.parse import quote as _quote
+
 # pylint: enable=import-error,no-name-in-module,redefined-builtin
 
-from hubblestack.utils.signing import find_wrapf
+from hubblestack.utils.signing_utils import find_file_func_wrapper
 
 log = logging.getLogger(__name__)
 
@@ -119,33 +120,32 @@ def update():
 
     if S3_SYNC_ON_UPDATE and metadata:
         # sync the buckets to the local cache
-        log.info('Syncing local cache from S3...')
+        log.info("Syncing local cache from S3...")
         for saltenv, env_meta in metadata.items():
             for bucket_files in _find_files(env_meta):
                 for bucket, files in bucket_files.items():
                     for file_path in files:
                         cached_file_path = _get_cached_file_name(bucket, saltenv, file_path)
-                        log.info('%s - %s : %s', bucket, saltenv, file_path)
+                        log.info("%s - %s : %s", bucket, saltenv, file_path)
 
                         # load the file from S3 if it's not in the cache or it's old
                         _get_file_from_s3(metadata, saltenv, bucket, file_path, cached_file_path)
 
-        log.info('Sync local cache from S3 completed.')
+        log.info("Sync local cache from S3 completed.")
 
 
-@find_wrapf(not_found={'bucket': None, 'path': None}, real_path='cpath')
-def find_file(path, saltenv='base', **kwargs):
+@find_file_func_wrapper(not_found={"bucket": None, "path": None}, real_path="cpath")
+def find_file(path, saltenv="base", **kwargs):
     """
     Look through the buckets cache file for a match.
     If the field is found, it is retrieved from S3 only if its cached version
     is missing, or if the MD5 does not match.
     """
-    if 'env' in kwargs:
+    if "env" in kwargs:
         # "env" is not supported; Use "saltenv".
-        kwargs.pop('env')
+        kwargs.pop("env")
 
-    fnd = {'bucket': None,
-           'path': None}
+    fnd = {"bucket": None, "path": None}
 
     metadata = _init()
     if not metadata or saltenv not in metadata:
@@ -160,23 +160,23 @@ def find_file(path, saltenv='base', **kwargs):
     for bucket in env_files:
         for bucket_name, files in bucket.items():
             if path in files and not fs.is_file_ignored(__opts__, path):
-                fnd['bucket'] = bucket_name
-                fnd['path'] = path
+                fnd["bucket"] = bucket_name
+                fnd["path"] = path
                 break
         else:
             continue  # only executes if we didn't break
         break
 
-    if not fnd['path'] or not fnd['bucket']:
+    if not fnd["path"] or not fnd["bucket"]:
         return fnd
 
-    fnd['cpath'] = _get_cached_file_name(fnd['bucket'], saltenv, path)
+    fnd["cpath"] = _get_cached_file_name(fnd["bucket"], saltenv, path)
 
     try:
         # jit load the file from S3 if it's not in the cache or it's old
-        _get_file_from_s3(metadata, saltenv, fnd['bucket'], path, fnd['cpath'])
+        _get_file_from_s3(metadata, saltenv, fnd["bucket"], path, fnd["cpath"])
     except Exception as exc:
-        if not os.path.isfile(fnd['cpath']):
+        if not os.path.isfile(fnd["cpath"]):
             raise exc
 
     return fnd
@@ -186,26 +186,23 @@ def file_hash(load, fnd):
     """
     Return an MD5 file hash
     """
-    if 'env' in load:
+    if "env" in load:
         # "env" is not supported; Use "saltenv".
-        load.pop('env')
+        load.pop("env")
 
     ret = {}
 
-    if 'saltenv' not in load:
+    if "saltenv" not in load:
         return ret
 
-    if 'path' not in fnd or 'bucket' not in fnd or not fnd['path']:
+    if "path" not in fnd or "bucket" not in fnd or not fnd["path"]:
         return ret
 
-    cached_file_path = _get_cached_file_name(
-        fnd['bucket'],
-        load['saltenv'],
-        fnd['path'])
+    cached_file_path = _get_cached_file_name(fnd["bucket"], load["saltenv"], fnd["path"])
 
     if os.path.isfile(cached_file_path):
-        ret['hsum'] = hubblestack.utils.hashutils.get_hash(cached_file_path)
-        ret['hash_type'] = 'md5'
+        ret["hsum"] = hubblestack.utils.hashutils.get_hash(cached_file_path)
+        ret["hash_type"] = "md5"
 
     return ret
 
@@ -214,38 +211,34 @@ def serve_file(load, fnd):
     """
     Return a chunk from a file based on the data received
     """
-    if 'env' in load:
+    if "env" in load:
         # "env" is not supported; Use "saltenv".
-        load.pop('env')
+        load.pop("env")
 
-    ret = {'data': '',
-           'dest': ''}
+    ret = {"data": "", "dest": ""}
 
-    if 'path' not in load or 'loc' not in load or 'saltenv' not in load:
+    if "path" not in load or "loc" not in load or "saltenv" not in load:
         return ret
 
-    if 'path' not in fnd or 'bucket' not in fnd:
+    if "path" not in fnd or "bucket" not in fnd:
         return ret
 
-    gzip = load.get('gzip', None)
+    gzip = load.get("gzip", None)
 
     # get the saltenv/path file from the cache
-    cached_file_path = _get_cached_file_name(
-        fnd['bucket'],
-        load['saltenv'],
-        fnd['path'])
+    cached_file_path = _get_cached_file_name(fnd["bucket"], load["saltenv"], fnd["path"])
 
-    ret['dest'] = _trim_env_off_path([fnd['path']], load['saltenv'])[0]
+    ret["dest"] = _trim_env_off_path([fnd["path"]], load["saltenv"])[0]
 
-    with hubblestack.utils.files.fopen(cached_file_path, 'rb') as fp_:
-        fp_.seek(load['loc'])
-        data = fp_.read(__opts__['file_buffer_size'])
+    with hubblestack.utils.files.fopen(cached_file_path, "rb") as fp_:
+        fp_.seek(load["loc"])
+        data = fp_.read(__opts__["file_buffer_size"])
         if data and not hubblestack.utils.files.is_binary(cached_file_path):
             data = data.decode(__salt_system_encoding__)
         if gzip and data:
             data = hubblestack.utils.gzip_util.compress(data, gzip)
-            ret['gzip'] = gzip
-        ret['data'] = data
+            ret["gzip"] = gzip
+        ret["data"] = data
     return ret
 
 
@@ -253,16 +246,16 @@ def file_list(load):
     """
     Return a list of all files on the file server in a specified environment
     """
-    if 'env' in load:
+    if "env" in load:
         # "env" is not supported; Use "saltenv".
-        load.pop('env')
+        load.pop("env")
 
     ret = []
 
-    if 'saltenv' not in load:
+    if "saltenv" not in load:
         return ret
 
-    saltenv = load['saltenv']
+    saltenv = load["saltenv"]
     metadata = _init()
 
     if not metadata or saltenv not in metadata:
@@ -275,7 +268,7 @@ def file_list(load):
     return ret
 
 
-def file_list_emptydirs(load): # pylint: disable=unused-argument ; just a todo
+def file_list_emptydirs(load):  # pylint: disable=unused-argument ; just a todo
     """
     Return a list of all empty directories on the master
     """
@@ -289,16 +282,16 @@ def dir_list(load):
     """
     Return a list of all directories on the master
     """
-    if 'env' in load:
+    if "env" in load:
         # "env" is not supported; Use "saltenv".
-        load.pop('env')
+        load.pop("env")
 
     ret = []
 
-    if 'saltenv' not in load:
+    if "saltenv" not in load:
         return ret
 
-    saltenv = load['saltenv']
+    saltenv = load["saltenv"]
     metadata = _init()
 
     if not metadata or saltenv not in metadata:
@@ -321,26 +314,26 @@ def _get_s3_key():
     """
 
     defaults = {
-        'https_enable': True,
-        'verify_ssl': True,
-        'location': None,
-        'path_style': None,
-        'service_url': None,
-        'keyid': None,
-        'key': None,
-        'cache_expire': S3_CACHE_EXPIRE,
+        "https_enable": True,
+        "verify_ssl": True,
+        "location": None,
+        "path_style": None,
+        "service_url": None,
+        "keyid": None,
+        "key": None,
+        "cache_expire": S3_CACHE_EXPIRE,
     }
 
     ret = dict()
     for k in defaults:
-        s3k = 's3.' + k
+        s3k = "s3." + k
         ret[k] = __opts__.get(s3k, defaults[k])
 
     # kms_keyid = __opts__['aws.kmw.keyid'] if 'aws.kms.keyid' in __opts__ else None
     #
     # original was likely bugged: aws.kms.keyid is probably right, but people
     # that needed this may have entered it incorrectly to match. Support both for now.
-    ret['kms_keyid'] = __opts__.get('aws.kms.keyid', __opts__.get('aws.kmw.keyid'))
+    ret["kms_keyid"] = __opts__.get("aws.kms.keyid", __opts__.get("aws.kmw.keyid"))
 
     return ret
 
@@ -351,10 +344,10 @@ def _init():
     specified and cache the data to disk.
     """
     cache_file = _get_buckets_cache_filename()
-    cache_expire_time = float(_get_s3_key().get('cache_expire'))
+    cache_expire_time = float(_get_s3_key().get("cache_expire"))
     exp = time.time() - cache_expire_time
 
-    log.debug('S3 cache expire time is %ds', cache_expire_time)
+    log.debug("S3 cache expire time is %ds", cache_expire_time)
     # check mtime of the buckets files cache
     metadata = None
     try:
@@ -386,7 +379,7 @@ def _get_cache_dir():
     Return the path to the s3cache dir
     """
     # Or is that making too many assumptions?
-    return os.path.join(__opts__['cachedir'], 's3cache')
+    return os.path.join(__opts__["cachedir"], "s3cache")
 
 
 def _get_cached_file_name(bucket_name, saltenv, path):
@@ -411,7 +404,7 @@ def _get_buckets_cache_filename():
     if not os.path.exists(cache_dir):
         os.makedirs(cache_dir)
 
-    return os.path.join(cache_dir, 'buckets_files.cache')
+    return os.path.join(cache_dir, "buckets_files.cache")
 
 
 def _refresh_buckets_cache_file(cache_file):
@@ -419,38 +412,40 @@ def _refresh_buckets_cache_file(cache_file):
     Retrieve the content of all buckets and cache the metadata to the buckets
     cache file
     """
-    log.debug('Refreshing buckets cache file')
+    log.debug("Refreshing buckets cache file")
 
     s3_key_kwargs = _get_s3_key()
     metadata = {}
 
     # helper s3 query function
-    def __get_s3_meta(bucket, key=s3_key_kwargs['key'], keyid=s3_key_kwargs['keyid']):
-        ret, marker = [], ''
+    def __get_s3_meta(bucket, key=s3_key_kwargs["key"], keyid=s3_key_kwargs["keyid"]):
+        ret, marker = [], ""
         while True:
-            tmp = __utils__['s3.query'](key=key,
-                                        keyid=keyid,
-                                        kms_keyid=keyid,
-                                        bucket=bucket,
-                                        service_url=s3_key_kwargs['service_url'],
-                                        verify_ssl=s3_key_kwargs['verify_ssl'],
-                                        location=s3_key_kwargs['location'],
-                                        return_bin=False,
-                                        path_style=s3_key_kwargs['path_style'],
-                                        https_enable=s3_key_kwargs['https_enable'],
-                                        params={'marker': marker})
+            tmp = __utils__["s3.query"](
+                key=key,
+                keyid=keyid,
+                kms_keyid=keyid,
+                bucket=bucket,
+                service_url=s3_key_kwargs["service_url"],
+                verify_ssl=s3_key_kwargs["verify_ssl"],
+                location=s3_key_kwargs["location"],
+                return_bin=False,
+                path_style=s3_key_kwargs["path_style"],
+                https_enable=s3_key_kwargs["https_enable"],
+                params={"marker": marker},
+            )
             if not tmp:
                 return None
 
             headers = []
             for header in tmp:
-                if 'Key' in header:
+                if "Key" in header:
                     break
                 headers.append(header)
             ret.extend(tmp)
-            if all([header.get('IsTruncated', 'false') == 'false' for header in headers]):
+            if all([header.get("IsTruncated", "false") == "false" for header in headers]):
                 break
-            marker = tmp[-1]['Key']
+            marker = tmp[-1]["Key"]
         return ret
 
     def _parse_buckets(buckets, salt_env=None):
@@ -471,36 +466,34 @@ def _refresh_buckets_cache_file(cache_file):
                 continue
 
             # grab only the files/dirs
-            files = [k for k in s3_meta if 'Key' in k]
+            files = [k for k in s3_meta if "Key" in k]
             bucket_files_list.append({bucket_name: files})
 
             # check to see if we added any keys, otherwise investigate possible error conditions
             if not files:
                 meta_response = {}
                 for k in s3_meta:
-                    if 'Code' in k or 'Message' in k:
+                    if "Code" in k or "Message" in k:
                         # assumes no duplicate keys, consisdent with current error response.
                         meta_response.update(k)
                 # attempt use of human readable output first.
                 try:
-                    log.warning(
-                        "'%s' response for bucket '%s'", meta_response['Message'], bucket_name)
+                    log.warning("'%s' response for bucket '%s'", meta_response["Message"], bucket_name)
                     continue
                 except KeyError:
                     # no human readable error message provided
-                    if 'Code' in meta_response:
-                        log.warning(
-                            "'%s' response for bucket '%s'", meta_response['Code'], bucket_name)
+                    if "Code" in meta_response:
+                        log.warning("'%s' response for bucket '%s'", meta_response["Code"], bucket_name)
                         continue
                     else:
-                        log.warning('S3 Error! Do you have any files in your S3 bucket?')
+                        log.warning("S3 Error! Do you have any files in your S3 bucket?")
                         return {}
 
             # one environment per bucket, nothing left to parse
             if salt_env:
                 continue
 
-            environments = set([(os.path.dirname(k['Key']).split('/', 1))[0] for k in files])
+            environments = set([(os.path.dirname(k["Key"]).split("/", 1))[0] for k in files])
 
             # pull out the files for the environment
             _parse_env(environments=environments, bucket_name=bucket_name, files=files)
@@ -517,7 +510,7 @@ def _refresh_buckets_cache_file(cache_file):
         """
         for saltenv in environments:
             # grab only files/dirs that match this saltenv
-            env_files = [k for k in files if k['Key'].startswith(saltenv)]
+            env_files = [k for k in files if k["Key"].startswith(saltenv)]
 
             if saltenv not in metadata:
                 metadata[saltenv] = []
@@ -550,9 +543,9 @@ def _refresh_buckets_cache_file(cache_file):
     if os.path.isfile(cache_file):
         os.remove(cache_file)
 
-    log.debug('Writing buckets cache file')
+    log.debug("Writing buckets cache file")
 
-    with hubblestack.utils.files.fopen(cache_file, 'wb') as fp_:
+    with hubblestack.utils.files.fopen(cache_file, "wb") as fp_:
         pickle.dump(metadata, fp_)
 
     return metadata
@@ -562,19 +555,17 @@ def _read_buckets_cache_file(cache_file):
     """
     Return the contents of the buckets cache file
     """
-    log.debug('Reading buckets cache file')
+    log.debug("Reading buckets cache file")
 
-    with hubblestack.utils.files.fopen(cache_file, 'rb') as fp_:
+    with hubblestack.utils.files.fopen(cache_file, "rb") as fp_:
         try:
             data = pickle.load(fp_)
             # check for 'corrupted' cache data ex: {u'base':[]}
             if not any(data.values()):
                 data = None
 
-        except (pickle.UnpicklingError, AttributeError, EOFError, ImportError,
-                IndexError, KeyError) as eobj:
-            log.info('error unpickling buckets cache file (%s): %s',
-                cache_file, repr(eobj))
+        except (pickle.UnpicklingError, AttributeError, EOFError, ImportError, IndexError, KeyError) as eobj:
+            log.info("error unpickling buckets cache file (%s): %s", cache_file, repr(eobj))
             data = None
 
     return data
@@ -589,8 +580,8 @@ def _find_files(metadata):
 
     for bucket_dict in metadata:
         for bucket_name, data in bucket_dict.items():
-            file_paths = [k['Key'] for k in data]
-            file_paths = [k for k in file_paths if not k.endswith('/')]
+            file_paths = [k["Key"] for k in data]
+            file_paths = [k for k in file_paths if not k.endswith("/")]
             if bucket_name not in found:
                 found[bucket_name] = True
                 ret.append({bucket_name: file_paths})
@@ -615,10 +606,10 @@ def _find_dirs(metadata):
     for bucket_dict in metadata:
         for bucket_name, data in bucket_dict.items():
             dir_paths = set()
-            for path in [k['Key'] for k in data]:
-                prefix = ''
-                for part in path.split('/')[:-1]:
-                    directory = prefix + part + '/'
+            for path in [k["Key"] for k in data]:
+                prefix = ""
+                for part in path.split("/")[:-1]:
+                    directory = prefix + part + "/"
                     dir_paths.add(directory)
                     prefix = directory
             if bucket_name not in found:
@@ -642,13 +633,13 @@ def _find_file_meta(metadata, bucket_name, saltenv, path):
     for bucket in env_meta:
         if bucket_name in bucket:
             bucket_meta = bucket[bucket_name]
-    files_meta = list(list(filter((lambda k: 'Key' in k), bucket_meta)))
+    files_meta = list(list(filter((lambda k: "Key" in k), bucket_meta)))
 
     for item_meta in files_meta:
-        if 'Key' in item_meta and item_meta['Key'] == path:
+        if "Key" in item_meta and item_meta["Key"] == path:
             try:
                 # Get rid of quotes surrounding md5
-                item_meta['ETag'] = item_meta['ETag'].strip('"')
+                item_meta["ETag"] = item_meta["ETag"].strip('"')
             except KeyError:
                 pass
             return item_meta
@@ -661,7 +652,7 @@ def _get_buckets():
     Return the configuration buckets
     """
 
-    return __opts__['s3.buckets'] if 's3.buckets' in __opts__ else {}
+    return __opts__["s3.buckets"] if "s3.buckets" in __opts__ else {}
 
 
 def _get_file_from_s3(metadata, saltenv, bucket_name, path, cached_file_path):
@@ -676,35 +667,36 @@ def _get_file_from_s3(metadata, saltenv, bucket_name, path, cached_file_path):
         Helper function that gets the file from S3 and checks if it can be skipped.
         Returns True if the file was downloaded and False if the download was skipped.
         """
-        ret = __utils__['s3.query'](
-            key=s3_key_kwargs['key'],
-            keyid=s3_key_kwargs['keyid'],
-            kms_keyid=s3_key_kwargs['keyid'],
-            method='HEAD',
+        ret = __utils__["s3.query"](
+            key=s3_key_kwargs["key"],
+            keyid=s3_key_kwargs["keyid"],
+            kms_keyid=s3_key_kwargs["keyid"],
+            method="HEAD",
             bucket=bucket_name,
-            service_url=s3_key_kwargs['service_url'],
-            verify_ssl=s3_key_kwargs['verify_ssl'],
-            location=s3_key_kwargs['location'],
+            service_url=s3_key_kwargs["service_url"],
+            verify_ssl=s3_key_kwargs["verify_ssl"],
+            location=s3_key_kwargs["location"],
             path=_quote(path),
             local_file=cached_file_path,
             full_headers=True,
-            path_style=s3_key_kwargs['path_style'],
-            https_enable=s3_key_kwargs['https_enable'])
+            path_style=s3_key_kwargs["path_style"],
+            https_enable=s3_key_kwargs["https_enable"],
+        )
         if ret:
-            for header_name, header_value in ret['headers'].items():
+            for header_name, header_value in ret["headers"].items():
                 header_name = header_name.strip()
                 header_value = header_value.strip()
-                if str(header_name).lower() == 'last-modified':
-                    s3_file_mtime = datetime.datetime.strptime(
-                        header_value, '%a, %d %b %Y %H:%M:%S %Z')
-                elif str(header_name).lower() == 'content-length':
+                if str(header_name).lower() == "last-modified":
+                    s3_file_mtime = datetime.datetime.strptime(header_value, "%a, %d %b %Y %H:%M:%S %Z")
+                elif str(header_name).lower() == "content-length":
                     s3_file_size = int(header_value)
-            if cached_file_data['size'] == s3_file_size and \
-                    cached_file_data['mtime'] > s3_file_mtime:
+            if cached_file_data["size"] == s3_file_size and cached_file_data["mtime"] > s3_file_mtime:
                 log.info(
-                    '%s - %s : %s skipped download since cached file size '
-                    'equal to and mtime after s3 values',
-                    bucket_name, saltenv, path)
+                    "%s - %s : %s skipped download since cached file size " "equal to and mtime after s3 values",
+                    bucket_name,
+                    saltenv,
+                    path,
+                )
                 return False
         return True
 
@@ -712,42 +704,46 @@ def _get_file_from_s3(metadata, saltenv, bucket_name, path, cached_file_path):
     if os.path.isfile(cached_file_path):
         file_meta = _find_file_meta(metadata, bucket_name, saltenv, path)
         if file_meta:
-            if file_meta['ETag'].find('-') == -1:
-                cached_md5 = hubblestack.utils.hashutils.get_hash(cached_file_path, 'md5')
+            if file_meta["ETag"].find("-") == -1:
+                cached_md5 = hubblestack.utils.hashutils.get_hash(cached_file_path, "md5")
 
                 # hashes match we have a cache hit
-                if cached_md5 == file_meta['ETag']:
+                if cached_md5 == file_meta["ETag"]:
                     return
             else:
                 cached_file_stat = os.stat(cached_file_path)
                 cached_file_data = {
-                    'size': cached_file_stat.st_size,
-                    'mtime': datetime.datetime.fromtimestamp(cached_file_stat.st_mtime),
-                    'lastmod': datetime.datetime.strptime(
-                        file_meta['LastModified'], '%Y-%m-%dT%H:%M:%S.%fZ')}
+                    "size": cached_file_stat.st_size,
+                    "mtime": datetime.datetime.fromtimestamp(cached_file_stat.st_mtime),
+                    "lastmod": datetime.datetime.strptime(file_meta["LastModified"], "%Y-%m-%dT%H:%M:%S.%fZ"),
+                }
 
-                if (cached_file_data['size'] == int(file_meta['Size']) and
-                        cached_file_data['mtime'] > cached_file_data['lastmod']):
-                    log.debug('cached file size equal to metadata size and '
-                              'cached file mtime later than metadata last '
-                              'modification time.')
+                if (
+                    cached_file_data["size"] == int(file_meta["Size"])
+                    and cached_file_data["mtime"] > cached_file_data["lastmod"]
+                ):
+                    log.debug(
+                        "cached file size equal to metadata size and "
+                        "cached file mtime later than metadata last "
+                        "modification time."
+                    )
                     if not _get_file():
                         # skipped download
                         return
 
     # ... or get the file from S3
-    __utils__['s3.query'](
-        key=s3_key_kwargs['key'],
-        keyid=s3_key_kwargs['keyid'],
-        kms_keyid=s3_key_kwargs['keyid'],
+    __utils__["s3.query"](
+        key=s3_key_kwargs["key"],
+        keyid=s3_key_kwargs["keyid"],
+        kms_keyid=s3_key_kwargs["keyid"],
         bucket=bucket_name,
-        service_url=s3_key_kwargs['service_url'],
-        verify_ssl=s3_key_kwargs['verify_ssl'],
-        location=s3_key_kwargs['location'],
+        service_url=s3_key_kwargs["service_url"],
+        verify_ssl=s3_key_kwargs["verify_ssl"],
+        location=s3_key_kwargs["location"],
         path=_quote(path),
         local_file=cached_file_path,
-        path_style=s3_key_kwargs['path_style'],
-        https_enable=s3_key_kwargs['https_enable'],
+        path_style=s3_key_kwargs["path_style"],
+        https_enable=s3_key_kwargs["https_enable"],
     )
 
 
@@ -772,4 +768,4 @@ def _is_env_per_bucket():
     elif isinstance(buckets, list):
         return False
     else:
-        raise ValueError('Incorrect s3.buckets type given in config')
+        raise ValueError("Incorrect s3.buckets type given in config")

--- a/hubblestack/modules/signing.py
+++ b/hubblestack/modules/signing.py
@@ -7,10 +7,12 @@ import hubblestack.utils.signing as HuS
 
 log = logging.getLogger(__name__)
 
-__virtualname__ = 'signing'
+__virtualname__ = "signing"
+
 
 def __virtual__():
     return True
+
 
 def msign(*targets, **kw):
     """
@@ -22,12 +24,13 @@ def msign(*targets, **kw):
         private_key :- the private key to use for the signature (default
             /etc/hubble/sign/private.key)
     """
-    mfname = kw.get('mfname', HuS.Options.manifest_file_name)
-    sfname = kw.get('sfname', HuS.Options.signature_file_name)
-    private_key = kw.get('private_key', HuS.Options.private_key)
+    mfname = kw.get("mfname", HuS.Options.manifest_file_name)
+    sfname = kw.get("sfname", HuS.Options.signature_file_name)
+    private_key = kw.get("private_key", HuS.Options.private_key)
 
-    HuS.manifest(targets, mfname=mfname)
+    HuS.create_manifest(targets, mfname=mfname)
     HuS.sign_target(mfname, sfname, private_key=private_key)
+
 
 def verify(*targets, **kw):
     """
@@ -46,21 +49,31 @@ def verify(*targets, **kw):
                   found.
     """
 
-    mfname = kw.get('mfname', HuS.Options.manifest_file_name)
-    sfname = kw.get('sfname', HuS.Options.signature_file_name)
-    cfname = kw.get('cfname', HuS.Options.certificates_file_name)
-    public_crt = kw.get('public_crt', HuS.Options.public_crt)
-    ca_crt = kw.get('ca_crt', HuS.Options.ca_crt)
+    mfname = kw.get("mfname", HuS.Options.manifest_file_name)
+    sfname = kw.get("sfname", HuS.Options.signature_file_name)
+    cfname = kw.get("cfname", HuS.Options.certificates_file_name)
+    public_crt = kw.get("public_crt", HuS.Options.public_crt)
+    ca_crt = kw.get("ca_crt", HuS.Options.ca_crt)
     pwd = os.path.abspath(os.path.curdir)
 
-    log.debug('signing.verify(targets=%s, mfname=%s, sfname=%s, public_crt=%s, ca_crt=%s, cfname=%s, pwd=%s)',
-        targets, mfname, sfname, public_crt, ca_crt, cfname, pwd)
+    log.debug(
+        "signing.verify(targets=%s, mfname=%s, sfname=%s, public_crt=%s, ca_crt=%s, cfname=%s, pwd=%s)",
+        targets,
+        mfname,
+        sfname,
+        public_crt,
+        ca_crt,
+        cfname,
+        pwd,
+    )
 
-    return dict(HuS.verify_files(targets, mfname=mfname, sfname=sfname,
-        public_crt=public_crt, ca_crt=ca_crt, extra_crt=cfname))
+    return dict(
+        HuS.verify_files(targets, mfname=mfname, sfname=sfname, public_crt=public_crt, ca_crt=ca_crt, extra_crt=cfname)
+    )
+
 
 def enumerate():
-    """ enumerate installed certificates """
+    """enumerate installed certificates"""
 
     x509 = HuS.X509AwareCertBucket()
-    return [ ' '.join(x.split()[1:]) for x in x509.trusted ]
+    return [" ".join(x.split()[1:]) for x in x509.trusted]

--- a/hubblestack/utils/powershell.py
+++ b/hubblestack/utils/powershell.py
@@ -110,7 +110,7 @@ def get_modules():
             for file_name in file_names:
                 base_name, file_extension = os.path.splitext(file_name)
 
-                # If a module file or module manifest is present, check if
+                # If a module file or module create_manifest is present, check if
                 # the base name matches the directory name.
 
                 if file_extension.lower() in valid_extensions:

--- a/hubblestack/utils/signing.py
+++ b/hubblestack/utils/signing.py
@@ -62,6 +62,9 @@ from cryptography.hazmat.primitives.serialization import load_pem_private_key
 
 from hubblestack.utils.signing_utils import encode_pem, decode_pem
 
+from enum import Enum
+
+
 MANIFEST_RE = re.compile(r"^\s*(?P<digest>[0-9a-fA-F]+)\s+(?P<fname>.+)$")
 log = logging.getLogger(__name__)
 
@@ -153,7 +156,7 @@ def check_verify_timestamp(target, dampener_limit=None):
     return False
 
 
-class STATUS:
+class STATUS(Enum):
     """container for status code (strings)"""
 
     FAIL = "fail"

--- a/hubblestack/utils/signing.py
+++ b/hubblestack/utils/signing.py
@@ -51,8 +51,6 @@ from collections import OrderedDict, namedtuple
 # In any case, pycrypto won't do the job. The below requires pycryptodome.
 # (M2Crypto is the other choice; but the docs are weaker, mostly non-existent.)
 
-from Crypto.IO import PEM
-
 import OpenSSL.crypto as ossl
 import OpenSSL._util
 

--- a/hubblestack/utils/signing.py
+++ b/hubblestack/utils/signing.py
@@ -61,7 +61,7 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import padding, utils
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives.serialization import load_pem_private_key, Encoding, PrivateFormat, NoEncryption
+from cryptography.hazmat.primitives.serialization import load_pem_private_key
 
 MANIFEST_RE = re.compile(r"^\s*(?P<digest>[0-9a-fA-F]+)\s+(?P<fname>.+)$")
 log = logging.getLogger(__name__)

--- a/hubblestack/utils/signing.py
+++ b/hubblestack/utils/signing.py
@@ -38,13 +38,11 @@ something like the following in a repo root.
 """
 
 import os
-import logging
 import re
 import io as cStringIO
-import hubblestack.utils.platform
 
 from time import time
-from collections import OrderedDict, namedtuple
+from collections import namedtuple
 
 # In any case, pycrypto won't do the job. The below requires pycryptodome.
 # (M2Crypto is the other choice; but the docs are weaker, mostly non-existent.)
@@ -67,10 +65,11 @@ from hubblestack.utils.signing_helpers import (
     run_callback,
     _cache_key,
     STATUS,
+    Options,
+    log,
 )
 
 MANIFEST_RE = re.compile(r"^\s*(?P<digest>[0-9a-fA-F]+)\s+(?P<fname>.+)$")
-log = logging.getLogger(__name__)
 
 
 def _our_byte_string(x, charmap="utf-8"):  # pylint: disable=unused-argument
@@ -158,46 +157,6 @@ def check_verify_timestamp(target, dampener_limit=None):
         VERIFY_LOG_TIMESTAMPS[target] = new_ts
         return True
     return False
-
-
-class Options(object):
-    """
-    The Options class is simply a convenience interface for interacting with repo_signing options.
-
-    Instead of `__mods__['config.get']('repo_signing:public_crt')`, write `Options.public_crt`.
-    """
-
-    class Defaults:
-        """defaults storage for options"""
-
-        require_verify = False
-        verify_cache_age = 600
-        ca_crt = "/etc/hubble/sign/ca-root.crt"
-        public_crt = "/etc/hubble/sign/public.crt"
-        private_key = "/etc/hubble/sign/private.key"
-        manifest_file_name = "MANIFEST"
-        signature_file_name = "SIGNATURE"
-        certificates_file_name = "CERTIFICATES"
-        salt_padding_bits = ["max", 32]
-        # The first generation signature padding bits were 32 (only) the
-        # crypto-recommended is "however many we can fit". AWS CloudHSM is
-        # incompatible with max, ... we'll need to try both. See below.
-
-    def __getattribute__(self, name):
-        """If the option exists in the default pseudo meta class
-        Try to find the option with config.get under repo_signing.
-        Failing that, return the default from the pseudo meta class.
-        If the option name isn't in the defaults, raise the exception.
-        """
-        try:
-            return object.__getattribute__(self, name)
-        except AttributeError:
-            pass
-        try:
-            default = getattr(self.Defaults, name)
-            return __mods__["config.get"]("repo_signing:{}".format(name), default)
-        except AttributeError:
-            raise
 
 
 # replace class with instance
@@ -676,126 +635,3 @@ def iterate_manifest(mfname):
                 _, manifested_fname = matched.groups()
                 manifested_fname = normalize_path(manifested_fname)
                 yield manifested_fname
-
-
-def verify_files(targets, mfname=None, sfname=None, public_crt=None, ca_crt=None, extra_crt=None):
-    """given a list of `targets`, a MANIFEST, and a SIGNATURE file:
-
-    1. Check the signature of the create_manifest, mark the 'MANIFEST' item of the return as:
-         STATUS.FAIL if the signature doesn't match
-         STATUS.UNKNOWN if the certificate signature can't be verified with the ca cert
-         STATUS.VERIFIED if both the signature and the CA sig match
-    2. mark all targets as STATUS.UNKNOWN
-    3. check the digest of each target against the create_manifest, mark each file as
-         STATUS.FAIL if the digest doesn't match
-         STATUS.*, the status of the MANIFEST file above
-
-    return a mapping from the input target list to the status values (a dict of filename: status)
-    """
-
-    if mfname is None:
-        mfname = Options.manifest_file_name
-    if sfname is None:
-        sfname = Options.signature_file_name
-    if public_crt is None:
-        public_crt = Options.public_crt
-    if ca_crt is None:
-        ca_crt = Options.ca_crt
-
-    log.debug(
-        "verifying: files: %s | mfname: %s | sfname: %s | public_crt: %s| ca_crt: %s",
-        targets,
-        mfname,
-        sfname,
-        public_crt,
-        ca_crt,
-    )
-
-    ret = OrderedDict()
-    ret[mfname] = verify_signature(mfname, sfname=sfname, public_crt=public_crt, ca_crt=ca_crt, extra_crt=extra_crt)
-    # ret[mfname] is the strongest claim we can make about the files we're
-    # verifiying if they match their hash in the create_manifest, the best we can say
-    # is whatever is the status of the create_manifest itself.
-
-    mf_dir, _ = os.path.split(mfname)
-    sf_dir, _ = os.path.split(sfname)
-
-    if mf_dir and mf_dir == sf_dir:
-        if hubblestack.utils.platform.is_windows():
-            trunc = mf_dir
-        else:
-            trunc = mf_dir + "/"
-    else:
-        trunc = None
-
-    # pre-populate digests with STATUS.UNKNOWN, skip things that shouldn't be
-    # digested (MANIFEST, SIGNATURE, etc) and build a database mapping
-    # normalized names back to given target names.
-    xlate = dict()
-    digests = OrderedDict()
-    if not targets:
-        targets = list(iterate_manifest(mfname))
-    for otarget in targets:
-        target = normalize_path(otarget, trunc=trunc)
-
-        log.debug("found create_manifest for %s (%s)", otarget, target)
-        if otarget != target:
-            xlate[target] = otarget
-        if target in digests or target in (mfname, sfname):
-            continue
-        digests[target] = STATUS.UNKNOWN
-    # populate digests with the hashes from the MANIFEST
-    if os.path.isfile(mfname):
-        with open(mfname, "r") as fh:
-            for line in fh.readlines():
-                matched = MANIFEST_RE.match(line)
-                if matched:
-                    digest, manifested_fname = matched.groups()
-                    manifested_fname = normalize_path(manifested_fname)
-                    if manifested_fname in digests:
-                        digests[manifested_fname] = digest
-    # number of seconds before a FAIL or UNKNOWN is set to the returner
-    # compare actual digests of files (if they exist) to the manifested digests
-    for vfname in digests:
-        digest = digests[vfname]
-        htname = os.path.join(trunc, vfname) if trunc else vfname
-        new_hash = hash_target(htname)
-
-        log_level = log.debug
-        if digest == STATUS.UNKNOWN:
-            # digests[vfname] is either UNKNOWN (from the targets population)
-            # or it's a digest from the MANIFEST. If UNKNOWN, we have nothing to compare
-            # so we return UNKNOWN
-            status = STATUS.UNKNOWN
-            # check to see if the the status of a failed target has been sent is the last
-            # x seconds, we reset time and set log level accordingly. the same for FAIL
-        elif digest == new_hash:
-            # path gets same status as MANIFEST
-            # Cool, the digest matches, but rather than mark STATUS.VERIFIED,
-            # we mark it with the same status as the MANIFEST itself --
-            # presumably it's signed (STATUS.VERIFIED); but perhaps it's only
-            # UNKNOWN or even FAIL.
-            status = ret[mfname]
-        else:
-            # We do have a MANIFEST entry and it doesn't match: FAIL with or
-            # without a matching SIGNATURE
-            status = STATUS.FAIL
-        if check_verify_timestamp(digest):
-            if status == STATUS.FAIL:
-                log_level = log.error
-            elif status == STATUS.UNKNOWN:
-                log_level = log.error
-        # logs according to the STATUS of target file
-        log_level(
-            'file: "%s" | status: %s | create_manifest sha256: "%s" | real sha256: "%s"',
-            vfname,
-            status,
-            digest,
-            new_hash,
-        )
-        ret[vfname] = status
-
-    # fix any normalized names so the caller gets back their specified targets
-    for k, v in xlate.items():
-        ret[v] = ret.pop(k)
-    return ret

--- a/hubblestack/utils/signing.py
+++ b/hubblestack/utils/signing.py
@@ -79,7 +79,7 @@ OpenSSL._util.byte_string = _our_byte_string
 VERIFY_LOG_TIMESTAMPS = {}
 # How often in seconds 3600 = 1 hour to set log level to log.error/critical
 # maybe set in /etc/hubble/hubble
-VERIFY_LOG_DAMPENER_LIM = 3600
+VERIFY_LOG_DAMPENER_LIM = [3600]
 
 
 def _format_padding_bits(x):
@@ -132,11 +132,8 @@ def check_verify_timestamp(target, dampener_limit=None):
             -- False if it isn't greater than or equal to when the time() value of
                 verif_log_timestamps
     """
-    global VERIFY_LOG_TIMESTAMPS
-    global VERIFY_LOG_DAMPENER_LIM
-
     if dampener_limit is None:
-        dampener_limit = VERIFY_LOG_DAMPENER_LIM
+        dampener_limit = VERIFY_LOG_DAMPENER_LIM[0]
 
     # get the ts of the last time a profile failed a verification check
     ts_0 = VERIFY_LOG_TIMESTAMPS.get(target)
@@ -572,6 +569,7 @@ def decode_pem(data: bytes) -> str:
     m = pattern.search(data)
     if not m or m.group(1) != marker:
         raise ValueError("Not a valid PEM post boundary")
+
     data = data.replace(" ", "").split()
     output = a2b_base64("".join(data[1:-1]))
 
@@ -861,7 +859,6 @@ def verify_files(targets, mfname=None, sfname=None, public_crt=None, ca_crt=None
                     if manifested_fname in digests:
                         digests[manifested_fname] = digest
     # number of seconds before a FAIL or UNKNOWN is set to the returner
-    global VERIFY_LOG_TIMESTAMPS
     # compare actual digests of files (if they exist) to the manifested digests
     for vfname in digests:
         digest = digests[vfname]

--- a/hubblestack/utils/signing_utils.py
+++ b/hubblestack/utils/signing_utils.py
@@ -1,0 +1,118 @@
+import logging
+import re
+from binascii import b2a_base64, a2b_base64
+
+from hubblestack.utils.signing import Options, log, verify_files, STATUS
+
+
+def encode_pem(data: bytes, marker: str) -> str:
+    """
+    Encode a bytestring as base64, using the PEM format.
+    :param data: bytestring to be encoded
+    :param marker: PEM format specific header
+    :returns: PEM encoded string
+    """
+    output = "-----BEGIN {}-----\n".format(marker)
+    chunks = [b2a_base64(data[i : i + 48]).decode("latin-1") for i in range(0, len(data), 48)]
+    output += "".join(chunks)
+    output += "-----END {}-----".format(marker)
+    return output
+
+
+def decode_pem(data: bytes) -> str:
+    """
+    Decode a bytestring encoded in the PEM format
+    :param data: bytestring to be decoded
+    :returns: decoded string
+    """
+    # Verify Pre-Encapsulation Boundary
+    pattern = re.compile(r"\s*-----BEGIN (.*)-----\s+")
+    m = pattern.match(data)
+    if not m:
+        raise ValueError("Not a valid PEM pre boundary")
+    marker = m.group(1)
+
+    # Verify Post-Encapsulation Boundary
+    pattern = re.compile(r"-----END (.*)-----\s*$")
+    m = pattern.search(data)
+    if not m or m.group(1) != marker:
+        raise ValueError("Not a valid PEM post boundary")
+
+    data = data.replace(" ", "").split()
+    output = a2b_base64("".join(data[1:-1]))
+
+    return output
+
+
+def find_file_func_wrapper(not_found=None, real_path="path"):
+    """
+    Wrap a filesystem find_file function and return the original result if the
+    MANIFEST and SIGNATURE indicate the file is valid. If the file is not verified
+    and Options.require_verify is False (the default); but the file did not
+    explicity fail to match the MANIFEST, continue to return the original find result.
+
+    Otherwise, return a pretend not-found result instead of the original repo result.
+    """
+    if not not_found:
+        not_found = {"path": "", "rel": ""}
+
+    def wrapper(find_file_func):
+        def normalize_search_path(fnd):
+            """
+            Since `real_path` is poorly named, we make it so that is contains the name
+            of the key where we'll find the real path of the file we're finding with
+            find_file_func()
+            """
+            return fnd.get(real_path, fnd.get("path", ""))
+
+        def inner(path, saltenv, *a, **kwargs):
+            f_path = find_file_func(path, saltenv, *a, **kwargs)
+            p_path = normalize_search_path(f_path)
+
+            if not p_path:
+                # if the file doesn't exist anyway, there's no reason to continue
+                return f_path
+
+            path_manifest = normalize_search_path(find_file_func(Options.manifest_file_name, saltenv, *a, **kwargs))
+            path_signature = normalize_search_path(find_file_func(Options.signature_file_name, saltenv, *a, **kwargs))
+            path_certificate = normalize_search_path(
+                find_file_func(Options.certificates_file_name, saltenv, *a, **kwargs)
+            )
+
+            log.debug(
+                'path: %s | f_path: %s | p_path: %s | manifest: "%s" | signature: "%s"',
+                path,
+                f_path,
+                p_path,
+                path_manifest,
+                path_signature,
+            )
+
+            verify_res = verify_files(
+                [p_path],
+                mfname=path_manifest,
+                sfname=path_signature,
+                public_crt=Options.public_crt,
+                ca_crt=Options.ca_crt,
+                extra_crt=path_certificate,
+            )
+
+            log.debug("verify: %s", dict(**verify_res))
+
+            vrg = verify_res.get(p_path, STATUS.UNKNOWN)
+            if vrg == STATUS.VERIFIED:
+                return f_path
+            if vrg == STATUS.UNKNOWN and not Options.require_verify:
+                return f_path
+            log.debug("claiming not found: %s (%s)", path, f_path)
+            if log.isEnabledFor(logging.DEBUG):
+                import inspect
+
+                for idx, frame in enumerate(inspect.stack()[1:60]):
+                    if "hubblestack" in frame.filename:
+                        log.debug("find caller[%d] %s %s() %s", idx, frame.filename, frame.function, frame.lineno)
+            return dict(**not_found)
+
+        return inner
+
+    return wrapper

--- a/tests/unittests/test_repo_signing.py
+++ b/tests/unittests/test_repo_signing.py
@@ -4,46 +4,54 @@
 import os, sys
 from pytest import fixture
 import hubblestack.utils.signing as sig
+import hubblestack.utils.signing_utils
 
-@fixture(scope='module', params=['rsa', '448', '25519'])
+
+@fixture(scope="module", params=["rsa", "448", "25519"])
 def cdbt(request):
     yield request.param
 
-@fixture(scope='function')
+
+@fixture(scope="function")
 def no_ppc():
     def nuke():
-        for i in ('py', 'pyc'):
-            if os.path.isfile('hubblestack/pre_packaged_certificates.{}'.format(i)):
-                os.unlink('hubblestack/pre_packaged_certificates.{}'.format(i))
+        for i in ("py", "pyc"):
+            if os.path.isfile("hubblestack/pre_packaged_certificates.{}".format(i)):
+                os.unlink("hubblestack/pre_packaged_certificates.{}".format(i))
+
     nuke()
-    if 'hubblestack.pre_packaged_certificates' in sys.modules:
-        del sys.modules['hubblestack.pre_packaged_certificates']
+    if "hubblestack.pre_packaged_certificates" in sys.modules:
+        del sys.modules["hubblestack.pre_packaged_certificates"]
     yield True
     nuke()
 
-@fixture(scope='session')
+
+@fixture(scope="session")
 def targets():
-    _t = [ 'tests/unittests/resources/test-{}.file'.format(i) for i in 'abcd' ]
+    _t = ["tests/unittests/resources/test-{}.file".format(i) for i in "abcd"]
     for fname in _t:
         if not os.path.isfile(fname):
-            with open(fname, 'w') as fh:
-                fh.write(fname + ', lol\n')
+            with open(fname, "w") as fh:
+                fh.write(fname + ", lol\n")
     return _t
 
-def cdb(fname, t, n, fmt='{t}-{n}'):
+
+def cdb(fname, t, n, fmt="{t}-{n}"):
     sdname = fmt.format(t=t, n=n)
-    base = os.path.join('tests/unittests/resources/pretend-certs', sdname)
+    base = os.path.join("tests/unittests/resources/pretend-certs", sdname)
     return os.path.join(base, fname)
+
 
 V = sig.STATUS.VERIFIED
 U = sig.STATUS.UNKNOWN
 F = sig.STATUS.FAIL
 
-def test_read_certs(no_ppc, cdbt):
-    fname = cdb('bundle.pem', cdbt, 1)
-    fnam2 = cdb('ca-root.crt', cdbt, 1)
 
-    with open(fname, 'r') as fh:
+def test_read_certs(no_ppc, cdbt):
+    fname = cdb("bundle.pem", cdbt, 1)
+    fnam2 = cdb("ca-root.crt", cdbt, 1)
+
+    with open(fname, "r") as fh:
         dat = fh.read()
 
     file_read = tuple(sig.read_certs(fname))
@@ -59,13 +67,14 @@ def test_read_certs(no_ppc, cdbt):
     three_certs = tuple(sig.read_certs(fnam2, fname))
     assert len(three_certs) == 3
 
-    fname = cdb('public-1.crt', cdbt, 1)
+    fname = cdb("public-1.crt", cdbt, 1)
     file_read = tuple(sig.read_certs(fname))
     assert len(file_read) == 1
 
-    fname = cdb('private-1.key', cdbt, 1)
+    fname = cdb("private-1.key", cdbt, 1)
     file_read = tuple(sig.read_certs(fname))
     assert len(file_read) == 1
+
 
 def test_x509_basics(no_ppc, cdbt):
     """
@@ -78,35 +87,35 @@ def test_x509_basics(no_ppc, cdbt):
     """
 
     def acert(x, y):
-        return sig.X509AwareCertBucket(x,y).authenticate_cert()
+        return sig.X509AwareCertBucket(x, y).authenticate_cert()
 
     # we can verify that both intermediate certs relate to this ca-root
-    assert acert(cdb('intermediate-1.crt', cdbt, 1), cdb('ca-root.crt', cdbt, 1)) == V
-    assert acert(cdb('intermediate-2.crt', cdbt, 1), cdb('ca-root.crt', cdbt, 1)) == V
+    assert acert(cdb("intermediate-1.crt", cdbt, 1), cdb("ca-root.crt", cdbt, 1)) == V
+    assert acert(cdb("intermediate-2.crt", cdbt, 1), cdb("ca-root.crt", cdbt, 1)) == V
 
     # the intermediate certs can't be verified without the root cert
     # (they can't be verified, but that's all we can really say)
-    assert acert(cdb('public-1.crt', cdbt, 1), cdb('intermediate-1.crt', cdbt, 1)) == U
-    assert acert(cdb('public-1.crt', cdbt, 1), cdb('intermediate-2.crt', cdbt, 1)) == U
+    assert acert(cdb("public-1.crt", cdbt, 1), cdb("intermediate-1.crt", cdbt, 1)) == U
+    assert acert(cdb("public-1.crt", cdbt, 1), cdb("intermediate-2.crt", cdbt, 1)) == U
 
-    assert acert(cdb('public-2.crt', cdbt, 1), cdb('intermediate-1.crt', cdbt, 1)) == U
-    assert acert(cdb('public-2.crt', cdbt, 1), cdb('intermediate-2.crt', cdbt, 1)) == U
+    assert acert(cdb("public-2.crt", cdbt, 1), cdb("intermediate-1.crt", cdbt, 1)) == U
+    assert acert(cdb("public-2.crt", cdbt, 1), cdb("intermediate-2.crt", cdbt, 1)) == U
 
     # with the root cert, the two intermediate certs can verify their child certs only
     # (we can't verify public-1 with intermediate-2, but we can tell it's from
     # the right modulo group, so we can't say the cert is bad either)
-    ri1 = (cdb('ca-root.crt', cdbt, 1), cdb('intermediate-1.crt', cdbt, 1))
-    ri2 = (cdb('ca-root.crt', cdbt, 1), cdb('intermediate-2.crt', cdbt, 1))
-    assert acert(cdb('public-1.crt', cdbt, 1), ri1) == V
-    assert acert(cdb('public-1.crt', cdbt, 1), ri2) == U
+    ri1 = (cdb("ca-root.crt", cdbt, 1), cdb("intermediate-1.crt", cdbt, 1))
+    ri2 = (cdb("ca-root.crt", cdbt, 1), cdb("intermediate-2.crt", cdbt, 1))
+    assert acert(cdb("public-1.crt", cdbt, 1), ri1) == V
+    assert acert(cdb("public-1.crt", cdbt, 1), ri2) == U
 
-    assert acert(cdb('public-2.crt', cdbt, 1), ri1) == U
-    assert acert(cdb('public-2.crt', cdbt, 1), ri2) == V
+    assert acert(cdb("public-2.crt", cdbt, 1), ri1) == U
+    assert acert(cdb("public-2.crt", cdbt, 1), ri2) == V
 
     # with the root cert, the bundle (both intermediates) can verify either child key
-    bndl = (cdb('ca-root.crt', cdbt, 1), cdb('bundle.pem', cdbt, 1))
-    assert acert(cdb('public-1.crt', cdbt, 1), bndl) == V
-    assert acert(cdb('public-2.crt', cdbt, 1), bndl) == V
+    bndl = (cdb("ca-root.crt", cdbt, 1), cdb("bundle.pem", cdbt, 1))
+    assert acert(cdb("public-1.crt", cdbt, 1), bndl) == V
+    assert acert(cdb("public-2.crt", cdbt, 1), bndl) == V
 
     # rsa2:public-1 and rsa2:private-1 are from a totally different ca-root
     # this should give us a real actual FAIL condition *iff* the CN matches.
@@ -115,72 +124,77 @@ def test_x509_basics(no_ppc, cdbt):
     # matches between the rsa1/ and rsa2/ certificate databases. If the CN of
     # the issuer differs, the code will be 20 (issuer not found) rather than
     # 7 (signature failed)
-    assert acert(cdb('public-1.crt', cdbt, 2), bndl) == F
+    assert acert(cdb("public-1.crt", cdbt, 2), bndl) == F
+
 
 def test_msign_and_verify_files(__mods__, targets, no_ppc, cdbt):
-    inverse = {2:1, 1:2}
-    sig.Options.ca_crt = (cdb('ca-root.crt', cdbt, 1), cdb('bundle.pem', cdbt, 1))
+    inverse = {2: 1, 1: 2}
+    sig.Options.ca_crt = (cdb("ca-root.crt", cdbt, 1), cdb("bundle.pem", cdbt, 1))
 
-    for i in (1,2):
+    for i in (1, 2):
         # setup key-{i} and sign the repo
-        sig.Options.public_crt  = cdb('public-{}.crt'.format(i), cdbt, 1)
-        sig.Options.private_key = cdb('private-{}.key'.format(i), cdbt, 1)
-        __mods__['signing.msign'](*targets)
+        sig.Options.public_crt = cdb("public-{}.crt".format(i), cdbt, 1)
+        sig.Options.private_key = cdb("private-{}.key".format(i), cdbt, 1)
+        __mods__["signing.msign"](*targets)
 
         # verify that we trust the files
         res = sig.verify_files(targets, public_crt=sig.Options.public_crt, ca_crt=sig.Options.ca_crt)
-        for thing in [ 'MANIFEST' ] + list(targets):
+        for thing in ["MANIFEST"] + list(targets):
             assert thing in res and res[thing] == V
 
         # let's mess with one file and see how we do
-        with open(targets[-1], 'a') as fh:
-            fh.write('hi there!\n')
+        with open(targets[-1], "a") as fh:
+            fh.write("hi there!\n")
         res2 = sig.verify_files(targets, public_crt=sig.Options.public_crt, ca_crt=sig.Options.ca_crt)
-        assert targets[-1] in res2 and res2[targets[-1]] == F # we ruined it
-        assert targets[0]  in res2 and res2[targets[0]]  == V # still good
+        assert targets[-1] in res2 and res2[targets[-1]] == F  # we ruined it
+        assert targets[0] in res2 and res2[targets[0]] == V  # still good
 
         # swap our configs to use the other public key
         # but don't resign the file; uh oh, these aren't signed right now!!
-        sig.Options.public_crt  = cdb('public-{}.crt'.format(inverse[i]), cdbt, 1)
-        sig.Options.private_key = cdb('private-{}.key'.format(inverse[i]), cdbt, 1)
+        sig.Options.public_crt = cdb("public-{}.crt".format(inverse[i]), cdbt, 1)
+        sig.Options.private_key = cdb("private-{}.key".format(inverse[i]), cdbt, 1)
 
         res = sig.verify_files(targets, public_crt=sig.Options.public_crt, ca_crt=sig.Options.ca_crt)
-        for thing in [ 'MANIFEST' ] + list(targets):
+        for thing in ["MANIFEST"] + list(targets):
             assert thing in res and res[thing] == F
+
 
 def test_cert_outside_ca(__mods__, targets, no_ppc, cdbt):
     # the public/private-3 keypair is not from the same modulo group
     # as the other keys. we should get a FAIL result here
-    sig.Options.ca_crt = (cdb('ca-root.crt', cdbt, 1), cdb('bundle.pem', cdbt, 1))
-    sig.Options.public_crt  = cdb('public-1.crt', cdbt, 2)
-    sig.Options.private_key = cdb('private-1.key', cdbt, 2)
-    __mods__['signing.msign'](*targets)
+    sig.Options.ca_crt = (cdb("ca-root.crt", cdbt, 1), cdb("bundle.pem", cdbt, 1))
+    sig.Options.public_crt = cdb("public-1.crt", cdbt, 2)
+    sig.Options.private_key = cdb("private-1.key", cdbt, 2)
+    __mods__["signing.msign"](*targets)
     res = sig.verify_files(targets, public_crt=sig.Options.public_crt, ca_crt=sig.Options.ca_crt)
-    for thing in [ 'MANIFEST' ] + list(targets):
+    for thing in ["MANIFEST"] + list(targets):
         assert thing in res and res[thing] == F
+
 
 def test_no_ca_given(__mods__, targets, no_ppc, cdbt):
     # the public/private-3 is from some unknown CA
     # ... so if we don't specify any CA, then our result should be unknown
-    sig.Options.ca_crt = ''
-    sig.Options.public_crt  = cdb('public-1.crt', cdbt, 2)
-    sig.Options.private_key = cdb('private-1.key', cdbt, 2)
-    __mods__['signing.msign'](*targets)
+    sig.Options.ca_crt = ""
+    sig.Options.public_crt = cdb("public-1.crt", cdbt, 2)
+    sig.Options.private_key = cdb("private-1.key", cdbt, 2)
+    __mods__["signing.msign"](*targets)
     res = sig.verify_files(targets, public_crt=sig.Options.public_crt, ca_crt=sig.Options.ca_crt)
-    for thing in [ 'MANIFEST' ] + list(targets):
+    for thing in ["MANIFEST"] + list(targets):
         assert thing in res and res[thing] == U
+
 
 def test_no_SIGNATURE(__mods__, targets, no_ppc, cdbt):
     # the public/private-3 is from some unknown CA
     # ... so if we don't specify any CA, then our result should be unknown
-    sig.Options.ca_crt = (cdb('ca-root.crt', cdbt, 1), cdb('bundle.pem', cdbt, 1))
-    sig.Options.public_crt  = cdb('public-1.crt', cdbt, 1)
-    sig.Options.private_key = cdb('private-1.key', cdbt, 1)
-    __mods__['signing.msign'](*targets)
-    os.unlink('SIGNATURE')
+    sig.Options.ca_crt = (cdb("ca-root.crt", cdbt, 1), cdb("bundle.pem", cdbt, 1))
+    sig.Options.public_crt = cdb("public-1.crt", cdbt, 1)
+    sig.Options.private_key = cdb("private-1.key", cdbt, 1)
+    __mods__["signing.msign"](*targets)
+    os.unlink("SIGNATURE")
     res = sig.verify_files(targets, public_crt=sig.Options.public_crt, ca_crt=sig.Options.ca_crt)
-    for thing in [ 'MANIFEST' ] + list(targets):
+    for thing in ["MANIFEST"] + list(targets):
         assert thing in res and res[thing] == U
+
 
 def test_no_MANIFEST(__mods__, targets, no_ppc, cdbt):
     # If we have a SIGNATURE without a MANIFEST, we should fail, because our
@@ -188,143 +202,154 @@ def test_no_MANIFEST(__mods__, targets, no_ppc, cdbt):
     # probably a really bad sign and also a rare condition anyway. Also,
     # without the manifest, the most we can say about the rest of the files is
     # UNKNOWN
-    sig.Options.ca_crt = (cdb('ca-root.crt', cdbt, 1), cdb('bundle.pem', cdbt, 1))
-    sig.Options.public_crt  = cdb('public-1.crt', cdbt, 1)
-    sig.Options.private_key = cdb('private-1.key', cdbt, 1)
-    __mods__['signing.msign'](*targets)
-    os.unlink('MANIFEST')
+    sig.Options.ca_crt = (cdb("ca-root.crt", cdbt, 1), cdb("bundle.pem", cdbt, 1))
+    sig.Options.public_crt = cdb("public-1.crt", cdbt, 1)
+    sig.Options.private_key = cdb("private-1.key", cdbt, 1)
+    __mods__["signing.msign"](*targets)
+    os.unlink("MANIFEST")
     res = sig.verify_files(targets, public_crt=sig.Options.public_crt, ca_crt=sig.Options.ca_crt)
-    assert 'MANIFEST' in res and res['MANIFEST'] == F
+    assert "MANIFEST" in res and res["MANIFEST"] == F
     for thing in list(targets):
         assert thing in res and res[thing] == U
+
 
 def test_no_MANIFEST_or_SIGNATURE(__mods__, targets, no_ppc, cdbt):
     # if we have a SIGNATURE without a MANIFEST, we should fail
     # because our MANIFEST hash will not match the signed hash
     # (a sig without manifest is probably a really bad sign and also a rare condition anyway)
-    sig.Options.ca_crt = (cdb('ca-root.crt', cdbt, 1), cdb('bundle.pem', cdbt, 1))
-    sig.Options.public_crt  = cdb('public-1.crt', cdbt, 1)
-    sig.Options.private_key = cdb('private-1.key', cdbt, 1)
-    __mods__['signing.msign'](*targets) # re-sign just to make sure the two files are present
-    os.unlink('MANIFEST') # but remove them
-    os.unlink('SIGNATURE') # bahleeted
+    sig.Options.ca_crt = (cdb("ca-root.crt", cdbt, 1), cdb("bundle.pem", cdbt, 1))
+    sig.Options.public_crt = cdb("public-1.crt", cdbt, 1)
+    sig.Options.private_key = cdb("private-1.key", cdbt, 1)
+    __mods__["signing.msign"](*targets)  # re-sign just to make sure the two files are present
+    os.unlink("MANIFEST")  # but remove them
+    os.unlink("SIGNATURE")  # bahleeted
     res = sig.verify_files(targets, public_crt=sig.Options.public_crt, ca_crt=sig.Options.ca_crt)
     len(res) == 0
+
 
 def pretend_finder(path, saltenv, **kwargs):
     full = rel = os.path.normpath(path)
     if not os.path.isfile(rel):
-        full = os.path.join('tests/unittests/resources', rel)
+        full = os.path.join("tests/unittests/resources", rel)
     full = os.path.realpath(full)
     if os.path.isfile(full):
-        return {'path': full, 'rel': rel}
-    return {'path': '?pf?', 'rel': '?pf?'} # not found for real: ?pf?
+        return {"path": full, "rel": rel}
+    return {"path": "?pf?", "rel": "?pf?"}  # not found for real: ?pf?
 
-wrapped_finder = sig.find_wrapf( # but due to verification trouble, ?wf?
-    not_found={'path': '?wf?', 'rel': '?wf?'})(pretend_finder)
+
+wrapped_finder = hubblestack.utils.signing_utils.find_file_func_wrapper(  # but due to verification trouble, ?wf?
+    not_found={"path": "?wf?", "rel": "?wf?"}
+)(pretend_finder)
+
 
 def test_fs_find_wrapper_correct_required(__mods__, targets, no_ppc, cdbt):
-    btargets = [ (os.path.basename(x),x) for x in targets ]
-    sig.Options.ca_crt = (cdb('ca-root.crt', cdbt, 1), cdb('bundle.pem', cdbt, 1))
+    btargets = [(os.path.basename(x), x) for x in targets]
+    sig.Options.ca_crt = (cdb("ca-root.crt", cdbt, 1), cdb("bundle.pem", cdbt, 1))
     sig.Options.require_verify = True
 
-    for i in (1,2):
-        sig.Options.public_crt = cdb('public-{}.crt'.format(i), cdbt, 1)
-        sig.Options.private_key = cdb('private-{}.key'.format(i), cdbt, 1)
-        __mods__['signing.msign'](*targets)
+    for i in (1, 2):
+        sig.Options.public_crt = cdb("public-{}.crt".format(i), cdbt, 1)
+        sig.Options.private_key = cdb("private-{}.key".format(i), cdbt, 1)
+        __mods__["signing.msign"](*targets)
 
-        for btarget,target in btargets:
+        for btarget, target in btargets:
             full = os.path.realpath(target)
-            assert pretend_finder(btarget, 'base').get('path') == full
-            assert wrapped_finder(btarget, 'base').get('path') == full
+            assert pretend_finder(btarget, "base").get("path") == full
+            assert wrapped_finder(btarget, "base").get("path") == full
+
 
 def test_fs_find_wrapper_correct_optional(__mods__, targets, no_ppc, cdbt):
-    btargets = [ (os.path.basename(x),x) for x in targets ]
-    sig.Options.ca_crt = (cdb('ca-root.crt', cdbt, 1), cdb('bundle.pem', cdbt, 1))
+    btargets = [(os.path.basename(x), x) for x in targets]
+    sig.Options.ca_crt = (cdb("ca-root.crt", cdbt, 1), cdb("bundle.pem", cdbt, 1))
     sig.Options.require_verify = False
 
-    for i in (1,2):
-        sig.Options.public_crt = cdb('public-{}.crt'.format(i), cdbt, 1)
-        sig.Options.private_key = cdb('private-{}.key'.format(i), cdbt, 1)
-        __mods__['signing.msign'](*targets)
+    for i in (1, 2):
+        sig.Options.public_crt = cdb("public-{}.crt".format(i), cdbt, 1)
+        sig.Options.private_key = cdb("private-{}.key".format(i), cdbt, 1)
+        __mods__["signing.msign"](*targets)
 
-        for btarget,target in btargets:
+        for btarget, target in btargets:
             full = os.path.realpath(target)
-            assert pretend_finder(btarget, 'base').get('path') == full
-            assert wrapped_finder(btarget, 'base').get('path') == full
+            assert pretend_finder(btarget, "base").get("path") == full
+            assert wrapped_finder(btarget, "base").get("path") == full
+
 
 def test_fs_find_wrapper_unknown_required(__mods__, targets, no_ppc, cdbt):
-    btargets = [ (os.path.basename(x),x) for x in targets ]
-    sig.Options.ca_crt = ''
+    btargets = [(os.path.basename(x), x) for x in targets]
+    sig.Options.ca_crt = ""
     sig.Options.require_verify = True
 
-    for i in (1,2):
-        sig.Options.public_crt = cdb('public-{}.crt'.format(i), cdbt, 1)
-        sig.Options.private_key = cdb('private-{}.key'.format(i), cdbt, 1)
-        __mods__['signing.msign'](*targets)
+    for i in (1, 2):
+        sig.Options.public_crt = cdb("public-{}.crt".format(i), cdbt, 1)
+        sig.Options.private_key = cdb("private-{}.key".format(i), cdbt, 1)
+        __mods__["signing.msign"](*targets)
 
-        for btarget,target in btargets:
+        for btarget, target in btargets:
             full = os.path.realpath(target)
-            assert pretend_finder(btarget, 'base').get('path') == full
-            assert wrapped_finder(btarget, 'base').get('path') == '?wf?'
+            assert pretend_finder(btarget, "base").get("path") == full
+            assert wrapped_finder(btarget, "base").get("path") == "?wf?"
+
 
 def test_fs_find_wrapper_unknown_optional(__mods__, targets, no_ppc, cdbt):
-    btargets = [ (os.path.basename(x),x) for x in targets ]
-    sig.Options.ca_crt = ''
+    btargets = [(os.path.basename(x), x) for x in targets]
+    sig.Options.ca_crt = ""
     sig.Options.require_verify = False
 
-    for i in (1,2):
-        sig.Options.public_crt = cdb('public-{}.crt'.format(i), cdbt, 1)
-        sig.Options.private_key = cdb('private-{}.key'.format(i), cdbt, 1)
-        __mods__['signing.msign'](*targets)
+    for i in (1, 2):
+        sig.Options.public_crt = cdb("public-{}.crt".format(i), cdbt, 1)
+        sig.Options.private_key = cdb("private-{}.key".format(i), cdbt, 1)
+        __mods__["signing.msign"](*targets)
 
-        for btarget,target in btargets:
+        for btarget, target in btargets:
             full = os.path.realpath(target)
-            assert pretend_finder(btarget, 'base').get('path') == full
-            assert wrapped_finder(btarget, 'base').get('path') == full
+            assert pretend_finder(btarget, "base").get("path") == full
+            assert wrapped_finder(btarget, "base").get("path") == full
+
 
 def test_fs_find_wrapper_incorrect_required(__mods__, targets, no_ppc, cdbt):
-    btargets = [ (os.path.basename(x),x) for x in targets ]
-    sig.Options.ca_crt = ''
+    btargets = [(os.path.basename(x), x) for x in targets]
+    sig.Options.ca_crt = ""
     sig.Options.require_verify = True
 
-    for i in (1,2):
-        sig.Options.public_crt = cdb('public-{}.crt'.format(i), cdbt, 1)
-        sig.Options.private_key = cdb('private-{}.key'.format(i), cdbt, 1)
-        __mods__['signing.msign'](*targets)
-        sig.Options.public_crt = cdb('public-{}.crt'.format(3), cdbt, 1)
+    for i in (1, 2):
+        sig.Options.public_crt = cdb("public-{}.crt".format(i), cdbt, 1)
+        sig.Options.private_key = cdb("private-{}.key".format(i), cdbt, 1)
+        __mods__["signing.msign"](*targets)
+        sig.Options.public_crt = cdb("public-{}.crt".format(3), cdbt, 1)
 
-        for btarget,target in btargets:
+        for btarget, target in btargets:
             full = os.path.realpath(target)
-            assert pretend_finder(btarget, 'base').get('path') == full
-            assert wrapped_finder(btarget, 'base').get('path') == '?wf?'
+            assert pretend_finder(btarget, "base").get("path") == full
+            assert wrapped_finder(btarget, "base").get("path") == "?wf?"
+
 
 def test_fs_find_wrapper_incorrect_optional(__mods__, targets, no_ppc, cdbt):
-    btargets = [ (os.path.basename(x),x) for x in targets ]
-    sig.Options.ca_crt = ''
+    btargets = [(os.path.basename(x), x) for x in targets]
+    sig.Options.ca_crt = ""
     sig.Options.require_verify = False
 
-    for i in (1,2):
-        sig.Options.public_crt = cdb('public-{}.crt'.format(i), cdbt, 1)
-        sig.Options.private_key = cdb('private-{}.key'.format(i), cdbt, 1)
-        __mods__['signing.msign'](*targets)
-        sig.Options.public_crt = cdb('public-3.crt', cdbt, 2)
+    for i in (1, 2):
+        sig.Options.public_crt = cdb("public-{}.crt".format(i), cdbt, 1)
+        sig.Options.private_key = cdb("private-{}.key".format(i), cdbt, 1)
+        __mods__["signing.msign"](*targets)
+        sig.Options.public_crt = cdb("public-3.crt", cdbt, 2)
 
-        for btarget,target in btargets:
+        for btarget, target in btargets:
             full = os.path.realpath(target)
-            assert pretend_finder(btarget, 'base').get('path') == full
-            assert wrapped_finder(btarget, 'base').get('path') == '?wf?'
+            assert pretend_finder(btarget, "base").get("path") == full
+            assert wrapped_finder(btarget, "base").get("path") == "?wf?"
+
 
 def test_bundled_certs(no_ppc, cdbt):
     # no_ppc ensures there's no pre_packaged_certificates;
     # we then load pretend-certs/public-1, pretend-certs/ca-root and
     # pretend-certs/bundle into x1.
-    bndl = (cdb('ca-root.crt', cdbt, 1), cdb('bundle.pem', cdbt, 1))
-    x1 = sig.X509AwareCertBucket(cdb('public-1.crt', cdbt, 1), bndl)
+    bndl = (cdb("ca-root.crt", cdbt, 1), cdb("bundle.pem", cdbt, 1))
+    x1 = sig.X509AwareCertBucket(cdb("public-1.crt", cdbt, 1), bndl)
 
-    with open('hubblestack/pre_packaged_certificates.py', 'w') as ofh:
+    with open("hubblestack/pre_packaged_certificates.py", "w") as ofh:
         ofh.write('ca_crt = """\n')
-        with open(cdb('ca-root.crt', cdbt, 2)) as ifh:
+        with open(cdb("ca-root.crt", cdbt, 2)) as ifh:
             for line in ifh:
                 ofh.write(line)
         ofh.write('"""\n')
@@ -336,108 +361,102 @@ def test_bundled_certs(no_ppc, cdbt):
     # we lie to X509 and say we want pretend-certs/ca-root.crt
     # but because that's defined in pre_packaged_certificates, it loads that
     # instead.
-    bndl = (cdb('ca-root.crt', cdbt, 1), cdb('bundle.pem', cdbt, 1))
-    x2 = sig.X509AwareCertBucket(cdb('public-1.crt', cdbt, 1), bndl)
+    bndl = (cdb("ca-root.crt", cdbt, 1), cdb("bundle.pem", cdbt, 1))
+    x2 = sig.X509AwareCertBucket(cdb("public-1.crt", cdbt, 1), bndl)
 
-    for x,y in zip(x1.trusted, x2.trusted):
+    for x, y in zip(x1.trusted, x2.trusted):
         x_fingerprint, x_subject = x.split()
         y_fingerprint, y_subject = y.split()
         assert x_subject == y_subject
-        if 'CN=car' in x_subject:
+        if "CN=car" in x_subject:
             assert x_fingerprint != y_fingerprint
         else:
             assert x_fingerprint == y_fingerprint
 
+
 def test_msign_and_verify_signature(__mods__, targets, no_ppc, cdbt):
-    sig.Options.ca_crt = (cdb('ca-root.crt', cdbt, 1), cdb('bundle.pem', cdbt, 1))
+    sig.Options.ca_crt = (cdb("ca-root.crt", cdbt, 1), cdb("bundle.pem", cdbt, 1))
 
-    sig.Options.public_crt  = cdb('public-1.crt', cdbt, 1)
-    sig.Options.private_key = cdb('private-1.key', cdbt, 1)
+    sig.Options.public_crt = cdb("public-1.crt", cdbt, 1)
+    sig.Options.private_key = cdb("private-1.key", cdbt, 1)
 
-    __mods__['signing.msign'](*targets)
-    res = sig.verify_signature('MANIFEST', 'SIGNATURE',
-        public_crt=sig.Options.public_crt, ca_crt=sig.Options.ca_crt)
+    __mods__["signing.msign"](*targets)
+    res = sig.verify_signature("MANIFEST", "SIGNATURE", public_crt=sig.Options.public_crt, ca_crt=sig.Options.ca_crt)
 
     assert res == sig.STATUS.VERIFIED
 
-    sig.Options.public_crt  = cdb('public-1.crt', cdbt, 1)
-    sig.Options.private_key = cdb('private-2.key', cdbt, 1)
+    sig.Options.public_crt = cdb("public-1.crt", cdbt, 1)
+    sig.Options.private_key = cdb("private-2.key", cdbt, 1)
 
-    __mods__['signing.msign'](*targets)
-    res = sig.verify_signature('MANIFEST', 'SIGNATURE',
-        public_crt=sig.Options.public_crt, ca_crt=sig.Options.ca_crt)
+    __mods__["signing.msign"](*targets)
+    res = sig.verify_signature("MANIFEST", "SIGNATURE", public_crt=sig.Options.public_crt, ca_crt=sig.Options.ca_crt)
+
+    assert res == sig.STATUS.FAIL
+
+    sig.Options.public_crt = cdb("public-1.crt", cdbt, 2)
+    sig.Options.private_key = cdb("private-1.key", cdbt, 2)
+
+    __mods__["signing.msign"](*targets)
+    res = sig.verify_signature("MANIFEST", "SIGNATURE", public_crt=sig.Options.public_crt, ca_crt=sig.Options.ca_crt)
 
     assert res == sig.STATUS.FAIL
 
-    sig.Options.public_crt  = cdb('public-1.crt', cdbt, 2)
-    sig.Options.private_key = cdb('private-1.key', cdbt, 2)
-
-    __mods__['signing.msign'](*targets)
-    res = sig.verify_signature('MANIFEST', 'SIGNATURE',
-        public_crt=sig.Options.public_crt, ca_crt=sig.Options.ca_crt)
-
-    assert res == sig.STATUS.FAIL
 
 def test_various_padding_bits(__mods__, targets, no_ppc, cdbt):
-    sig.Options.ca_crt = (cdb('ca-root.crt', cdbt, 1), cdb('bundle.pem', cdbt, 1))
+    sig.Options.ca_crt = (cdb("ca-root.crt", cdbt, 1), cdb("bundle.pem", cdbt, 1))
 
-    sig.Options.public_crt  = cdb('public-1.crt', cdbt, 1)
-    sig.Options.private_key = cdb('private-1.key', cdbt, 1)
+    sig.Options.public_crt = cdb("public-1.crt", cdbt, 1)
+    sig.Options.private_key = cdb("private-1.key", cdbt, 1)
 
     # sign with 32-bit-salt-padding
     sig.Options.salt_padding_bits = 32
-    __mods__['signing.msign'](*targets)
+    __mods__["signing.msign"](*targets)
     # check either 'max' or 32 or whatever
-    sig.Options.salt_padding_bits = ['max', 32]
-    res = sig.verify_signature('MANIFEST', 'SIGNATURE',
-        public_crt=sig.Options.public_crt, ca_crt=sig.Options.ca_crt)
+    sig.Options.salt_padding_bits = ["max", 32]
+    res = sig.verify_signature("MANIFEST", "SIGNATURE", public_crt=sig.Options.public_crt, ca_crt=sig.Options.ca_crt)
     assert res == sig.STATUS.VERIFIED
 
     # sign with max-bit-salt-padding
-    sig.Options.salt_padding_bits = 'max'
-    __mods__['signing.msign'](*targets)
+    sig.Options.salt_padding_bits = "max"
+    __mods__["signing.msign"](*targets)
     # check with max or 32 or whatever
-    sig.Options.salt_padding_bits = ['max', 32]
-    res = sig.verify_signature('MANIFEST', 'SIGNATURE',
-        public_crt=sig.Options.public_crt, ca_crt=sig.Options.ca_crt)
+    sig.Options.salt_padding_bits = ["max", 32]
+    res = sig.verify_signature("MANIFEST", "SIGNATURE", public_crt=sig.Options.public_crt, ca_crt=sig.Options.ca_crt)
     assert res == sig.STATUS.VERIFIED
 
     # check one more time with 32/max instead of max/32 (shouldn't matter)
-    sig.Options.salt_padding_bits = [32, 'max']
-    res = sig.verify_signature('MANIFEST', 'SIGNATURE',
-        public_crt=sig.Options.public_crt, ca_crt=sig.Options.ca_crt)
+    sig.Options.salt_padding_bits = [32, "max"]
+    res = sig.verify_signature("MANIFEST", "SIGNATURE", public_crt=sig.Options.public_crt, ca_crt=sig.Options.ca_crt)
     assert res == sig.STATUS.VERIFIED
 
     # The padding thing really only applies to RSA.
     # So, for the below expected failures, it's only when cdbt is 'rsa'.
-    expected = sig.STATUS.FAIL if cdbt == 'rsa' else sig.STATUS.VERIFIED
+    expected = sig.STATUS.FAIL if cdbt == "rsa" else sig.STATUS.VERIFIED
 
     # sign with max-bit-salt-padding
-    sig.Options.salt_padding_bits = 'max'
-    __mods__['signing.msign'](*targets)
+    sig.Options.salt_padding_bits = "max"
+    __mods__["signing.msign"](*targets)
     # check with 32bit only
     sig.Options.salt_padding_bits = 32
-    res = sig.verify_signature('MANIFEST', 'SIGNATURE',
-        public_crt=sig.Options.public_crt, ca_crt=sig.Options.ca_crt)
+    res = sig.verify_signature("MANIFEST", "SIGNATURE", public_crt=sig.Options.public_crt, ca_crt=sig.Options.ca_crt)
     assert res == expected
 
     # re-sign with 32 bit salt padding bits
     sig.Options.salt_padding_bits = 32
-    __mods__['signing.msign'](*targets)
+    __mods__["signing.msign"](*targets)
     # but verify under max-padding-bits (should fail)
-    sig.Options.salt_padding_bits = 'max'
-    res = sig.verify_signature('MANIFEST', 'SIGNATURE',
-        public_crt=sig.Options.public_crt, ca_crt=sig.Options.ca_crt)
+    sig.Options.salt_padding_bits = "max"
+    res = sig.verify_signature("MANIFEST", "SIGNATURE", public_crt=sig.Options.public_crt, ca_crt=sig.Options.ca_crt)
     assert res == expected
 
 
 def test_like_a_daemon_with_bundle(__mods__, no_ppc, cdbt):
-    sig.Options.ca_crt = (cdb('ca-root.crt', cdbt, 1), cdb('bundle.pem', cdbt, 1))
-    sig.Options.public_crt = cdb('public-1.crt', cdbt, 1)
-    sig.Options.private_key = cdb('private-1.key', cdbt, 1)
+    sig.Options.ca_crt = (cdb("ca-root.crt", cdbt, 1), cdb("bundle.pem", cdbt, 1))
+    sig.Options.public_crt = cdb("public-1.crt", cdbt, 1)
+    sig.Options.private_key = cdb("private-1.key", cdbt, 1)
 
-    __mods__['signing.msign']('tests/unittests/conftest.py')
-    res = __mods__['signing.verify']('tests/unittests/conftest.py')
+    __mods__["signing.msign"]("tests/unittests/conftest.py")
+    res = __mods__["signing.verify"]("tests/unittests/conftest.py")
     assert len(res) == 2
     for item in res:
         assert res[item] == sig.STATUS.VERIFIED


### PR DESCRIPTION
Since pycrypto is unmaintained, we're replacing the methods used in our signing and signature verification workflows.
We're also updating the code styling.